### PR TITLE
.NET Generic Host registration improvements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -55,5 +55,6 @@
   },
   "coverage-gutters.coverageFileNames": ["coverage.info", "coverage.cobertura.xml"],
   "xmlTools.xmlFormatterImplementation": "v2",
-  "xmlTools.enforcePrettySelfClosingTagOnFormat": true
+  "xmlTools.enforcePrettySelfClosingTagOnFormat": true,
+  "cSpell.words": ["Npgsql"]
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageVersion Include="coverlet.msbuild" Version="10.0.0" />
     <PackageVersion Include="JunitXml.TestLogger" Version="7.1.0" />
+    <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.13.1" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
@@ -18,6 +19,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Minio" Version="7.0.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,8 @@
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageVersion Include="coverlet.msbuild" Version="10.0.0" />
     <PackageVersion Include="JunitXml.TestLogger" Version="7.1.0" />
+    <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.13.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.5" />
@@ -18,11 +20,10 @@
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.7" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Minio" Version="7.0.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Npgsql" Version="10.0.2" />
+    <PackageVersion Include="Npgsql.DependencyInjection" Version="10.0.2" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
-    <PackageVersion Include="Serilog" Version="4.3.1" />
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="StackExchange.Redis" Version="2.12.14" />
     <PackageVersion Include="Testcontainers.Redis" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.Azurite" Version="4.11.0" />

--- a/examples/LeaderElectionTester/LeaderElectionTester.csproj
+++ b/examples/LeaderElectionTester/LeaderElectionTester.csproj
@@ -12,11 +12,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Azure" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Minio" />
+    <PackageReference Include="Npgsql.DependencyInjection" />
     <PackageReference Include="ZiggyCreatures.FusionCache.Serialization.SystemTextJson" />
   </ItemGroup>
 

--- a/examples/LeaderElectionTester/Program.cs
+++ b/examples/LeaderElectionTester/Program.cs
@@ -16,15 +16,9 @@ using ZiggyCreatures.Caching.Fusion;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-builder.Services.Configure<ServiceProviderOptions>(options =>
-{
-    options.ValidateOnBuild = true;
-    options.ValidateScopes = true;
-});
-
-var leaderElectionType = ConfigurationBinder
-    .GetValue(builder.Configuration, "LeaderElectionType", "Redis")
-    .ToUpperInvariant() switch
+var leaderElectionType = (
+    builder.Configuration["LeaderElectionType"] ?? "Redis"
+).ToUpperInvariant() switch
 {
     "REDIS" => "Redis",
     "DISTRIBUTEDCACHE" or "DC" => "DistributedCache",

--- a/examples/LeaderElectionTester/Program.cs
+++ b/examples/LeaderElectionTester/Program.cs
@@ -16,6 +16,12 @@ using ZiggyCreatures.Caching.Fusion;
 
 var builder = Host.CreateApplicationBuilder(args);
 
+builder.Services.Configure<ServiceProviderOptions>(options =>
+{
+    options.ValidateOnBuild = true;
+    options.ValidateScopes = true;
+});
+
 var leaderElectionType = ConfigurationBinder
     .GetValue(builder.Configuration, "LeaderElectionType", "Redis")
     .ToUpperInvariant() switch

--- a/examples/LeaderElectionTester/Program.cs
+++ b/examples/LeaderElectionTester/Program.cs
@@ -6,6 +6,7 @@ using LeaderElection.Redis;
 using LeaderElection.S3;
 using LeaderElectionTester;
 using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -55,6 +56,7 @@ if (leaderElectionType is "Redis")
 if (leaderElectionType is "DistributedCache")
 {
     builder.Services.AddRedisServices(redisConfiguration);
+    builder.Services.AddDistributedCache();
     builder.Services.AddDistributedCacheLeaderElection(options =>
     {
         options.LockKey = "leader_election_tester_dc";
@@ -65,6 +67,7 @@ if (leaderElectionType is "DistributedCache")
 if (leaderElectionType is "FusionCache")
 {
     builder.Services.AddRedisServices(redisConfiguration);
+    builder.Services.AddDistributedCache();
     builder
         .Services.AddFusionCache()
         .WithRegisteredDistributedCache()
@@ -133,15 +136,20 @@ internal static class ProgramExtensions
         string redisConfiguration
     )
     {
-        var connectionMultiplexer = new Lazy<IConnectionMultiplexer>(() =>
+        return services.AddSingleton<IConnectionMultiplexer>(_ =>
             ConnectionMultiplexer.Connect(redisConfiguration)
         );
+    }
 
-        services.AddSingleton(_ => connectionMultiplexer.Value);
-        services.AddStackExchangeRedisCache(options =>
-            options.ConnectionMultiplexerFactory = () =>
-                Task.FromResult(connectionMultiplexer.Value)
-        );
+    public static IServiceCollection AddDistributedCache(this IServiceCollection services)
+    {
+        services.AddStackExchangeRedisCache(_ => { });
+        services
+            .AddOptions<RedisCacheOptions>()
+            .Configure<IConnectionMultiplexer>(
+                (options, connection) =>
+                    options.ConnectionMultiplexerFactory = () => Task.FromResult(connection)
+            );
         return services;
     }
 }

--- a/examples/LeaderElectionTester/Program.cs
+++ b/examples/LeaderElectionTester/Program.cs
@@ -5,6 +5,7 @@ using LeaderElection.Postgres;
 using LeaderElection.Redis;
 using LeaderElection.S3;
 using LeaderElectionTester;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -77,9 +78,13 @@ if (leaderElectionType is "FusionCache")
 
 if (leaderElectionType is "BlobStorage")
 {
+    builder.Services.AddAzureClients(configure =>
+    {
+        // blob test using Azurite or Storage Emulator
+        configure.AddBlobServiceClient("UseDevelopmentStorage=true;");
+    });
     builder.Services.AddBlobStorageLeaderElection(options =>
     {
-        options.ConnectionString = "UseDevelopmentStorage=true";
         options.ContainerName = "leader-election";
         options.BlobName = "leader_election_tester";
         options.InstanceId = instanceId;
@@ -105,10 +110,12 @@ if (leaderElectionType is "S3")
 
 if (leaderElectionType is "Postgres")
 {
+    builder.Services.AddNpgsqlDataSource(
+        "Host=localhost;Database=mydb;Username=myuser;Password=mypassword"
+    );
+
     builder.Services.AddPostgresLeaderElection(options =>
     {
-        options.ConnectionString =
-            "Host=localhost;Database=mydb;Username=myuser;Password=mypassword";
         options.LockId = 1;
         options.InstanceId = instanceId;
     });

--- a/examples/LeaderElectionTester/Program.cs
+++ b/examples/LeaderElectionTester/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Minio;
+using Npgsql;
 using StackExchange.Redis;
 using ZiggyCreatures.Caching.Fusion;
 
@@ -46,22 +47,28 @@ var redisConfiguration = "localhost:6379";
 if (leaderElectionType is "Redis")
 {
     builder.Services.AddRedisServices(redisConfiguration);
-    builder.Services.AddRedisLeaderElection(options =>
-    {
-        options.LockKey = "leader_election_tester_redis";
-        options.InstanceId = instanceId;
-    });
+    builder.Services.AddRedisLeaderElection(builder =>
+        builder
+            .WithInstanceId(instanceId)
+            .WithSettings(options =>
+            {
+                options.LockKey = "leader_election_tester_redis";
+            })
+    );
 }
 
 if (leaderElectionType is "DistributedCache")
 {
     builder.Services.AddRedisServices(redisConfiguration);
     builder.Services.AddDistributedCache();
-    builder.Services.AddDistributedCacheLeaderElection(options =>
-    {
-        options.LockKey = "leader_election_tester_dc";
-        options.InstanceId = instanceId;
-    });
+    builder.Services.AddDistributedCacheLeaderElection(builder =>
+        builder
+            .WithInstanceId(instanceId)
+            .WithSettings(options =>
+            {
+                options.LockKey = "leader_election_tester_dc";
+            })
+    );
 }
 
 if (leaderElectionType is "FusionCache")
@@ -72,11 +79,14 @@ if (leaderElectionType is "FusionCache")
         .Services.AddFusionCache()
         .WithRegisteredDistributedCache()
         .WithSystemTextJsonSerializer();
-    builder.Services.AddFusionCacheLeaderElection(options =>
-    {
-        options.LockKey = "leader_election_tester_fc";
-        options.InstanceId = instanceId;
-    });
+    builder.Services.AddFusionCacheLeaderElection(builder =>
+        builder
+            .WithInstanceId(instanceId)
+            .WithSettings(options =>
+            {
+                options.LockKey = "leader_election_tester_fc";
+            })
+    );
 }
 
 if (leaderElectionType is "BlobStorage")
@@ -86,12 +96,15 @@ if (leaderElectionType is "BlobStorage")
         // blob test using Azurite or Storage Emulator
         configure.AddBlobServiceClient("UseDevelopmentStorage=true;");
     });
-    builder.Services.AddBlobStorageLeaderElection(options =>
-    {
-        options.ContainerName = "leader-election";
-        options.BlobName = "leader_election_tester";
-        options.InstanceId = instanceId;
-    });
+    builder.Services.AddBlobStorageLeaderElection(builder =>
+        builder
+            .WithInstanceId(instanceId)
+            .WithSettings(options =>
+            {
+                options.ContainerName = "leader-election";
+                options.BlobName = "leader_election_tester";
+            })
+    );
 }
 
 if (leaderElectionType is "S3")
@@ -103,25 +116,41 @@ if (leaderElectionType is "S3")
             .WithSSL(false)
             .Build()
     );
-    builder.Services.AddS3LeaderElection(options =>
-    {
-        options.BucketName = "my-app-locks";
-        options.ObjectKey = "leader-lock.json";
-        options.InstanceId = instanceId;
-    });
+
+    builder.Services.AddS3LeaderElection(builder =>
+        builder
+            .WithInstanceId(instanceId)
+            .WithSettings(options =>
+            {
+                options.BucketName = "my-app-locks";
+                options.ObjectKey = "leader-lock.json";
+            })
+    );
 }
 
 if (leaderElectionType is "Postgres")
 {
+    // Register a NpgsqlDataSource specifically for Leader Election use...
+    const string postgresLeaderElectionDataSource = "PostgresLeaderElectionDataSource";
     builder.Services.AddNpgsqlDataSource(
-        "Host=localhost;Database=mydb;Username=myuser;Password=mypassword"
+        // Use short CommandTimeout to avoid long waits if the database becomes unresponsive.
+        "Host=localhost;Database=mydb;Username=myuser;Password=mypassword;Timeout=5;CommandTimeout=3;",
+        serviceKey: postgresLeaderElectionDataSource
     );
 
-    builder.Services.AddPostgresLeaderElection(options =>
-    {
-        options.LockId = 1;
-        options.InstanceId = instanceId;
-    });
+    builder.Services.AddPostgresLeaderElection(builder =>
+        builder
+            .WithRegisteredDataSource(postgresLeaderElectionDataSource)
+            .WithInstanceId(instanceId)
+            .WithSettings(options =>
+            {
+                options.LockId = 1;
+                // Use a short RenewInterval to quickly detect and recover from failed leaders.
+                // Note that the actual detection time will be at least the sum of the CommandTimeout
+                // and RenewInterval, so keep CommandTimeout low as well.
+                options.RenewInterval = TimeSpan.FromSeconds(5); // aggressive renew
+            })
+    );
 }
 
 builder.Services.AddHostedService<Service>();

--- a/examples/LeaderElectionTester/Settings.cs
+++ b/examples/LeaderElectionTester/Settings.cs
@@ -1,8 +1,0 @@
-using LeaderElection.Redis;
-
-namespace LeaderElectionTester;
-
-internal sealed class Settings
-{
-    public RedisSettings Redis { get; init; } = new();
-}

--- a/examples/LeaderElectionTester/appsettings.json
+++ b/examples/LeaderElectionTester/appsettings.json
@@ -7,7 +7,8 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information",
       "Azure": "Error",
-      "ZiggyCreatures": "Warning"
+      "ZiggyCreatures": "Warning",
+      "Npgsql": "Warning"
     },
     "Console": {
       "FormatterName": "simple",

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -49,10 +49,18 @@
       </ItemGroup>
       <PropertyGroup>
         <PolySharpIncludeGeneratedTypes>System.Runtime.CompilerServices.IsExternalInit;$(PolySharpIncludeGeneratedTypes)</PolySharpIncludeGeneratedTypes>
+        <PolySharpIncludeGeneratedTypes>System.Diagnostics.CodeAnalysis.NotNullAttribute;$(PolySharpIncludeGeneratedTypes)</PolySharpIncludeGeneratedTypes>
+        <PolySharpIncludeGeneratedTypes>System.Runtime.CompilerServices.CallerArgumentExpressionAttribute;$(PolySharpIncludeGeneratedTypes)</PolySharpIncludeGeneratedTypes>
+        <PolySharpIncludeGeneratedTypes>System.Runtime.CompilerServices.RequiredMemberAttribute;System.Runtime.CompilerServices.CompilerFeatureRequiredAttribute;$(PolySharpIncludeGeneratedTypes)</PolySharpIncludeGeneratedTypes>
+        <PolySharpIncludeGeneratedTypes>System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute;$(PolySharpIncludeGeneratedTypes)</PolySharpIncludeGeneratedTypes>
       </PropertyGroup>
       <ItemGroup>
         <Compile Include="$(SrcDir)Polyfill.cs" />
       </ItemGroup>
     </When>
   </Choose>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="LeaderElection.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/LeaderElection.BlobStorage/BlobStorageLeaderElection.cs
+++ b/src/LeaderElection.BlobStorage/BlobStorageLeaderElection.cs
@@ -170,7 +170,7 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
     {
         if (_settings.BlobClientFactory != null)
         {
-            if (_settings.ConnectionString != null)
+            if (!string.IsNullOrEmpty(_settings.ConnectionString))
             {
                 LogIgnoringConnectionStringBecauseFactoryIsSet();
             }
@@ -180,7 +180,7 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
                 .ConfigureAwait(false);
         }
 
-        if (_settings.ConnectionString != null)
+        if (!string.IsNullOrEmpty(_settings.ConnectionString))
         {
             var bsc = new BlobServiceClient(_settings.ConnectionString);
             return await BlobStorageServiceBuilderExtensions

--- a/src/LeaderElection.BlobStorage/BlobStorageLeaderElection.cs
+++ b/src/LeaderElection.BlobStorage/BlobStorageLeaderElection.cs
@@ -96,11 +96,13 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
         }
         catch (Azure.RequestFailedException ex)
         {
+            // this is unexpected since we should own the lease.
+            // Log as a warning and give up our leadership.
             var logLevel = (HttpStatusCode)ex.Status switch
             {
-                HttpStatusCode.NotFound => LogLevel.Information, // blob deleted?
-                HttpStatusCode.Conflict => LogLevel.Information, // least broke/breaking
-                HttpStatusCode.PreconditionFailed => LogLevel.Information, // least lost
+                HttpStatusCode.NotFound => LogLevel.Warning, // blob deleted?
+                HttpStatusCode.Conflict => LogLevel.Warning, // lease broke/breaking
+                HttpStatusCode.PreconditionFailed => LogLevel.Warning, // lease lost
                 _ => LogLevel.Error,
             };
 
@@ -139,11 +141,13 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
         }
         catch (Azure.RequestFailedException ex)
         {
+            // this is unexpected since we should own the lease.
+            // Log as a warning and give up our leadership.
             var logLevel = (HttpStatusCode)ex.Status switch
             {
-                HttpStatusCode.NotFound => LogLevel.Information, // blob deleted?
-                HttpStatusCode.Conflict => LogLevel.Information, // least broke/breaking
-                HttpStatusCode.PreconditionFailed => LogLevel.Information, // least lost
+                HttpStatusCode.NotFound => LogLevel.Warning, // blob deleted?
+                HttpStatusCode.Conflict => LogLevel.Warning, // lease broke/breaking
+                HttpStatusCode.PreconditionFailed => LogLevel.Warning, // lease lost
                 _ => LogLevel.Error,
             };
 

--- a/src/LeaderElection.BlobStorage/BlobStorageLeaderElection.cs
+++ b/src/LeaderElection.BlobStorage/BlobStorageLeaderElection.cs
@@ -201,16 +201,18 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
             }
 
             return await _settings
-                .BlobClientFactory(_settings, cancellationToken)
-                .ConfigureAwait(false);
+                    .BlobClientFactory(_settings, cancellationToken)
+                    .ConfigureAwait(false)
+                ?? throw new InvalidOperationException("BlobClientFactory returned null.");
         }
 
         if (!string.IsNullOrEmpty(_settings.ConnectionString))
         {
             var bsc = new BlobServiceClient(_settings.ConnectionString);
             return await BlobStorageServiceBuilderExtensions
-                .CreateBlobClient(bsc, _settings, cancellationToken)
-                .ConfigureAwait(false);
+                    .CreateBlobClient(bsc, _settings, cancellationToken)
+                    .ConfigureAwait(false)
+                ?? throw new InvalidOperationException("CreateBlobClient returned null.");
         }
 
         throw new InvalidOperationException(

--- a/src/LeaderElection.BlobStorage/BlobStorageLeaderElection.cs
+++ b/src/LeaderElection.BlobStorage/BlobStorageLeaderElection.cs
@@ -36,7 +36,7 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
     {
         if (!string.IsNullOrEmpty(_currentLeaseId))
         {
-            LogLeaseAlreadyAcquired(_blobClient?.Uri);
+            LogLeaseAlreadyAcquired(_blobClient!.Uri.GetLeftPart(UriPartial.Path));
             return false;
         }
 
@@ -55,7 +55,10 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
             success = true;
             _currentLeaseId = leaseResponse.Value.LeaseId;
             _blobClient = blobClient;
-            LogAcquiredLeaseWithIdLeaseId(_blobClient.Uri, _currentLeaseId);
+            LogAcquiredLeaseWithIdLeaseId(
+                _blobClient.Uri.GetLeftPart(UriPartial.Path),
+                _currentLeaseId
+            );
         }
         catch (Azure.RequestFailedException ex)
         {
@@ -64,7 +67,14 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
                     ? LogLevel.Debug
                     : LogLevel.Error;
 
-            LogFailureAcquiringLease(logLevel, blobClient.Uri, ex.Status, ex.ErrorCode);
+#pragma warning disable CA1873 // Avoid potentially expensive logging
+            LogFailureAcquiringLease(
+                logLevel,
+                blobClient.Uri.GetLeftPart(UriPartial.Path),
+                ex.Status,
+                ex.ErrorCode
+            );
+#pragma warning restore CA1873 // Avoid potentially expensive logging
         }
 
         return success;
@@ -92,7 +102,7 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
 
             success = true;
             Debug.Assert(_currentLeaseId == leaseResponse.Value.LeaseId);
-            LogLeaseRenewed(_blobClient.Uri, _currentLeaseId);
+            LogLeaseRenewed(_blobClient.Uri.GetLeftPart(UriPartial.Path), _currentLeaseId);
         }
         catch (Azure.RequestFailedException ex)
         {
@@ -106,7 +116,15 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
                 _ => LogLevel.Error,
             };
 
-            LogFailureRenewingLease(logLevel, _blobClient.Uri, ex.Status, ex.ErrorCode, ex);
+#pragma warning disable CA1873 // Avoid potentially expensive logging
+            LogFailureRenewingLease(
+                logLevel,
+                _blobClient.Uri.GetLeftPart(UriPartial.Path),
+                ex.Status,
+                ex.ErrorCode,
+                ex
+            );
+#pragma warning restore CA1873 // Avoid potentially expensive logging
         }
         finally
         {
@@ -135,7 +153,7 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
             var leaseClient = _blobClient.GetBlobLeaseClient(_currentLeaseId);
             await leaseClient.ReleaseAsync().ConfigureAwait(false);
 
-            LogLeaseReleased(_blobClient.Uri);
+            LogLeaseReleased(_blobClient.Uri.GetLeftPart(UriPartial.Path));
         }
         catch (Azure.RequestFailedException ex)
         {
@@ -149,7 +167,14 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
                 _ => LogLevel.Error,
             };
 
-            LogFailureReleasingLease(logLevel, _blobClient.Uri, ex.Status, ex.ErrorCode);
+#pragma warning disable CA1873 // Avoid potentially expensive logging
+            LogFailureReleasingLease(
+                logLevel,
+                _blobClient.Uri.GetLeftPart(UriPartial.Path),
+                ex.Status,
+                ex.ErrorCode
+            );
+#pragma warning restore CA1873 // Avoid potentially expensive logging
         }
         finally
         {
@@ -208,7 +233,7 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
                 )
                 .ConfigureAwait(false);
 
-            LogCreatedBlob(blobClient.Uri);
+            LogCreatedBlob(blobClient.Uri.GetLeftPart(UriPartial.Path));
         }
         catch (Azure.RequestFailedException ex)
             when (ex.ErrorCode == BlobErrorCode.BlobAlreadyExists)
@@ -217,20 +242,24 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
         }
         catch (Azure.RequestFailedException ex)
         {
-            LogFailureCreatingBlob(blobClient.Uri, ex.Status, ex.ErrorCode);
+            LogFailureCreatingBlob(
+                blobClient.Uri.GetLeftPart(UriPartial.Path),
+                ex.Status,
+                ex.ErrorCode
+            );
         }
     }
 
-    [LoggerMessage(LogLevel.Information, "Lease already acquired on {BlobUri}.")]
-    partial void LogLeaseAlreadyAcquired(Uri? blobUri);
+    [LoggerMessage(LogLevel.Information, "Lease already acquired on {BlobUrl}.")]
+    partial void LogLeaseAlreadyAcquired(string blobUrl);
 
-    [LoggerMessage(LogLevel.Debug, "Lease acquired on {BlobUri}: {LeaseId}.")]
-    partial void LogAcquiredLeaseWithIdLeaseId(Uri blobUri, string leaseId);
+    [LoggerMessage(LogLevel.Debug, "Lease acquired on {BlobUrl}: {LeaseId}.")]
+    partial void LogAcquiredLeaseWithIdLeaseId(string blobUrl, string leaseId);
 
-    [LoggerMessage("Failure acquiring lease on {BlobUri}: {Status} - {ErrorCode}.")]
+    [LoggerMessage("Failure acquiring lease on {BlobUrl}: {Status} - {ErrorCode}.")]
     partial void LogFailureAcquiringLease(
         LogLevel level,
-        Uri blobUri,
+        string blobUrl,
         int status,
         string? errorCode
     );
@@ -238,13 +267,13 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
     [LoggerMessage(LogLevel.Information, "No lease to renew.")]
     partial void LogNoCurrentLeaseToRenew();
 
-    [LoggerMessage(LogLevel.Debug, "Lease renewed on {BlobUri}: {LeaseId}.")]
-    partial void LogLeaseRenewed(Uri blobUri, string leaseId);
+    [LoggerMessage(LogLevel.Debug, "Lease renewed on {BlobUrl}: {LeaseId}.")]
+    partial void LogLeaseRenewed(string blobUrl, string leaseId);
 
-    [LoggerMessage("Failure renewing lease on {BlobUri}: {Status} - {ErrorCode}.")]
+    [LoggerMessage("Failure renewing lease on {BlobUrl}: {Status} - {ErrorCode}.")]
     partial void LogFailureRenewingLease(
         LogLevel logLevel,
-        Uri blobUri,
+        string blobUrl,
         int status,
         string? errorCode,
         Exception exception
@@ -253,13 +282,13 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
     [LoggerMessage(LogLevel.Information, "No lease to release.")]
     partial void LogNoLeaseToRelease();
 
-    [LoggerMessage(LogLevel.Debug, "Lease released on {BlobUri}.")]
-    partial void LogLeaseReleased(Uri blobUri);
+    [LoggerMessage(LogLevel.Debug, "Lease released on {BlobUrl}.")]
+    partial void LogLeaseReleased(string blobUrl);
 
-    [LoggerMessage("Failure releasing lease on {BlobUri}: {Status} - {ErrorCode}.")]
+    [LoggerMessage("Failure releasing lease on {BlobUrl}: {Status} - {ErrorCode}.")]
     partial void LogFailureReleasingLease(
         LogLevel logLevel,
-        Uri blobUri,
+        string blobUrl,
         int status,
         string? errorCode
     );
@@ -270,9 +299,9 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
     )]
     partial void LogIgnoringConnectionStringBecauseFactoryIsSet();
 
-    [LoggerMessage(LogLevel.Information, "Created blob: {BlobUri}.")]
-    partial void LogCreatedBlob(Uri blobUri);
+    [LoggerMessage(LogLevel.Information, "Created blob: {BlobUrl}.")]
+    partial void LogCreatedBlob(string blobUrl);
 
-    [LoggerMessage(LogLevel.Warning, "Failure creating blob: {BlobUri}: {Status} - {ErrorCode}.")]
-    partial void LogFailureCreatingBlob(Uri blobUri, int status, string? errorCode);
+    [LoggerMessage(LogLevel.Warning, "Failure creating blob: {BlobUrl}: {Status} - {ErrorCode}.")]
+    partial void LogFailureCreatingBlob(string blobUrl, int status, string? errorCode);
 }

--- a/src/LeaderElection.BlobStorage/BlobStorageLeaderElection.cs
+++ b/src/LeaderElection.BlobStorage/BlobStorageLeaderElection.cs
@@ -113,7 +113,7 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
             if (!success)
             {
                 // give up the lease in our state to avoid being stuck in a bad state
-                ForceReset();
+                await ResetLeadershipAsync().ConfigureAwait(false);
             }
         }
 
@@ -155,14 +155,15 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
         {
             // always give up local leadership state even if release failed, since we don't
             // want to be stuck in a bad state where we think we are the leader but are not.
-            ForceReset();
+            await ResetLeadershipAsync().ConfigureAwait(false);
         }
     }
 
-    private void ForceReset()
+    protected override ValueTask ResetLeadershipAsync()
     {
         _currentLeaseId = null;
         _blobClient = null;
+        return new ValueTask();
     }
 
     private async Task<BlobClient> CreateBlobClientAsync(CancellationToken cancellationToken)

--- a/src/LeaderElection.BlobStorage/BlobStorageLeaderElection.cs
+++ b/src/LeaderElection.BlobStorage/BlobStorageLeaderElection.cs
@@ -1,76 +1,71 @@
+using System.Diagnostics;
+using System.Net;
 using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace LeaderElection.BlobStorage;
 
+/// <summary>
+/// Leader Election implementation that uses blob leases for leader election.
+/// Each contender will attempt to acquire a lease on the same blob, and the one
+/// that holds the lease is the leader. The lease will be automatically released
+/// if the contender fails to renew it within the lease duration, allowing other
+/// contenders to acquire leadership.
+///
+/// This implementation relies on Azure Blob Storage's strong consistency and lease
+/// mechanism to ensure that only one contender can be the leader at any given time.
+/// </summary>
 public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageSettings>
 {
-    private readonly BlobContainerClient _containerClient;
-    private readonly BlobClient _blobClient;
+    private BlobClient? _blobClient;
     private string? _currentLeaseId;
 
     public BlobStorageLeaderElection(
-        BlobServiceClient blobServiceClient,
-        IOptions<BlobStorageSettings> options,
-        ILogger<BlobStorageLeaderElection> logger
-    )
-        : base(options?.Value ?? throw new ArgumentNullException(nameof(options)), logger)
-    {
-        _ = blobServiceClient ?? throw new ArgumentNullException(nameof(blobServiceClient));
-        _containerClient = blobServiceClient.GetBlobContainerClient(_settings.ContainerName);
-
-        _blobClient = _containerClient.GetBlobClient(_settings.BlobName);
-    }
-
-    public BlobStorageLeaderElection(
-        BlobContainerClient client,
         BlobStorageSettings settings,
         ILogger<BlobStorageLeaderElection> logger
     )
-        : base(settings ?? throw new ArgumentNullException(nameof(settings)), logger)
-    {
-        _containerClient = client ?? throw new ArgumentNullException(nameof(client));
-
-        _blobClient = _containerClient.GetBlobClient(_settings.BlobName);
-    }
+        : base(settings ?? throw new ArgumentNullException(nameof(settings)), logger) { }
 
     protected override async Task<bool> TryAcquireLeadershipInternalAsync(
         CancellationToken cancellationToken
     )
     {
+        if (!string.IsNullOrEmpty(_currentLeaseId))
+        {
+            LogLeaseAlreadyAcquired(_blobClient?.Uri);
+            return false;
+        }
+
+        var blobClient = await CreateBlobClientAsync(cancellationToken).ConfigureAwait(false);
+
+        await EnsureBlobExistsAsync(blobClient, cancellationToken).ConfigureAwait(false);
+
+        var success = false;
         try
         {
-            if (_settings.CreateContainerIfNotExists)
-            {
-                await EnsureBlobExistsAsync(cancellationToken).ConfigureAwait(false);
-            }
-
-            var leaseClient = _blobClient.GetBlobLeaseClient();
+            var leaseClient = blobClient.GetBlobLeaseClient();
             var leaseResponse = await leaseClient
                 .AcquireAsync(_settings.LeaseDuration, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
-            if (leaseResponse?.Value?.LeaseId != null)
-            {
-                _currentLeaseId = leaseResponse.Value.LeaseId;
-                LogAcquiredLeaseWithIdLeaseId(_logger, _currentLeaseId);
-                return true;
-            }
+            success = true;
+            _currentLeaseId = leaseResponse.Value.LeaseId;
+            _blobClient = blobClient;
+            LogAcquiredLeaseWithIdLeaseId(_blobClient.Uri, _currentLeaseId);
+        }
+        catch (Azure.RequestFailedException ex)
+        {
+            var logLevel =
+                ex.ErrorCode == BlobErrorCode.LeaseAlreadyPresent // another instance holds the lease - very common
+                    ? LogLevel.Debug
+                    : LogLevel.Error;
 
-            return false;
+            LogFailureAcquiringLease(logLevel, blobClient.Uri, ex.Status, ex.ErrorCode);
         }
-        catch (Azure.RequestFailedException ex) when (ex.Status == 409) // Conflict - lease already exists
-        {
-            LogLeaseAlreadyExistsCannotAcquireLeadership(_logger);
-            return false;
-        }
-        catch (Exception ex)
-        {
-            LogErrorAcquiringLeadership(_logger, ex);
-            return false;
-        }
+
+        return success;
     }
 
     protected override async Task<bool> RenewLeadershipInternalAsync(
@@ -79,10 +74,13 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
     {
         if (string.IsNullOrEmpty(_currentLeaseId))
         {
-            LogNoCurrentLeaseIdCannotRenewLeadership(_logger);
+            LogNoCurrentLeaseToRenew();
             return false;
         }
 
+        Debug.Assert(_blobClient != null);
+
+        var success = false;
         try
         {
             var leaseClient = _blobClient.GetBlobLeaseClient(_currentLeaseId);
@@ -90,149 +88,188 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
                 .RenewAsync(cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
-            if (leaseResponse?.Value?.LeaseId != null)
+            success = true;
+            Debug.Assert(_currentLeaseId == leaseResponse.Value.LeaseId);
+            LogLeaseRenewed(_blobClient.Uri, _currentLeaseId);
+        }
+        catch (Azure.RequestFailedException ex)
+        {
+            var logLevel = (HttpStatusCode)ex.Status switch
             {
-                LogRenewedLeaseSuccessfully(_logger);
-                return true;
-            }
+                HttpStatusCode.NotFound => LogLevel.Information, // blob deleted?
+                HttpStatusCode.Conflict => LogLevel.Information, // least broke/breaking
+                HttpStatusCode.PreconditionFailed => LogLevel.Information, // least lost
+                _ => LogLevel.Error,
+            };
 
-            return false;
+            LogFailureRenewingLease(logLevel, _blobClient.Uri, ex.Status, ex.ErrorCode, ex);
         }
-        catch (Azure.RequestFailedException ex) when (ex.Status == 404) // Not Found - blob doesn't exist
+        finally
         {
-            LogBlobNotFoundDuringLeaseRenewal(_logger);
-            return false;
+            if (!success)
+            {
+                // give up the lease in our state to avoid being stuck in a bad state
+                ForceReset();
+            }
         }
-        catch (Azure.RequestFailedException ex) when (ex.Status == 409) // Conflict - lease lost
-        {
-            LogLeaseConflictDuringRenewalLeadershipLost(_logger);
-            return false;
-        }
-        catch (Exception ex)
-        {
-            LogErrorRenewingLeadership(_logger, ex);
-            return false;
-        }
+
+        return success;
     }
 
     protected override async Task ReleaseLeadershipAsync()
     {
         if (string.IsNullOrEmpty(_currentLeaseId))
         {
-            LogNoLeaseIdToRelease(_logger);
+            LogNoLeaseToRelease();
             return;
         }
 
+        Debug.Assert(_blobClient != null);
+
+        var success = false;
         try
         {
             var leaseClient = _blobClient.GetBlobLeaseClient(_currentLeaseId);
             await leaseClient.ReleaseAsync().ConfigureAwait(false);
 
-            _currentLeaseId = null;
-            LogLeadershipReleasedForInstanceInstanceId(_logger, _settings.InstanceId);
+            success = true;
+            LogLeaseReleased(_blobClient.Uri);
         }
-        catch (Azure.RequestFailedException ex) when (ex.Status == 404) // Not Found - blob doesn't exist
+        catch (Azure.RequestFailedException ex)
         {
-            LogBlobNotFoundDuringLeaseRelease(_logger);
+            var logLevel = (HttpStatusCode)ex.Status switch
+            {
+                HttpStatusCode.NotFound => LogLevel.Information, // blob deleted?
+                HttpStatusCode.Conflict => LogLevel.Information, // least broke/breaking
+                HttpStatusCode.PreconditionFailed => LogLevel.Information, // least lost
+                _ => LogLevel.Error,
+            };
+
+            LogFailureReleasingLease(logLevel, _blobClient.Uri, ex.Status, ex.ErrorCode);
         }
-        catch (Azure.RequestFailedException ex) when (ex.Status == 409) // Conflict - lease already expired
+        finally
         {
-            LogLeaseAlreadyExpiredDuringRelease(_logger);
-        }
-        catch (Exception ex)
-        {
-            LogErrorReleasingLeadership(_logger, ex);
+            if (!success)
+            {
+                // give up the lease in our state to avoid being stuck in a bad state
+                ForceReset();
+            }
         }
     }
 
-    private async Task EnsureBlobExistsAsync(CancellationToken cancellationToken)
+    private void ForceReset()
+    {
+        _currentLeaseId = null;
+        _blobClient = null;
+    }
+
+    private async Task<BlobClient> CreateBlobClientAsync(CancellationToken cancellationToken)
+    {
+        if (_settings.BlobClientFactory != null)
+        {
+            if (_settings.ConnectionString != null)
+            {
+                LogIgnoringConnectionStringBecauseFactoryIsSet();
+            }
+
+            return await _settings
+                .BlobClientFactory(_settings, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        if (_settings.ConnectionString != null)
+        {
+            var bsc = new BlobServiceClient(_settings.ConnectionString);
+            return await BlobStorageServiceBuilderExtensions
+                .CreateBlobClient(bsc, _settings, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        throw new InvalidOperationException(
+            "Either BlobClientFactory or ConnectionString must be specified in settings."
+        );
+    }
+
+    private async Task EnsureBlobExistsAsync(
+        BlobClient blobClient,
+        CancellationToken cancellationToken
+    )
     {
         try
         {
-            if (_containerClient != null)
-            {
-                var containerExists = await _containerClient
-                    .ExistsAsync(cancellationToken)
-                    .ConfigureAwait(false);
-                if (!containerExists.Value && _settings.CreateContainerIfNotExists)
-                {
-                    LogCreatingLeaderElectionContainer(_logger);
-                    await _containerClient
-                        .CreateIfNotExistsAsync(cancellationToken: cancellationToken)
-                        .ConfigureAwait(false);
-                }
-            }
+            await blobClient
+                .UploadAsync(
+                    new BinaryData(_settings.InstanceId),
+                    overwrite: false,
+                    cancellationToken: cancellationToken
+                )
+                .ConfigureAwait(false);
 
-            if (_blobClient != null)
-            {
-                var exists = await _blobClient.ExistsAsync(cancellationToken).ConfigureAwait(false);
-                if (!exists.Value)
-                {
-                    LogCreatingLeaderElectionBlob(_logger);
-                    await _blobClient
-                        .UploadAsync(
-                            new BinaryData(_settings.InstanceId),
-                            overwrite: true,
-                            cancellationToken: cancellationToken
-                        )
-                        .ConfigureAwait(false);
-                }
-            }
+            LogCreatedBlob(blobClient.Uri);
         }
-        catch (Exception ex)
+        catch (Azure.RequestFailedException ex)
+            when (ex.ErrorCode == BlobErrorCode.BlobAlreadyExists)
         {
-            LogErrorEnsuringBlobExists(_logger, ex);
+            // Okay.
+        }
+        catch (Azure.RequestFailedException ex)
+        {
+            LogFailureCreatingBlob(blobClient.Uri, ex.Status, ex.ErrorCode);
         }
     }
 
-    [LoggerMessage(LogLevel.Debug, "Acquired lease with ID: {leaseId}")]
-    static partial void LogAcquiredLeaseWithIdLeaseId(ILogger logger, string leaseId);
+    [LoggerMessage(LogLevel.Information, "Lease already acquired on {BlobUri}.")]
+    partial void LogLeaseAlreadyAcquired(Uri? blobUri);
 
-    [LoggerMessage(LogLevel.Debug, "Lease already exists, cannot acquire leadership")]
-    static partial void LogLeaseAlreadyExistsCannotAcquireLeadership(ILogger logger);
+    [LoggerMessage(LogLevel.Debug, "Lease acquired on {BlobUri}: {LeaseId}.")]
+    partial void LogAcquiredLeaseWithIdLeaseId(Uri blobUri, string leaseId);
 
-    [LoggerMessage(LogLevel.Error, "Error acquiring leadership")]
-    static partial void LogErrorAcquiringLeadership(ILogger logger, Exception exception);
-
-    [LoggerMessage(LogLevel.Warning, "No current lease ID, cannot renew leadership")]
-    static partial void LogNoCurrentLeaseIdCannotRenewLeadership(ILogger logger);
-
-    [LoggerMessage(LogLevel.Debug, "Renewed lease successfully")]
-    static partial void LogRenewedLeaseSuccessfully(ILogger logger);
-
-    [LoggerMessage(LogLevel.Warning, "Blob not found during lease renewal")]
-    static partial void LogBlobNotFoundDuringLeaseRenewal(ILogger logger);
-
-    [LoggerMessage(LogLevel.Warning, "Lease conflict during renewal - leadership lost")]
-    static partial void LogLeaseConflictDuringRenewalLeadershipLost(ILogger logger);
-
-    [LoggerMessage(LogLevel.Error, "Error renewing leadership")]
-    static partial void LogErrorRenewingLeadership(ILogger logger, Exception exception);
-
-    [LoggerMessage(LogLevel.Debug, "No lease ID to release")]
-    static partial void LogNoLeaseIdToRelease(ILogger logger);
-
-    [LoggerMessage(LogLevel.Information, "Leadership released for instance {instanceId}")]
-    static partial void LogLeadershipReleasedForInstanceInstanceId(
-        ILogger logger,
-        string instanceId
+    [LoggerMessage("Failure acquiring lease on {BlobUri}: {Status} - {ErrorCode}.")]
+    partial void LogFailureAcquiringLease(
+        LogLevel level,
+        Uri blobUri,
+        int status,
+        string? errorCode
     );
 
-    [LoggerMessage(LogLevel.Debug, "Blob not found during lease release")]
-    static partial void LogBlobNotFoundDuringLeaseRelease(ILogger logger);
+    [LoggerMessage(LogLevel.Information, "No lease to renew.")]
+    partial void LogNoCurrentLeaseToRenew();
 
-    [LoggerMessage(LogLevel.Debug, "Lease already expired during release")]
-    static partial void LogLeaseAlreadyExpiredDuringRelease(ILogger logger);
+    [LoggerMessage(LogLevel.Debug, "Lease renewed on {BlobUri}: {LeaseId}.")]
+    partial void LogLeaseRenewed(Uri blobUri, string leaseId);
 
-    [LoggerMessage(LogLevel.Error, "Error releasing leadership")]
-    static partial void LogErrorReleasingLeadership(ILogger logger, Exception exception);
+    [LoggerMessage("Failure renewing lease on {BlobUri}: {Status} - {ErrorCode}.")]
+    partial void LogFailureRenewingLease(
+        LogLevel logLevel,
+        Uri blobUri,
+        int status,
+        string? errorCode,
+        Exception exception
+    );
 
-    [LoggerMessage(LogLevel.Debug, "Creating leader election container")]
-    static partial void LogCreatingLeaderElectionContainer(ILogger logger);
+    [LoggerMessage(LogLevel.Information, "No lease to release.")]
+    partial void LogNoLeaseToRelease();
 
-    [LoggerMessage(LogLevel.Debug, "Creating leader election blob")]
-    static partial void LogCreatingLeaderElectionBlob(ILogger logger);
+    [LoggerMessage(LogLevel.Debug, "Lease released on {BlobUri}.")]
+    partial void LogLeaseReleased(Uri blobUri);
 
-    [LoggerMessage(LogLevel.Error, "Error ensuring blob exists")]
-    static partial void LogErrorEnsuringBlobExists(ILogger logger, Exception exception);
+    [LoggerMessage("Failure releasing lease on {BlobUri}: {Status} - {ErrorCode}.")]
+    partial void LogFailureReleasingLease(
+        LogLevel logLevel,
+        Uri blobUri,
+        int status,
+        string? errorCode
+    );
+
+    [LoggerMessage(
+        LogLevel.Warning,
+        "Ignoring ConnectionString, ContainerName, and BlobName because BlobClientFactory is set."
+    )]
+    partial void LogIgnoringConnectionStringBecauseFactoryIsSet();
+
+    [LoggerMessage(LogLevel.Information, "Created blob: {BlobUri}.")]
+    partial void LogCreatedBlob(Uri blobUri);
+
+    [LoggerMessage(LogLevel.Warning, "Failure creating blob: {BlobUri}: {Status} - {ErrorCode}.")]
+    partial void LogFailureCreatingBlob(Uri blobUri, int status, string? errorCode);
 }

--- a/src/LeaderElection.BlobStorage/BlobStorageLeaderElection.cs
+++ b/src/LeaderElection.BlobStorage/BlobStorageLeaderElection.cs
@@ -24,9 +24,11 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
 
     public BlobStorageLeaderElection(
         BlobStorageSettings settings,
-        ILogger<BlobStorageLeaderElection> logger
+        ILogger<BlobStorageLeaderElection>? logger = null,
+        TimeProvider? timeProvider = null
     )
-        : base(settings ?? throw new ArgumentNullException(nameof(settings)), logger) { }
+        : base(settings ?? throw new ArgumentNullException(nameof(settings)), logger, timeProvider)
+    { }
 
     protected override async Task<bool> TryAcquireLeadershipInternalAsync(
         CancellationToken cancellationToken

--- a/src/LeaderElection.BlobStorage/BlobStorageLeaderElection.cs
+++ b/src/LeaderElection.BlobStorage/BlobStorageLeaderElection.cs
@@ -130,13 +130,11 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
 
         Debug.Assert(_blobClient != null);
 
-        var success = false;
         try
         {
             var leaseClient = _blobClient.GetBlobLeaseClient(_currentLeaseId);
             await leaseClient.ReleaseAsync().ConfigureAwait(false);
 
-            success = true;
             LogLeaseReleased(_blobClient.Uri);
         }
         catch (Azure.RequestFailedException ex)
@@ -155,11 +153,9 @@ public partial class BlobStorageLeaderElection : LeaderElectionBase<BlobStorageS
         }
         finally
         {
-            if (!success)
-            {
-                // give up the lease in our state to avoid being stuck in a bad state
-                ForceReset();
-            }
+            // always give up local leadership state even if release failed, since we don't
+            // want to be stuck in a bad state where we think we are the leader but are not.
+            ForceReset();
         }
     }
 

--- a/src/LeaderElection.BlobStorage/BlobStorageServiceBuilderExtensions.cs
+++ b/src/LeaderElection.BlobStorage/BlobStorageServiceBuilderExtensions.cs
@@ -107,7 +107,7 @@ public static class BlobStorageServiceBuilderExtensions
             static (sp, key) =>
             {
                 // get settings
-                var settings = sp.GetRequiredService<IOptionsSnapshot<BlobStorageSettings>>()
+                var settings = sp.GetRequiredService<IOptionsMonitor<BlobStorageSettings>>()
                     .Get(key as string);
 
                 // create a new instance...

--- a/src/LeaderElection.BlobStorage/BlobStorageServiceBuilderExtensions.cs
+++ b/src/LeaderElection.BlobStorage/BlobStorageServiceBuilderExtensions.cs
@@ -216,13 +216,13 @@ public static class BlobStorageServiceBuilderExtensions
     /// </remarks>
     public static ServiceBuilder WithSettings(
         this ServiceBuilder builder,
-        Action<IServiceProvider, string?, BlobStorageSettings> configAction
+        Action<BlobStorageSettings, IServiceProvider, string?> configAction
     )
     {
         ArgumentNullException.ThrowIfNull(builder);
         ArgumentNullException.ThrowIfNull(configAction);
         builder.OptionsBuilder.Configure<IServiceProvider>(
-            (settings, sp) => configAction(sp, builder.ServiceKey, settings)
+            (settings, sp) => configAction(settings, sp, builder.ServiceKey)
         );
         return builder;
     }
@@ -258,7 +258,7 @@ public static class BlobStorageServiceBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(factoryFunc);
         return builder.WithSettings(
-            (sp, _, settings) =>
+            (settings, sp, _) =>
                 settings.BlobClientFactory = (settings, ct) => factoryFunc(sp, settings, ct)
         );
     }

--- a/src/LeaderElection.BlobStorage/BlobStorageServiceBuilderExtensions.cs
+++ b/src/LeaderElection.BlobStorage/BlobStorageServiceBuilderExtensions.cs
@@ -1,85 +1,358 @@
 using Azure.Identity;
 using Azure.Storage.Blobs;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace LeaderElection.BlobStorage;
 
+public sealed record ServiceBuilder(
+    string? ServiceKey,
+    OptionsBuilder<BlobStorageSettings> OptionsBuilder
+);
+
 public static class BlobStorageServiceBuilderExtensions
 {
+    /// <inheritdoc cref="AddBlobStorageLeaderElectionInternal" />
+    /// <remarks>
+    /// This overload registers an unnamed ILeaderElection service which uses the
+    /// default BlobServiceClient factory (uses the ConnectionString setting
+    /// if specified, otherwise it will use the registered BlobServiceClient).
+    /// </remarks>
+    /// <param name="configureOptions">An action to configure the
+    /// <see cref="BlobStorageSettings"/> used by the Leader Election.</param>
     public static IServiceCollection AddBlobStorageLeaderElection(
         this IServiceCollection services,
         Action<BlobStorageSettings> configureOptions
-    )
-    {
-        services
-            .AddOptionsWithValidateOnStart<BlobStorageSettings, BlobStorageSettingsValidator>()
-            .Configure(configureOptions);
+    ) => services.AddBlobStorageLeaderElection(builder => builder.WithSettings(configureOptions));
 
-        services.AddSingleton<BlobServiceClient>(sp =>
-        {
-            var options = sp.GetRequiredService<IOptions<BlobStorageSettings>>().Value;
-            return new BlobServiceClient(options.ConnectionString);
-        });
-
-        services.AddSingleton<BlobStorageLeaderElection>();
-        services.AddSingleton<ILeaderElection>(sp =>
-            sp.GetRequiredService<BlobStorageLeaderElection>()
-        );
-
-        return services;
-    }
-
+    /// <inheritdoc cref="AddBlobStorageLeaderElectionInternal" />
+    /// <remarks>
+    /// This overload registers an unnamed ILeaderElection service which uses the
+    /// default BlobServiceClient factory (uses the ConnectionString setting
+    /// if specified, otherwise it will use the registered BlobServiceClient).
+    /// </remarks>
+    /// <param name="options">The <see cref="BlobStorageSettings"/> instance to use for
+    /// configuration.</param>
     public static IServiceCollection AddBlobStorageLeaderElection(
         this IServiceCollection services,
         BlobStorageSettings options
-    )
-    {
-        services.AddBlobStorageLeaderElection(opt =>
-        {
-            opt.ConnectionString = options.ConnectionString;
-            opt.ContainerName = options.ContainerName;
-            opt.BlobName = options.BlobName;
-            opt.InstanceId = options.InstanceId;
-            opt.LeaseDuration = options.LeaseDuration;
-            opt.RenewInterval = options.RenewInterval;
-            opt.RetryInterval = options.RetryInterval;
-            opt.MaxRetryAttempts = options.MaxRetryAttempts;
-            opt.EnableGracefulShutdown = options.EnableGracefulShutdown;
-            opt.CreateContainerIfNotExists = options.CreateContainerIfNotExists;
-        });
+    ) => services.AddBlobStorageLeaderElection(builder => builder.WithSettings(options));
 
-        return services;
-    }
-
+    /// <inheritdoc cref="AddBlobStorageLeaderElectionInternal" />
+    /// <remarks>
+    /// This overload registers an unnamed ILeaderElection service which uses the
+    /// default BlobServiceClient factory (uses the ConnectionString setting
+    /// if specified, otherwise it will use the registered BlobServiceClient).
+    /// </remarks>
+    /// <param name="endpoint">The Blob Storage endpoint. <see cref="DefaultAzureCredential"/>
+    /// will be used for authentication.</param>
+    /// <param name="options">The <see cref="BlobStorageSettings"/> instance to use
+    /// for configuration.</param>
     public static IServiceCollection AddBlobStorageLeaderElection(
         this IServiceCollection services,
         string endpoint,
         BlobStorageSettings options
     )
     {
-        services.Configure<BlobStorageSettings>(opt =>
+        return services.AddBlobStorageLeaderElection(builder =>
         {
-            opt.ConnectionString = options.ConnectionString;
-            opt.ContainerName = options.ContainerName;
-            opt.BlobName = options.BlobName;
-            opt.InstanceId = options.InstanceId;
-            opt.LeaseDuration = options.LeaseDuration;
-            opt.RenewInterval = options.RenewInterval;
-            opt.RetryInterval = options.RetryInterval;
-            opt.MaxRetryAttempts = options.MaxRetryAttempts;
-            opt.EnableGracefulShutdown = options.EnableGracefulShutdown;
-            opt.CreateContainerIfNotExists = options.CreateContainerIfNotExists;
+            builder.WithSettings(options);
+            builder.WithBlobServiceClient(
+                new BlobServiceClient(new Uri(endpoint), new DefaultAzureCredential())
+            );
         });
+    }
 
-        services.AddSingleton<BlobServiceClient>(
-            new BlobServiceClient(new Uri(endpoint), new DefaultAzureCredential())
+    /// <inheritdoc cref="AddBlobStorageLeaderElectionInternal" />
+    public static IServiceCollection AddBlobStorageLeaderElection(
+        this IServiceCollection services,
+        Action<ServiceBuilder> builder,
+        string? serviceKey = null
+    ) => AddBlobStorageLeaderElectionInternal(services, builder, serviceKey);
+
+    /// <summary>
+    /// Adds Blob Storage based leader election services to the specified
+    /// <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The service collection to add the services to.</param>
+    /// <param name="builder">An action used to configure the settings and blob client factory.</param>
+    /// <param name="serviceKey">An optional key to register the services and settings
+    /// with. This allows for multiple leader election registrations in the same
+    /// application. If not provided, the services and settings will be registered
+    /// without a key.</param>
+    /// <returns>The updated service collection.</returns>
+    private static IServiceCollection AddBlobStorageLeaderElectionInternal(
+        IServiceCollection services,
+        Action<ServiceBuilder> builder,
+        string? serviceKey = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // Register options and leader election services with the specified service key
+        // (or no key if serviceKey is null)
+        var optionsBuilder = services.AddOptionsWithValidateOnStart<
+            BlobStorageSettings,
+            BlobStorageSettingsValidator
+        >(serviceKey);
+
+        // Register the BlobStorageLeaderElection as a keyed singleton. The factory
+        // creates a new instance of the BlobStorageLeaderElection for each unique
+        // service key, using the corresponding settings and blob client factory.
+        // Note: AddKeyedSingleton(serviceKey: null) is the same as AddSingleton().
+        services.AddKeyedSingleton(
+            serviceKey,
+            static (sp, key) =>
+            {
+                // get [keyed] settings
+                var settings = sp.GetRequiredService<IOptionsSnapshot<BlobStorageSettings>>()
+                    .Get(key as string);
+
+                // create a new instance...
+                return ActivatorUtilities.CreateInstance<BlobStorageLeaderElection>(sp, settings);
+            }
         );
-        services.AddSingleton<BlobStorageLeaderElection>();
-        services.AddSingleton<ILeaderElection>(sp =>
-            sp.GetRequiredService<BlobStorageLeaderElection>()
+
+        services.AddKeyedSingleton<ILeaderElection>(
+            serviceKey,
+            static (sp, key) => sp.GetRequiredKeyedService<BlobStorageLeaderElection>(key)
+        );
+
+        // Invoke builder action to allow user to specify a blob client
+        // factory and settings
+        builder.Invoke(new ServiceBuilder(serviceKey, optionsBuilder));
+
+        // Ensure a blob client factory is registered if no connection string is provided
+        optionsBuilder.PostConfigure<IServiceProvider>(
+            (opts, sp) =>
+            {
+                if (string.IsNullOrEmpty(opts.ConnectionString))
+                {
+                    opts.BlobClientFactory ??= (settings, ct) =>
+                        CreateBlobClient(sp, serviceKey, settings, ct);
+                }
+            }
         );
 
         return services;
+    }
+
+    //
+    // Extension methods for specifying the BlobClient factory for the
+    // BlobStorageLeaderElection builder
+    //
+
+    /// <summary>
+    /// Specifies a Configuration section to bind to the default
+    /// <see cref="BlobStorageSettings"/> used by the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithConfiguration(
+        this ServiceBuilder builder,
+        IConfiguration configureSection
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureSection);
+        builder.OptionsBuilder.Configure(configureSection.Bind);
+        return builder;
+    }
+
+    /// <summary>
+    /// Specifies a Configuration section name to bind to the default
+    /// <see cref="BlobStorageSettings"/> used by the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithConfiguration(
+        this ServiceBuilder builder,
+        string configurationSectionName
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configurationSectionName);
+        builder.OptionsBuilder.Configure<IConfiguration>(
+            (opts, configuration) => configuration.GetSection(configurationSectionName).Bind(opts)
+        );
+        return builder;
+    }
+
+    /// <summary>
+    /// Specifies the default <see cref="BlobStorageSettings"/> used by
+    /// the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithSettings(
+        this ServiceBuilder builder,
+        BlobStorageSettings settings
+    )
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        return builder.WithSettings(dst => BlobStorageSettings.Copy(settings, dst));
+    }
+
+    /// <summary>
+    /// Specifies an action to configure the <see cref="BlobStorageSettings"/>
+    /// used by the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithSettings(
+        this ServiceBuilder builder,
+        Action<BlobStorageSettings> configureOptions
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+        builder.OptionsBuilder.Configure(configureOptions);
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the leader election settings using a configuration action which receives
+    /// the service provider and the optional service key.
+    /// </summary>
+    /// <remarks>
+    /// This is the most flexible configuration method, allowing for complex scenarios such as:
+    /// - Resolving different cache instances based on the service key
+    /// - Accessing other services from the service provider to configure the settings
+    /// - Dynamically determining configuration values at runtime
+    /// </remarks>
+    public static ServiceBuilder WithSettings(
+        this ServiceBuilder builder,
+        Action<IServiceProvider, string?, BlobStorageSettings> configAction
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configAction);
+        builder.OptionsBuilder.Configure<IServiceProvider>(
+            (settings, sp) => configAction(sp, builder.ServiceKey, settings)
+        );
+        return builder;
+    }
+
+    /// <summary>
+    /// Specifies the instance ID to use for the Leader Election.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="instanceId"></param>
+    /// <returns></returns>
+    public static ServiceBuilder WithInstanceId(this ServiceBuilder builder, string instanceId)
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(instanceId);
+        return builder.WithSettings(options => options.InstanceId = instanceId);
+    }
+
+    /// <summary>
+    /// Specifies a specific <see cref="BlobClient"/> to use with the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithBlobClient(this ServiceBuilder builder, BlobClient blobClient)
+    {
+        ArgumentNullException.ThrowIfNull(blobClient);
+        return builder.WithBlobClientFactory((_, _, _) => Task.FromResult(blobClient));
+    }
+
+    /// <summary>
+    /// Specifies a BlobClient factory to use with the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithBlobClientFactory(
+        this ServiceBuilder builder,
+        Func<IServiceProvider, BlobStorageSettings, CancellationToken, Task<BlobClient>> factoryFunc
+    )
+    {
+        ArgumentNullException.ThrowIfNull(factoryFunc);
+        return builder.WithSettings(
+            (sp, _, settings) =>
+                settings.BlobClientFactory = (settings, ct) => factoryFunc(sp, settings, ct)
+        );
+    }
+
+    /// <summary>
+    /// Specifies a specific <see cref="BlobContainerClient"/> to use with the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithContainerClient(
+        this ServiceBuilder builder,
+        BlobContainerClient containerClient
+    )
+    {
+        ArgumentNullException.ThrowIfNull(containerClient);
+        return builder.WithBlobClientFactory(
+            (_, settings, ct) => CreateBlobClient(containerClient, settings, ct)
+        );
+    }
+
+    /// <summary>
+    /// Specifies a <see cref="BlobServiceClient"/> factory to use with the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithRegisteredBlobServiceClient(this ServiceBuilder builder)
+    {
+        return builder.WithBlobClientFactory(
+            (sp, settings, ct) => CreateBlobClient(sp, builder.ServiceKey, settings, ct)
+        );
+    }
+
+    /// <summary>
+    /// Specifies a specific <see cref="BlobServiceClient"/> to use with the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithBlobServiceClient(
+        this ServiceBuilder builder,
+        BlobServiceClient blobServiceClient
+    )
+    {
+        ArgumentNullException.ThrowIfNull(blobServiceClient);
+        return builder.WithBlobServiceClientFactory(_ => blobServiceClient);
+    }
+
+    /// <summary>
+    /// Specifies a <see cref="BlobServiceClient"/> factory to use with the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithBlobServiceClientFactory(
+        this ServiceBuilder builder,
+        Func<IServiceProvider, BlobServiceClient> blobServiceClientFactory
+    )
+    {
+        ArgumentNullException.ThrowIfNull(blobServiceClientFactory);
+        return builder.WithBlobClientFactory(
+            (sp, settings, ct) =>
+            {
+                var bsc = blobServiceClientFactory(sp);
+                return CreateBlobClient(bsc, settings, ct);
+            }
+        );
+    }
+
+    private static Task<BlobClient> CreateBlobClient(
+        IServiceProvider sp,
+        string? serviceKey,
+        BlobStorageSettings settings,
+        CancellationToken ct
+    )
+    {
+        var bsc =
+            sp.GetKeyedService<BlobServiceClient>(serviceKey)
+            ?? sp.GetRequiredService<BlobServiceClient>();
+        return CreateBlobClient(bsc, settings, ct);
+    }
+
+    internal static Task<BlobClient> CreateBlobClient(
+        BlobServiceClient bsc,
+        BlobStorageSettings settings,
+        CancellationToken ct
+    )
+    {
+        var bcc = bsc.GetBlobContainerClient(settings.ContainerName);
+        return CreateBlobClient(bcc, settings, ct);
+    }
+
+    private static async Task<BlobClient> CreateBlobClient(
+        BlobContainerClient bcc,
+        BlobStorageSettings settings,
+        CancellationToken ct
+    )
+    {
+        var blobClient = bcc.GetBlobClient(settings.BlobName);
+
+        if (settings.CreateContainerIfNotExists)
+        {
+            await bcc.CreateIfNotExistsAsync(cancellationToken: ct).ConfigureAwait(false);
+        }
+
+        return blobClient;
     }
 }

--- a/src/LeaderElection.BlobStorage/BlobStorageServiceBuilderExtensions.cs
+++ b/src/LeaderElection.BlobStorage/BlobStorageServiceBuilderExtensions.cs
@@ -106,7 +106,7 @@ public static class BlobStorageServiceBuilderExtensions
             serviceKey,
             static (sp, key) =>
             {
-                // get [keyed] settings
+                // get settings
                 var settings = sp.GetRequiredService<IOptionsSnapshot<BlobStorageSettings>>()
                     .Get(key as string);
 

--- a/src/LeaderElection.BlobStorage/BlobStorageServiceBuilderExtensions.cs
+++ b/src/LeaderElection.BlobStorage/BlobStorageServiceBuilderExtensions.cs
@@ -259,7 +259,7 @@ public static class BlobStorageServiceBuilderExtensions
         ArgumentNullException.ThrowIfNull(factoryFunc);
         return builder.WithSettings(
             (settings, sp, _) =>
-                settings.BlobClientFactory = (settings, ct) => factoryFunc(sp, settings, ct)
+                settings.BlobClientFactory = (blobSettings, ct) => factoryFunc(sp, blobSettings, ct)
         );
     }
 

--- a/src/LeaderElection.BlobStorage/BlobStorageServiceBuilderExtensions.cs
+++ b/src/LeaderElection.BlobStorage/BlobStorageServiceBuilderExtensions.cs
@@ -131,7 +131,7 @@ public static class BlobStorageServiceBuilderExtensions
                 if (string.IsNullOrEmpty(opts.ConnectionString))
                 {
                     opts.BlobClientFactory ??= (settings, ct) =>
-                        CreateBlobClient(sp, serviceKey, settings, ct);
+                        UseRegisteredBlobServiceClient(sp, serviceKey, settings, ct);
                 }
             }
         );
@@ -283,7 +283,8 @@ public static class BlobStorageServiceBuilderExtensions
     public static ServiceBuilder WithRegisteredBlobServiceClient(this ServiceBuilder builder)
     {
         return builder.WithBlobClientFactory(
-            (sp, settings, ct) => CreateBlobClient(sp, builder.ServiceKey, settings, ct)
+            (sp, settings, ct) =>
+                UseRegisteredBlobServiceClient(sp, builder.ServiceKey, settings, ct)
         );
     }
 
@@ -317,15 +318,15 @@ public static class BlobStorageServiceBuilderExtensions
         );
     }
 
-    private static Task<BlobClient> CreateBlobClient(
+    private static Task<BlobClient> UseRegisteredBlobServiceClient(
         IServiceProvider sp,
-        string? serviceKey,
+        object? serviceKey,
         BlobStorageSettings settings,
         CancellationToken ct
     )
     {
         var bsc =
-            sp.GetKeyedService<BlobServiceClient>(serviceKey)
+            (serviceKey != null ? sp.GetKeyedService<BlobServiceClient>(serviceKey) : null)
             ?? sp.GetRequiredService<BlobServiceClient>();
         return CreateBlobClient(bsc, settings, ct);
     }

--- a/src/LeaderElection.BlobStorage/BlobStorageSettings.cs
+++ b/src/LeaderElection.BlobStorage/BlobStorageSettings.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Azure.Storage.Blobs;
 
 namespace LeaderElection.BlobStorage;
 
@@ -7,10 +8,24 @@ public class BlobStorageSettings : LeaderElectionSettingsBase
     /// <summary>
     /// The connection string for the Azure Blob Storage account.
     /// <para/>
-    /// Ignored when using the constructor that accepts a BlobContainerClient.
+    /// Ignored when <see cref="BlobClientFactory"/> is set.
     /// </summary>
-    [Required(AllowEmptyStrings = true)]
-    public string ConnectionString { get; set; } = string.Empty;
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// An optional factory function to create a <see cref="BlobClient"/> instance for leader election.
+    /// <para/>
+    /// If set, this factory will be used to get a <see cref="BlobClient"/> instead of using
+    /// the <see cref="ConnectionString"/> setting.
+    /// <para/>
+    /// If neither <see cref="BlobClientFactory"/> nor <see cref="ConnectionString"/>
+    /// are set, a <see cref="BlobClientService"/> will be resolved from the DI container.
+    /// </summary>
+    public Func<
+        BlobStorageSettings,
+        CancellationToken,
+        Task<BlobClient>
+    >? BlobClientFactory { get; set; }
 
     /// <summary>
     /// The name of the blob container to use for leader election.
@@ -18,7 +33,7 @@ public class BlobStorageSettings : LeaderElectionSettingsBase
     /// Must be a valid Azure Blob Storage container name.
     /// Default is "leader-election-lock".
     /// <para/>
-    /// Ignored when using the constructor that accepts a BlobContainerClient.
+    /// Ignored when <see cref="BlobClientFactory"/> is set.
     /// </summary>
     [Required]
     public string ContainerName { get; set; } = "leader-election";
@@ -28,6 +43,8 @@ public class BlobStorageSettings : LeaderElectionSettingsBase
     /// <para/>
     /// Must be a valid Azure Blob Storage blob name.
     /// Default is "leader-election-lock".
+    /// <para/>
+    /// Ignored when <see cref="BlobClientFactory"/> is set.
     /// </summary>
     [Required]
     public string BlobName { get; set; } = "leader-election-lock";
@@ -51,4 +68,20 @@ public class BlobStorageSettings : LeaderElectionSettingsBase
     /// Default is true.
     /// </summary>
     public bool CreateContainerIfNotExists { get; set; } = true;
+
+    /// <summary>
+    /// Copies the BlobStorage settings from the source to the destination.
+    /// </summary>
+    public static void Copy(BlobStorageSettings src, BlobStorageSettings dst)
+    {
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(dst);
+        LeaderElectionSettingsBase.Copy(src, dst);
+        dst.ConnectionString = src.ConnectionString;
+        dst.BlobClientFactory = src.BlobClientFactory;
+        dst.ContainerName = src.ContainerName;
+        dst.BlobName = src.BlobName;
+        dst.LeaseDuration = src.LeaseDuration;
+        dst.CreateContainerIfNotExists = src.CreateContainerIfNotExists;
+    }
 }

--- a/src/LeaderElection.BlobStorage/BlobStorageSettings.cs
+++ b/src/LeaderElection.BlobStorage/BlobStorageSettings.cs
@@ -42,7 +42,7 @@ public class BlobStorageSettings : LeaderElectionSettingsBase
     /// <remarks>
     /// Will be created if it does not exist and <see cref="CreateContainerIfNotExists"/> is true.
     /// <para/>
-    /// Must be a valid Azure Blob Storage blob name. See
+    /// Must be a valid Azure Blob Storage container name. See
     /// https://learn.microsoft.com/en-us/rest/api/storageservices/blob-service-concepts.
     /// </remarks>
     [Required]

--- a/src/LeaderElection.BlobStorage/BlobStorageSettings.cs
+++ b/src/LeaderElection.BlobStorage/BlobStorageSettings.cs
@@ -3,24 +3,24 @@ using Azure.Storage.Blobs;
 
 namespace LeaderElection.BlobStorage;
 
+/// <summary>
+/// Settings for Azure Blob Storage-based leader election.
+/// </summary>
 public class BlobStorageSettings : LeaderElectionSettingsBase
 {
     /// <summary>
-    /// The connection string for the Azure Blob Storage account.
-    /// <para/>
-    /// Ignored when <see cref="BlobClientFactory"/> is set.
+    /// An optional factory function used to create a <see cref="BlobClient"/> instance.
     /// </summary>
-    public string? ConnectionString { get; set; }
-
-    /// <summary>
-    /// An optional factory function to create a <see cref="BlobClient"/> instance for leader election.
+    /// <remarks>
+    /// If not provided, a <see cref="BlobServiceClient"/> will be created using the
+    /// <see cref="ConnectionString"/> property. If that is null or empty,
+    /// it will attempt to obtain a <see cref="BlobServiceClient"/> from DI
+    /// (assuming the leader election is created via DI).
     /// <para/>
-    /// If set, this factory will be used to get a <see cref="BlobClient"/> instead of using
-    /// the <see cref="ConnectionString"/> setting.
-    /// <para/>
-    /// If neither <see cref="BlobClientFactory"/> nor <see cref="ConnectionString"/>
-    /// are set, a <see cref="BlobClientService"/> will be resolved from the DI container.
-    /// </summary>
+    /// The returned <see cref="BlobClient"/> should point to the blob specified by the
+    /// <see cref="ContainerName"/> and <see cref="BlobName"/> properties, and should
+    /// be able to perform lease operations on that blob.
+    /// </remarks>
     public Func<
         BlobStorageSettings,
         CancellationToken,
@@ -28,33 +28,51 @@ public class BlobStorageSettings : LeaderElectionSettingsBase
     >? BlobClientFactory { get; set; }
 
     /// <summary>
-    /// The name of the blob container to use for leader election.
-    /// <para/>
-    /// Must be a valid Azure Blob Storage container name.
-    /// Default is "leader-election-lock".
-    /// <para/>
-    /// Ignored when <see cref="BlobClientFactory"/> is set.
+    /// Optional connection string for the Azure Storage account.
     /// </summary>
+    /// <remarks>
+    /// Ignored if <see cref="BlobClientFactory"/> is set.
+    /// </remarks>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// The name of the blob container to use for leader election.
+    /// Default is "leader-election-lock".
+    /// </summary>
+    /// <remarks>
+    /// Will be created if it does not exist and <see cref="CreateContainerIfNotExists"/> is true.
+    /// <para/>
+    /// Must be a valid Azure Blob Storage blob name. See
+    /// https://learn.microsoft.com/en-us/rest/api/storageservices/blob-service-concepts.
+    /// </remarks>
     [Required]
     public string ContainerName { get; set; } = "leader-election";
 
     /// <summary>
     /// The name of the blob to use for leader election.
-    /// <para/>
-    /// Must be a valid Azure Blob Storage blob name.
-    /// Default is "leader-election-lock".
-    /// <para/>
-    /// Ignored when <see cref="BlobClientFactory"/> is set.
     /// </summary>
+    /// <remarks>
+    /// Must be a valid Azure Blob Storage blob name. See
+    /// https://learn.microsoft.com/en-us/rest/api/storageservices/blob-service-concepts.
+    /// <para/>
+    /// This blob will be created if it does not exist. Otherwise the blob will not be modified.
+    /// <para/>
+    /// Minimum required RBAC role is <pre>Storage Blob Data Contributor</pre> on the
+    /// container or blob level.
+    /// <para/>
+    /// Default is "leader-election-lock".
+    /// </remarks>
     [Required]
     public string BlobName { get; set; } = "leader-election-lock";
 
     /// <summary>
     /// The duration of the lease when acquiring leadership.
-    /// <para/>
-    /// Must be between 15 and 60 seconds, or -1 for infinite.
-    /// Default is 30 seconds.
     /// </summary>
+    /// <remarks>
+    /// Must be between 15 and 60 seconds, or -1 for infinite.
+    /// <para/>
+    /// Default is 30 seconds.
+    /// </remarks>
     [CustomValidation(
         typeof(BlobStorageSettingsValidator),
         nameof(BlobStorageSettingsValidator.IsValidLeaseDuration)
@@ -63,10 +81,11 @@ public class BlobStorageSettings : LeaderElectionSettingsBase
 
     /// <summary>
     /// Whether to create the blob container if it does not exist.
-    /// <para/>
-    /// If false, the container must already exist.
     /// Default is true.
     /// </summary>
+    /// <remarks>
+    /// If false, the container must already exist.
+    /// </remarks>
     public bool CreateContainerIfNotExists { get; set; } = true;
 
     /// <summary>
@@ -77,8 +96,8 @@ public class BlobStorageSettings : LeaderElectionSettingsBase
         ArgumentNullException.ThrowIfNull(src);
         ArgumentNullException.ThrowIfNull(dst);
         LeaderElectionSettingsBase.Copy(src, dst);
-        dst.ConnectionString = src.ConnectionString;
         dst.BlobClientFactory = src.BlobClientFactory;
+        dst.ConnectionString = src.ConnectionString;
         dst.ContainerName = src.ContainerName;
         dst.BlobName = src.BlobName;
         dst.LeaseDuration = src.LeaseDuration;

--- a/src/LeaderElection.BlobStorage/LeaderElection.BlobStorage.csproj
+++ b/src/LeaderElection.BlobStorage/LeaderElection.BlobStorage.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Azure.Storage.Blobs" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>

--- a/src/LeaderElection.DistributedCache/DistributedCacheLeaderElection.cs
+++ b/src/LeaderElection.DistributedCache/DistributedCacheLeaderElection.cs
@@ -99,7 +99,7 @@ public partial class DistributedCacheLeaderElection : LeaderElectionBase<Distrib
         }
 
         // We can't perform atomic read-modify-write operations with IDistributedCache,
-        // so we're relying on on the fact that the lock key will not be modified outside
+        // so we're relying on the fact that the lock key will not be modified outside
         // of this algorithm.
         var success = false;
         try
@@ -190,7 +190,7 @@ public partial class DistributedCacheLeaderElection : LeaderElectionBase<Distrib
             }
             else
             {
-                // this is unexpected since we should own the lock, but since we cant
+                // this is unexpected since we should own the lock, but since we can't
                 // verify ownership atomically, it's possible that another instance
                 // has legitimately already taken over the lock.
                 // Log as information and give up our leadership.

--- a/src/LeaderElection.DistributedCache/DistributedCacheLeaderElection.cs
+++ b/src/LeaderElection.DistributedCache/DistributedCacheLeaderElection.cs
@@ -15,18 +15,14 @@ public partial class DistributedCacheLeaderElection : LeaderElectionBase<Distrib
 
     public DistributedCacheLeaderElection(
         DistributedCacheSettings settings,
+        IDistributedCache cache,
         ILogger<DistributedCacheLeaderElection>? logger = null,
         TimeProvider? timeProvider = null
     )
         : base(settings ?? throw new ArgumentNullException(nameof(settings)), logger, timeProvider)
     {
-        _ =
-            settings.CacheFactory
-            ?? throw new ArgumentException("CacheFactory must be provided.", nameof(settings));
-
-        _cache =
-            settings.CacheFactory.Invoke(settings)
-            ?? throw new InvalidOperationException("CacheFactory returned null.");
+        ArgumentNullException.ThrowIfNull(cache);
+        _cache = cache;
     }
 
     protected override async Task<bool> TryAcquireLeadershipInternalAsync(

--- a/src/LeaderElection.DistributedCache/DistributedCacheLeaderElection.cs
+++ b/src/LeaderElection.DistributedCache/DistributedCacheLeaderElection.cs
@@ -153,7 +153,7 @@ public partial class DistributedCacheLeaderElection : LeaderElectionBase<Distrib
             if (!success)
             {
                 // Abandon the lock locally if we failed to renew it for any reason.
-                _lockOwnedUntil = null;
+                await ResetLeadershipAsync().ConfigureAwait(false);
             }
         }
         return success;
@@ -210,8 +210,14 @@ public partial class DistributedCacheLeaderElection : LeaderElectionBase<Distrib
         finally
         {
             // Regardless of whether the release succeeded, we should consider the lock abandoned locally
-            _lockOwnedUntil = null;
+            await ResetLeadershipAsync().ConfigureAwait(false);
         }
+    }
+
+    protected override ValueTask ResetLeadershipAsync()
+    {
+        _lockOwnedUntil = null;
+        return new ValueTask();
     }
 
     private Task<string?> GetOwnershipAsync(CancellationToken cancellationToken) =>

--- a/src/LeaderElection.DistributedCache/DistributedCacheLeaderElection.cs
+++ b/src/LeaderElection.DistributedCache/DistributedCacheLeaderElection.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Caching.Distributed;
-using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace LeaderElection.DistributedCache;
@@ -8,19 +7,18 @@ namespace LeaderElection.DistributedCache;
 public partial class DistributedCacheLeaderElection : LeaderElectionBase<DistributedCacheSettings>
 {
     private readonly IDistributedCache _cache;
-    private readonly ISystemClock _systemClock;
     private DateTimeOffset? _lockOwnedUntil;
 
     [MemberNotNullWhen(true, nameof(_lockOwnedUntil))]
     private bool IsLockOwner =>
-        _lockOwnedUntil.HasValue && _systemClock.UtcNow < _lockOwnedUntil.Value;
+        _lockOwnedUntil.HasValue && _timeProvider.GetUtcNow() < _lockOwnedUntil.Value;
 
     public DistributedCacheLeaderElection(
         DistributedCacheSettings settings,
-        ILogger<DistributedCacheLeaderElection> logger,
-        ISystemClock? systemClock = null
+        ILogger<DistributedCacheLeaderElection>? logger = null,
+        TimeProvider? timeProvider = null
     )
-        : base(settings ?? throw new ArgumentNullException(nameof(settings)), logger)
+        : base(settings ?? throw new ArgumentNullException(nameof(settings)), logger, timeProvider)
     {
         _ =
             settings.CacheFactory
@@ -29,8 +27,6 @@ public partial class DistributedCacheLeaderElection : LeaderElectionBase<Distrib
         _cache =
             settings.CacheFactory.Invoke(settings)
             ?? throw new InvalidOperationException("CacheFactory returned null.");
-
-        _systemClock = systemClock ?? new SystemClock();
     }
 
     protected override async Task<bool> TryAcquireLeadershipInternalAsync(
@@ -187,7 +183,7 @@ public partial class DistributedCacheLeaderElection : LeaderElectionBase<Distrib
                 // This also avoids unnecessary cache operations when we're about to lose the
                 // lock anyway.
                 var quietPeriod = TimeSpan.FromMilliseconds(50);
-                if (_systemClock.UtcNow + quietPeriod < _lockOwnedUntil)
+                if (_timeProvider.GetUtcNow() + quietPeriod < _lockOwnedUntil)
                 {
                     await ReleaseOwnershipAsync().ConfigureAwait(false);
                 }
@@ -245,7 +241,7 @@ public partial class DistributedCacheLeaderElection : LeaderElectionBase<Distrib
 
     private async Task<DateTimeOffset> TakeOwnershipAsync(CancellationToken cancellationToken)
     {
-        var expiresAt = _systemClock.UtcNow + _settings.LockExpiry;
+        var expiresAt = _timeProvider.GetUtcNow() + _settings.LockExpiry;
         await _cache
             .SetStringAsync(
                 _settings.LockKey,

--- a/src/LeaderElection.DistributedCache/DistributedCacheLeaderElection.cs
+++ b/src/LeaderElection.DistributedCache/DistributedCacheLeaderElection.cs
@@ -1,55 +1,97 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace LeaderElection.DistributedCache;
 
 public partial class DistributedCacheLeaderElection : LeaderElectionBase<DistributedCacheSettings>
 {
     private readonly IDistributedCache _cache;
+    private readonly ISystemClock _systemClock;
+    private DateTimeOffset? _lockOwnedUntil;
+
+    [MemberNotNullWhen(true, nameof(_lockOwnedUntil))]
+    private bool IsLockOwner =>
+        _lockOwnedUntil.HasValue && _systemClock.UtcNow < _lockOwnedUntil.Value;
 
     public DistributedCacheLeaderElection(
-        IDistributedCache cache,
-        IOptions<DistributedCacheSettings> options,
-        ILogger<DistributedCacheLeaderElection> logger
+        DistributedCacheSettings settings,
+        ILogger<DistributedCacheLeaderElection> logger,
+        ISystemClock? systemClock = null
     )
-        : base(options?.Value ?? throw new InvalidOperationException(), logger)
+        : base(settings ?? throw new ArgumentNullException(nameof(settings)), logger)
     {
-        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _ =
+            settings.CacheFactory
+            ?? throw new ArgumentException("CacheFactory must be provided.", nameof(settings));
+
+        _cache =
+            settings.CacheFactory.Invoke(settings)
+            ?? throw new InvalidOperationException("CacheFactory returned null.");
+
+        _systemClock = systemClock ?? new SystemClock();
     }
 
     protected override async Task<bool> TryAcquireLeadershipInternalAsync(
         CancellationToken cancellationToken
     )
     {
+        if (IsLockOwner)
+        {
+            LogLockAlreadyAcquired(_settings.LockKey);
+            return true;
+        }
+
         try
         {
-            var currentValue = await _cache
-                .GetStringAsync(_settings.LockKey, cancellationToken)
-                .ConfigureAwait(false);
-            if (!string.IsNullOrEmpty(currentValue))
-                return false;
-
-            await _cache
-                .SetStringAsync(
-                    _settings.LockKey,
-                    _settings.InstanceId,
-                    new DistributedCacheEntryOptions
-                    {
-                        AbsoluteExpirationRelativeToNow = _settings.LockExpiry,
-                    },
+            var (updatedKey, currentOwner, expiresAt) = await TryTakeOwnershipAsync(
                     cancellationToken
                 )
                 .ConfigureAwait(false);
 
-            var verifyValue = await _cache
-                .GetStringAsync(_settings.LockKey, cancellationToken)
-                .ConfigureAwait(false);
-            return verifyValue == _settings.InstanceId;
+            if (!updatedKey && currentOwner == _settings.InstanceId)
+            {
+                // Apparently we already own the lock. Treat this as no-owner.
+                currentOwner = null;
+            }
+
+            if (string.IsNullOrEmpty(currentOwner))
+            {
+                // No owner. Take the lock...
+                expiresAt = await TakeOwnershipAsync(cancellationToken).ConfigureAwait(false);
+                updatedKey = true;
+            }
+
+            if (updatedKey)
+            {
+                // Because we are using a distributed cache with a non-atomic read-modify-write
+                // operation to acquire the lock, there's a possibility that another instance
+                // could have updated the key concurrently. To mitigate this, we'll do a quick
+                // read after setting the lock to verify that we still hold it.
+                currentOwner = await GetOwnershipAsync(cancellationToken).ConfigureAwait(false);
+                updatedKey = currentOwner == _settings.InstanceId;
+            }
+
+            if (updatedKey)
+            {
+                _lockOwnedUntil = expiresAt;
+                LogLockAcquired(_settings.LockKey, _settings.InstanceId);
+                return true;
+            }
+            else
+            {
+                LogFailureAcquiringLock(
+                    LogLevel.Debug,
+                    _settings.LockKey,
+                    "Locked by another instance."
+                );
+                return false;
+            }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            LogErrorAcquiringLeadership(_logger, ex);
+            LogFailureAcquiringLock(LogLevel.Warning, _settings.LockKey, ex.Message);
             return false;
         }
     }
@@ -58,64 +100,193 @@ public partial class DistributedCacheLeaderElection : LeaderElectionBase<Distrib
         CancellationToken cancellationToken
     )
     {
+        if (!IsLockOwner)
+        {
+            LogNoActiveLockToRenew(_settings.LockKey);
+            return false;
+        }
+
+        // We can't perform atomic read-modify-write operations with IDistributedCache,
+        // so we're relying on on the fact that the lock key will not be modified outside
+        // of this algorithm.
+        var success = false;
         try
         {
-            var currentValue = await _cache
-                .GetStringAsync(_settings.LockKey, cancellationToken)
-                .ConfigureAwait(false);
-            if (currentValue != _settings.InstanceId)
-                return false;
-
-            await _cache
-                .SetStringAsync(
-                    _settings.LockKey,
-                    _settings.InstanceId,
-                    new DistributedCacheEntryOptions
-                    {
-                        AbsoluteExpirationRelativeToNow = _settings.LockExpiry,
-                    },
+            var (updatedKey, currentOwner, expiresAt) = await TryTakeOwnershipAsync(
                     cancellationToken
                 )
                 .ConfigureAwait(false);
 
-            return true;
+            if (currentOwner == _settings.InstanceId && !updatedKey)
+            {
+                // We still own the lock, so we can renew it by updating the value with
+                // the same instance ID
+                expiresAt = await TakeOwnershipAsync(cancellationToken).ConfigureAwait(false);
+                updatedKey = true;
+            }
+
+            if (updatedKey)
+            {
+                // Because we are using a distributed cache with a non-atomic read-modify-write
+                // operation to acquire the lock, there's a possibility that another instance
+                // could have updated the key concurrently. To mitigate this, we'll do a quick
+                // read after setting the lock to verify that we still hold it.
+                currentOwner = await GetOwnershipAsync(cancellationToken).ConfigureAwait(false);
+                updatedKey = currentOwner == _settings.InstanceId;
+            }
+
+            if (updatedKey)
+            {
+                success = true;
+                _lockOwnedUntil = expiresAt;
+                LogLockRenewed(_settings.LockKey, _settings.InstanceId);
+            }
+            else
+            {
+                LogFailureRenewingLock(
+                    LogLevel.Warning,
+                    _settings.LockKey,
+                    "Lock lost to another instance."
+                );
+            }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            LogErrorRenewingLeadership(_logger, ex);
-            return false;
+            LogFailureRenewingLock(LogLevel.Warning, _settings.LockKey, ex.Message);
         }
+        finally
+        {
+            if (!success)
+            {
+                // Abandon the lock locally if we failed to renew it for any reason.
+                _lockOwnedUntil = null;
+            }
+        }
+        return success;
     }
 
     protected override async Task ReleaseLeadershipAsync()
     {
+        if (!IsLockOwner)
+        {
+            LogNoActiveLockToRelease(_settings.LockKey);
+            return;
+        }
+
         try
         {
-            var currentValue = await _cache.GetStringAsync(_settings.LockKey).ConfigureAwait(false);
-            if (currentValue == _settings.InstanceId)
+            // Only remove the lock if we still own it...
+            var currentOwner = await GetOwnershipAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+
+            if (currentOwner == _settings.InstanceId)
             {
-                await _cache.RemoveAsync(_settings.LockKey).ConfigureAwait(false);
-                LogLeadershipReleasedForInstanceInstanceId(_logger, _settings.InstanceId);
+                // We can't perform atomic read-modify-write operations on the lock, so if we're
+                // too close to the lock expiry, we'll just abandon it, allowing it to
+                // expire naturally instead of risking a race condition with another instance.
+                // This also avoids unnecessary cache operations when we're about to lose the
+                // lock anyway.
+                var quietPeriod = TimeSpan.FromMilliseconds(50);
+                if (_systemClock.UtcNow + quietPeriod < _lockOwnedUntil)
+                {
+                    await ReleaseOwnershipAsync().ConfigureAwait(false);
+                }
+
+                LogLockReleased(_settings.LockKey, _settings.InstanceId);
+            }
+            else if (string.IsNullOrEmpty(currentOwner))
+            {
+                LogFailureReleasingLock(
+                    LogLevel.Information,
+                    _settings.LockKey,
+                    "Lock already expired."
+                );
+            }
+            else
+            {
+                LogFailureReleasingLock(
+                    LogLevel.Information,
+                    _settings.LockKey,
+                    "Lock lost to another instance."
+                );
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            LogErrorReleasingLeadership(_logger, ex);
+            LogFailureReleasingLock(LogLevel.Warning, _settings.LockKey, ex.Message);
+        }
+        finally
+        {
+            // Regardless of whether the release succeeded, we should consider the lock abandoned locally
+            _lockOwnedUntil = null;
         }
     }
 
-    [LoggerMessage(LogLevel.Error, "Error acquiring leadership")]
-    static partial void LogErrorAcquiringLeadership(ILogger logger, Exception exception);
+    private Task<string?> GetOwnershipAsync(CancellationToken cancellationToken) =>
+        _cache.GetStringAsync(_settings.LockKey, cancellationToken);
 
-    [LoggerMessage(LogLevel.Error, "Error renewing leadership")]
-    static partial void LogErrorRenewingLeadership(ILogger logger, Exception exception);
+    private async Task<(
+        bool updatedKey,
+        string? currentOwner,
+        DateTimeOffset expiresAt
+    )> TryTakeOwnershipAsync(CancellationToken cancellationToken)
+    {
+        var updatedKey = false;
+        var expiresAt = default(DateTimeOffset);
+        var currentOwner = await GetOwnershipAsync(cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrEmpty(currentOwner))
+        {
+            expiresAt = await TakeOwnershipAsync(cancellationToken).ConfigureAwait(false);
+            currentOwner = _settings.InstanceId;
+            updatedKey = true;
+        }
+        return (updatedKey, currentOwner, expiresAt);
+    }
 
-    [LoggerMessage(LogLevel.Information, "Leadership released for instance {instanceId}")]
-    static partial void LogLeadershipReleasedForInstanceInstanceId(
-        ILogger logger,
-        string instanceId
-    );
+    private async Task<DateTimeOffset> TakeOwnershipAsync(CancellationToken cancellationToken)
+    {
+        var expiresAt = _systemClock.UtcNow + _settings.LockExpiry;
+        await _cache
+            .SetStringAsync(
+                _settings.LockKey,
+                _settings.InstanceId,
+                new DistributedCacheEntryOptions
+                {
+                    AbsoluteExpirationRelativeToNow = _settings.LockExpiry,
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+        return expiresAt;
+    }
 
-    [LoggerMessage(LogLevel.Error, "Error releasing leadership")]
-    static partial void LogErrorReleasingLeadership(ILogger logger, Exception exception);
+    private Task ReleaseOwnershipAsync() =>
+        _cache.RemoveAsync(_settings.LockKey, CancellationToken.None);
+
+    [LoggerMessage(LogLevel.Information, "Lock already acquired for key {LockKey}.")]
+    partial void LogLockAlreadyAcquired(string lockKey);
+
+    [LoggerMessage(LogLevel.Debug, "Acquired lock for key {LockKey} by instance {InstanceId}.")]
+    partial void LogLockAcquired(string lockKey, string instanceId);
+
+    [LoggerMessage("Failure acquiring lock for key {LockKey}: {Reason}")]
+    partial void LogFailureAcquiringLock(LogLevel logLevel, string lockKey, string reason);
+
+    [LoggerMessage(LogLevel.Information, "No active lock to renew for key {LockKey}.")]
+    partial void LogNoActiveLockToRenew(string lockKey);
+
+    [LoggerMessage(LogLevel.Debug, "Lock renewed for key {LockKey} by instance {InstanceId}.")]
+    partial void LogLockRenewed(string lockKey, string instanceId);
+
+    [LoggerMessage("Failure renewing lock for key {LockKey}: {Reason}")]
+    partial void LogFailureRenewingLock(LogLevel logLevel, string lockKey, string reason);
+
+    [LoggerMessage(LogLevel.Information, "No active lock to release for key {LockKey}.")]
+    partial void LogNoActiveLockToRelease(string lockKey);
+
+    [LoggerMessage(LogLevel.Debug, "Lock released for key {LockKey} by instance {InstanceId}.")]
+    partial void LogLockReleased(string lockKey, string instanceId);
+
+    [LoggerMessage("Failure releasing lock for key {LockKey}: {Reason}")]
+    partial void LogFailureReleasingLock(LogLevel logLevel, string lockKey, string reason);
 }

--- a/src/LeaderElection.DistributedCache/DistributedCacheLeaderElection.cs
+++ b/src/LeaderElection.DistributedCache/DistributedCacheLeaderElection.cs
@@ -135,6 +135,8 @@ public partial class DistributedCacheLeaderElection : LeaderElectionBase<Distrib
             }
             else
             {
+                // this is unexpected since we should have the lease.
+                // Log as a warning and give up our leadership.
                 LogFailureRenewingLock(
                     LogLevel.Warning,
                     _settings.LockKey,
@@ -144,7 +146,7 @@ public partial class DistributedCacheLeaderElection : LeaderElectionBase<Distrib
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            LogFailureRenewingLock(LogLevel.Warning, _settings.LockKey, ex.Message);
+            LogFailureRenewingLock(LogLevel.Error, _settings.LockKey, ex.Message);
         }
         finally
         {
@@ -186,26 +188,24 @@ public partial class DistributedCacheLeaderElection : LeaderElectionBase<Distrib
 
                 LogLockReleased(_settings.LockKey);
             }
-            else if (string.IsNullOrEmpty(currentOwner))
-            {
-                LogFailureReleasingLock(
-                    LogLevel.Information,
-                    _settings.LockKey,
-                    "Lock already expired."
-                );
-            }
             else
             {
+                // this is unexpected since we should own the lock, but since we cant
+                // verify ownership atomically, it's possible that another instance
+                // has legitimately already taken over the lock.
+                // Log as information and give up our leadership.
                 LogFailureReleasingLock(
                     LogLevel.Information,
                     _settings.LockKey,
-                    "Lock lost to another instance."
+                    string.IsNullOrEmpty(currentOwner)
+                        ? "Lock already expired."
+                        : "Lock lost to another instance."
                 );
             }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            LogFailureReleasingLock(LogLevel.Warning, _settings.LockKey, ex.Message);
+            LogFailureReleasingLock(LogLevel.Error, _settings.LockKey, ex.Message);
         }
         finally
         {

--- a/src/LeaderElection.DistributedCache/DistributedCacheLeaderElection.cs
+++ b/src/LeaderElection.DistributedCache/DistributedCacheLeaderElection.cs
@@ -68,7 +68,7 @@ public partial class DistributedCacheLeaderElection : LeaderElectionBase<Distrib
             if (updatedKey)
             {
                 _lockOwnedUntil = expiresAt;
-                LogLockAcquired(_settings.LockKey, _settings.InstanceId);
+                LogLockAcquired(_settings.LockKey);
                 return true;
             }
             else
@@ -131,7 +131,7 @@ public partial class DistributedCacheLeaderElection : LeaderElectionBase<Distrib
             {
                 success = true;
                 _lockOwnedUntil = expiresAt;
-                LogLockRenewed(_settings.LockKey, _settings.InstanceId);
+                LogLockRenewed(_settings.LockKey);
             }
             else
             {
@@ -184,7 +184,7 @@ public partial class DistributedCacheLeaderElection : LeaderElectionBase<Distrib
                     await ReleaseOwnershipAsync().ConfigureAwait(false);
                 }
 
-                LogLockReleased(_settings.LockKey, _settings.InstanceId);
+                LogLockReleased(_settings.LockKey);
             }
             else if (string.IsNullOrEmpty(currentOwner))
             {
@@ -258,8 +258,8 @@ public partial class DistributedCacheLeaderElection : LeaderElectionBase<Distrib
     [LoggerMessage(LogLevel.Information, "Lock already acquired for key {LockKey}.")]
     partial void LogLockAlreadyAcquired(string lockKey);
 
-    [LoggerMessage(LogLevel.Debug, "Acquired lock for key {LockKey} by instance {InstanceId}.")]
-    partial void LogLockAcquired(string lockKey, string instanceId);
+    [LoggerMessage(LogLevel.Debug, "Acquired lock for key {LockKey}.")]
+    partial void LogLockAcquired(string lockKey);
 
     [LoggerMessage("Failure acquiring lock for key {LockKey}: {Reason}")]
     partial void LogFailureAcquiringLock(LogLevel logLevel, string lockKey, string reason);
@@ -267,8 +267,8 @@ public partial class DistributedCacheLeaderElection : LeaderElectionBase<Distrib
     [LoggerMessage(LogLevel.Information, "No active lock to renew for key {LockKey}.")]
     partial void LogNoActiveLockToRenew(string lockKey);
 
-    [LoggerMessage(LogLevel.Debug, "Lock renewed for key {LockKey} by instance {InstanceId}.")]
-    partial void LogLockRenewed(string lockKey, string instanceId);
+    [LoggerMessage(LogLevel.Debug, "Lock renewed for key {LockKey}.")]
+    partial void LogLockRenewed(string lockKey);
 
     [LoggerMessage("Failure renewing lock for key {LockKey}: {Reason}")]
     partial void LogFailureRenewingLock(LogLevel logLevel, string lockKey, string reason);
@@ -276,8 +276,8 @@ public partial class DistributedCacheLeaderElection : LeaderElectionBase<Distrib
     [LoggerMessage(LogLevel.Information, "No active lock to release for key {LockKey}.")]
     partial void LogNoActiveLockToRelease(string lockKey);
 
-    [LoggerMessage(LogLevel.Debug, "Lock released for key {LockKey} by instance {InstanceId}.")]
-    partial void LogLockReleased(string lockKey, string instanceId);
+    [LoggerMessage(LogLevel.Debug, "Lock released for key {LockKey}.")]
+    partial void LogLockReleased(string lockKey);
 
     [LoggerMessage("Failure releasing lock for key {LockKey}: {Reason}")]
     partial void LogFailureReleasingLock(LogLevel logLevel, string lockKey, string reason);

--- a/src/LeaderElection.DistributedCache/DistributedCacheServiceBuilderExtensions.cs
+++ b/src/LeaderElection.DistributedCache/DistributedCacheServiceBuilderExtensions.cs
@@ -146,6 +146,23 @@ public static class DistributedCacheServiceBuilderExtensions
     }
 
     /// <summary>
+    /// Specifies the default <see cref="DistributedCacheSettings"/> used by
+    /// the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithSettings(
+        this ServiceBuilder builder,
+        DistributedCacheSettings settings
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(settings);
+        builder.OptionsBuilder.Configure(options =>
+            DistributedCacheSettings.Copy(settings, options)
+        );
+        return builder;
+    }
+
+    /// <summary>
     /// Configures the leader election settings using a configuration action.
     /// </summary>
     public static ServiceBuilder WithSettings(

--- a/src/LeaderElection.DistributedCache/DistributedCacheServiceBuilderExtensions.cs
+++ b/src/LeaderElection.DistributedCache/DistributedCacheServiceBuilderExtensions.cs
@@ -66,14 +66,27 @@ public static class DistributedCacheServiceBuilderExtensions
             serviceKey,
             static (sp, key) =>
             {
-                // get keyed options
-                var options = sp.GetRequiredService<IOptionsMonitor<DistributedCacheSettings>>()
+                // get settings
+                var settings = sp.GetRequiredService<IOptionsMonitor<DistributedCacheSettings>>()
                     .Get(key as string);
+
+                // Note: We must resolve the cache here. If we don't do it now
+                // and the factory resolves it from DI, then the cache (or its dependencies)
+                // may be disposed before the LeaderElection resulting in a crash.
+                var cache =
+                    (
+                        settings.CacheFactory
+                        ?? throw new InvalidOperationException(
+                            "CacheFactory must be specified in settings."
+                        )
+                    ).Invoke(settings)
+                    ?? throw new InvalidOperationException("CacheFactory returned null.");
 
                 // create instance
                 return ActivatorUtilities.CreateInstance<DistributedCacheLeaderElection>(
                     sp,
-                    options
+                    settings,
+                    cache
                 );
             }
         );

--- a/src/LeaderElection.DistributedCache/DistributedCacheServiceBuilderExtensions.cs
+++ b/src/LeaderElection.DistributedCache/DistributedCacheServiceBuilderExtensions.cs
@@ -1,47 +1,196 @@
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace LeaderElection.DistributedCache;
 
+public sealed record ServiceBuilder(
+    string? ServiceKey,
+    OptionsBuilder<DistributedCacheSettings> OptionsBuilder
+);
+
 public static class DistributedCacheServiceBuilderExtensions
 {
+    /// <inheritdoc cref="AddDistributedCacheLeaderElectionInternal"/>
+    /// <param name="configureOptions">Action to configure the DistributedCacheSettings</param>
+    public static IServiceCollection AddDistributedCacheLeaderElection(
+        this IServiceCollection services,
+        Action<DistributedCacheSettings> configureOptions
+    ) =>
+        AddDistributedCacheLeaderElectionInternal(
+            services,
+            builder => builder.WithSettings(configureOptions)
+        );
+
+    /// <inheritdoc cref="AddDistributedCacheLeaderElectionInternal"/>
+    /// <param name="options">DistributedCacheSettings instance to use for configuration</param>
+    public static IServiceCollection AddDistributedCacheLeaderElection(
+        this IServiceCollection services,
+        DistributedCacheSettings options
+    ) =>
+        AddDistributedCacheLeaderElectionInternal(
+            services,
+            builder => builder.WithSettings(opts => DistributedCacheSettings.Copy(options, opts))
+        );
+
+    /// <inheritdoc cref="AddDistributedCacheLeaderElectionInternal"/>
+    public static IServiceCollection AddDistributedCacheLeaderElection(
+        this IServiceCollection services,
+        Action<ServiceBuilder> builder,
+        string? serviceKey = null
+    ) => AddDistributedCacheLeaderElectionInternal(services, builder, serviceKey);
+
     /// <summary>
     /// Adds DistributedCache leader election services to the service collection
     /// </summary>
     /// <param name="services">The service collection</param>
-    /// <param name="configureOptions">Action to configure the options</param>
+    /// <param name="builder">Action to configure the service builder</param>
+    /// <param name="serviceKey">Optional service key for keyed services</param>
     /// <returns>The service collection for chaining</returns>
-    public static IServiceCollection AddDistributedCacheLeaderElection(
+    private static IServiceCollection AddDistributedCacheLeaderElectionInternal(
         this IServiceCollection services,
+        Action<ServiceBuilder> builder,
+        string? serviceKey = null
+    )
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(builder);
+
+        var configBuilder = services.AddOptionsWithValidateOnStart<
+            DistributedCacheSettings,
+            DistributedCacheSettingsValidator
+        >(serviceKey);
+
+        services.AddKeyedSingleton<ILeaderElection>(
+            serviceKey,
+            static (sp, key) =>
+            {
+                // get keyed options
+                var options = sp.GetRequiredService<IOptionsMonitor<DistributedCacheSettings>>()
+                    .Get(key as string);
+
+                // create instance
+                return ActivatorUtilities.CreateInstance<DistributedCacheLeaderElection>(
+                    sp,
+                    options
+                );
+            }
+        );
+
+        builder.Invoke(new ServiceBuilder(serviceKey, configBuilder));
+
+        // Ensure CacheFactory is set after all configurations
+        configBuilder.PostConfigure<IServiceProvider>(
+            (opts, sp) => opts.CacheFactory ??= _ => GetRegisteredCache(serviceKey, sp)
+        );
+
+        return services;
+    }
+
+    /// <summary>
+    /// Specifies the instance ID to use for the Leader Election.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="instanceId"></param>
+    /// <returns></returns>
+    public static ServiceBuilder WithInstanceId(this ServiceBuilder builder, string instanceId)
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(instanceId);
+        return builder.WithSettings(options => options.InstanceId = instanceId);
+    }
+
+    /// <summary>
+    /// Configures the leader election settings using a configuration section from the
+    /// application's configuration.
+    /// </summary>
+    public static ServiceBuilder WithConfiguration(
+        this ServiceBuilder builder,
+        string configurationSectionName
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configurationSectionName);
+        builder.OptionsBuilder.Configure<IConfiguration>(
+            (opts, config) => config.GetSection(configurationSectionName).Bind(opts)
+        );
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the leader election settings using a configuration section from the
+    /// application's configuration.
+    /// </summary>
+    public static ServiceBuilder WithConfiguration(
+        this ServiceBuilder builder,
+        IConfiguration configurationSection
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configurationSection);
+        builder.OptionsBuilder.Configure(configurationSection.Bind);
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the leader election settings using a configuration action.
+    /// </summary>
+    public static ServiceBuilder WithSettings(
+        this ServiceBuilder builder,
         Action<DistributedCacheSettings> configureOptions
     )
     {
-        services
-            .AddOptionsWithValidateOnStart<
-                DistributedCacheSettings,
-                DistributedCacheSettingsValidator
-            >()
-            .Configure(configureOptions);
-
-        services.AddSingleton<ILeaderElection, DistributedCacheLeaderElection>();
-        return services;
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+        builder.OptionsBuilder.Configure(configureOptions);
+        return builder;
     }
 
-    public static IServiceCollection AddDistributedCacheLeaderElection(
-        this IServiceCollection services,
-        DistributedCacheSettings options
+    /// <summary>
+    /// Configures the leader election to use a registered IDistributedCache instance
+    /// from the service provider.
+    /// </summary>
+    public static ServiceBuilder WithRegisteredCache(this ServiceBuilder builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        return builder.WithSettings(
+            (opts, sp, key) => opts.CacheFactory = _ => GetRegisteredCache(key, sp)
+        );
+    }
+
+    /// <summary>
+    /// Configures the leader election to use the specified IDistributedCache instance.
+    /// </summary>
+    public static ServiceBuilder WithCache(this ServiceBuilder builder, IDistributedCache cache)
+    {
+        ArgumentNullException.ThrowIfNull(cache);
+        return builder.WithSettings(opts => opts.CacheFactory = _ => cache);
+    }
+
+    /// <summary>
+    /// Configures the leader election settings using a configuration action which receives
+    /// the service provider and the optional service key.
+    /// </summary>
+    /// <remarks>
+    /// This is the most flexible configuration method, allowing for complex scenarios such as:
+    /// - Resolving different cache instances based on the service key
+    /// - Accessing other services from the service provider to configure the settings
+    /// - Dynamically determining configuration values at runtime
+    /// </remarks>
+    public static ServiceBuilder WithSettings(
+        this ServiceBuilder builder,
+        Action<DistributedCacheSettings, IServiceProvider, string?> configAction
     )
     {
-        services.AddDistributedCacheLeaderElection(opt =>
-        {
-            opt.InstanceId = options.InstanceId;
-            opt.LockExpiry = options.LockExpiry;
-            opt.LockKey = options.LockKey;
-            opt.EnableGracefulShutdown = options.EnableGracefulShutdown;
-            opt.RenewInterval = options.RenewInterval;
-            opt.RetryInterval = options.RetryInterval;
-            opt.MaxRetryAttempts = options.MaxRetryAttempts;
-        });
-
-        return services;
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configAction);
+        builder.OptionsBuilder.Configure<IServiceProvider>(
+            (opts, sp) => configAction(opts, sp, builder.ServiceKey)
+        );
+        return builder;
     }
+
+    private static IDistributedCache GetRegisteredCache(object? serviceKey, IServiceProvider sp) =>
+        sp.GetKeyedService<IDistributedCache>(serviceKey)
+        ?? sp.GetRequiredService<IDistributedCache>();
 }

--- a/src/LeaderElection.DistributedCache/DistributedCacheServiceBuilderExtensions.cs
+++ b/src/LeaderElection.DistributedCache/DistributedCacheServiceBuilderExtensions.cs
@@ -95,7 +95,7 @@ public static class DistributedCacheServiceBuilderExtensions
 
         // Ensure CacheFactory is set after all configurations
         configBuilder.PostConfigure<IServiceProvider>(
-            (opts, sp) => opts.CacheFactory ??= _ => GetRegisteredCache(serviceKey, sp)
+            (opts, sp) => opts.CacheFactory ??= _ => GetRegisteredCache(sp, serviceKey)
         );
 
         return services;
@@ -184,7 +184,7 @@ public static class DistributedCacheServiceBuilderExtensions
     {
         ArgumentNullException.ThrowIfNull(builder);
         return builder.WithSettings(
-            (opts, sp, key) => opts.CacheFactory = _ => GetRegisteredCache(key, sp)
+            (opts, sp, key) => opts.CacheFactory = _ => GetRegisteredCache(sp, key)
         );
     }
 
@@ -220,7 +220,7 @@ public static class DistributedCacheServiceBuilderExtensions
         return builder;
     }
 
-    private static IDistributedCache GetRegisteredCache(object? serviceKey, IServiceProvider sp) =>
-        sp.GetKeyedService<IDistributedCache>(serviceKey)
+    private static IDistributedCache GetRegisteredCache(IServiceProvider sp, object? serviceKey) =>
+        (serviceKey != null ? sp.GetKeyedService<IDistributedCache>(serviceKey) : null)
         ?? sp.GetRequiredService<IDistributedCache>();
 }

--- a/src/LeaderElection.DistributedCache/DistributedCacheSettings.cs
+++ b/src/LeaderElection.DistributedCache/DistributedCacheSettings.cs
@@ -1,9 +1,17 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.Extensions.Caching.Distributed;
 
 namespace LeaderElection.DistributedCache;
 
 public class DistributedCacheSettings : LeaderElectionSettingsBase
 {
+    /// <summary>
+    /// Factory function to create an instance of IDistributedCache. This allows for
+    /// custom cache implementations or retrieval logic. If not set, the default
+    /// IDistributedCache registered in the service provider will be used.
+    /// </summary>
+    public Func<DistributedCacheSettings, IDistributedCache>? CacheFactory { get; set; }
+
     /// <summary>
     /// The key used to acquire the lock in the distributed cache.
     /// This should be unique to avoid conflicts with other applications
@@ -26,4 +34,17 @@ public class DistributedCacheSettings : LeaderElectionSettingsBase
         nameof(DistributedCacheSettingsValidator.ValidateLockExpiry)
     )]
     public TimeSpan LockExpiry { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Copies the DistributedCache settings from the source to the destination.
+    /// </summary>
+    public static void Copy(DistributedCacheSettings src, DistributedCacheSettings dst)
+    {
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(dst);
+        LeaderElectionSettingsBase.Copy(src, dst);
+        dst.LockKey = src.LockKey;
+        dst.LockExpiry = src.LockExpiry;
+        dst.CacheFactory = src.CacheFactory;
+    }
 }

--- a/src/LeaderElection.DistributedCache/DistributedCacheSettings.cs
+++ b/src/LeaderElection.DistributedCache/DistributedCacheSettings.cs
@@ -3,32 +3,39 @@ using Microsoft.Extensions.Caching.Distributed;
 
 namespace LeaderElection.DistributedCache;
 
+/// <summary>
+/// Settings for distributed cache-based leader election.
+/// </summary>
 public class DistributedCacheSettings : LeaderElectionSettingsBase
 {
     /// <summary>
-    /// Factory function to create an instance of IDistributedCache. This allows for
-    /// custom cache implementations or retrieval logic. If not set, the default
-    /// IDistributedCache registered in the service provider will be used.
+    /// An optional factory function used to obtain an <see cref="IDistributedCache"/>.
     /// </summary>
+    /// <remarks>
+    /// If not provided, it will attempt to obtain an <see cref="IDistributedCache"/> from DI
+    /// (assuming the leader election is created via DI).
+    /// </remarks>
     public Func<DistributedCacheSettings, IDistributedCache>? CacheFactory { get; set; }
 
     /// <summary>
-    /// The key used to acquire the lock in the distributed cache.
-    /// This should be unique to avoid conflicts with other applications
-    /// using the same cache.
-    /// <para/>
+    /// The key used for acquiring the leader lock.
     /// Default is "leader-election-lock".
     /// </summary>
+    /// <remarks>
+    /// This should be unique to avoid conflicts with other applications using the same cache.
+    /// </remarks>
     [Required]
     public string LockKey { get; set; } = "leader-election-lock";
 
     /// <summary>
-    /// The duration for which the lock will be held in the distributed cache.
-    /// If the lock is not renewed within this time, it will expire and another
-    /// instance can acquire it.
-    /// <para/>
+    /// The duration for which the leader lock will be held before it expires.
     /// Default is 30 seconds.
     /// </summary>
+    /// <remarks>
+    /// This should be set to a value that is long enough to allow the leader to
+    /// perform its duties, but short enough to allow for quick failover in case
+    /// the leader goes down.
+    /// </remarks>
     [CustomValidation(
         typeof(DistributedCacheSettingsValidator),
         nameof(DistributedCacheSettingsValidator.ValidateLockExpiry)
@@ -43,8 +50,8 @@ public class DistributedCacheSettings : LeaderElectionSettingsBase
         ArgumentNullException.ThrowIfNull(src);
         ArgumentNullException.ThrowIfNull(dst);
         LeaderElectionSettingsBase.Copy(src, dst);
+        dst.CacheFactory = src.CacheFactory;
         dst.LockKey = src.LockKey;
         dst.LockExpiry = src.LockExpiry;
-        dst.CacheFactory = src.CacheFactory;
     }
 }

--- a/src/LeaderElection.DistributedCache/LeaderElection.DistributedCache.csproj
+++ b/src/LeaderElection.DistributedCache/LeaderElection.DistributedCache.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>

--- a/src/LeaderElection.FusionCache/FusionCacheLeaderElection.cs
+++ b/src/LeaderElection.FusionCache/FusionCacheLeaderElection.cs
@@ -72,7 +72,7 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
             if (updatedKey)
             {
                 _lockOwnedUntil = expiresAt;
-                LogLockAcquired(_settings.LockKey, _settings.InstanceId);
+                LogLockAcquired(_settings.LockKey);
                 return true;
             }
             else
@@ -139,7 +139,7 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
             {
                 success = true;
                 _lockOwnedUntil = expiresAt;
-                LogLockRenewed(_settings.LockKey, _settings.InstanceId);
+                LogLockRenewed(_settings.LockKey);
             }
             else
             {
@@ -193,7 +193,7 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
                     await ReleaseOwnershipAsync(entryOptions).ConfigureAwait(false);
                 }
 
-                LogLockReleased(_settings.LockKey, _settings.InstanceId);
+                LogLockReleased(_settings.LockKey);
             }
             else if (string.IsNullOrEmpty(currentOwner))
             {
@@ -293,8 +293,8 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
     [LoggerMessage(LogLevel.Information, "Lock already acquired for key {LockKey}.")]
     partial void LogLockAlreadyAcquired(string lockKey);
 
-    [LoggerMessage(LogLevel.Debug, "Acquired lock for key {LockKey} by instance {InstanceId}.")]
-    partial void LogLockAcquired(string lockKey, string instanceId);
+    [LoggerMessage(LogLevel.Debug, "Acquired lock for key {LockKey}.")]
+    partial void LogLockAcquired(string lockKey);
 
     [LoggerMessage("Failure acquiring lock for key {LockKey}: {Reason}")]
     partial void LogFailureAcquiringLock(LogLevel logLevel, string lockKey, string reason);
@@ -302,8 +302,8 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
     [LoggerMessage(LogLevel.Information, "No active lock to renew for key {LockKey}.")]
     partial void LogNoActiveLockToRenew(string lockKey);
 
-    [LoggerMessage(LogLevel.Debug, "Lock renewed for key {LockKey} by instance {InstanceId}.")]
-    partial void LogLockRenewed(string lockKey, string instanceId);
+    [LoggerMessage(LogLevel.Debug, "Lock renewed for key {LockKey}.")]
+    partial void LogLockRenewed(string lockKey);
 
     [LoggerMessage("Failure renewing lock for key {LockKey}: {Reason}")]
     partial void LogFailureRenewingLock(LogLevel logLevel, string lockKey, string reason);
@@ -311,8 +311,8 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
     [LoggerMessage(LogLevel.Information, "No active lock to release for key {LockKey}.")]
     partial void LogNoActiveLockToRelease(string lockKey);
 
-    [LoggerMessage(LogLevel.Debug, "Lock released for key {LockKey} by instance {InstanceId}.")]
-    partial void LogLockReleased(string lockKey, string instanceId);
+    [LoggerMessage(LogLevel.Debug, "Lock released for key {LockKey}.")]
+    partial void LogLockReleased(string lockKey);
 
     [LoggerMessage("Failure releasing lock for key {LockKey}: {Reason}")]
     partial void LogFailureReleasingLock(LogLevel logLevel, string lockKey, string reason);

--- a/src/LeaderElection.FusionCache/FusionCacheLeaderElection.cs
+++ b/src/LeaderElection.FusionCache/FusionCacheLeaderElection.cs
@@ -143,6 +143,8 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
             }
             else
             {
+                // this is unexpected since we should own the lock.
+                // Log as a warning and give up our leadership.
                 LogFailureRenewingLock(
                     LogLevel.Warning,
                     _settings.LockKey,
@@ -152,7 +154,7 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            LogFailureRenewingLock(LogLevel.Warning, _settings.LockKey, ex.Message);
+            LogFailureRenewingLock(LogLevel.Error, _settings.LockKey, ex.Message);
         }
         finally
         {
@@ -195,26 +197,24 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
 
                 LogLockReleased(_settings.LockKey);
             }
-            else if (string.IsNullOrEmpty(currentOwner))
-            {
-                LogFailureReleasingLock(
-                    LogLevel.Information,
-                    _settings.LockKey,
-                    "Lock already expired."
-                );
-            }
             else
             {
+                // this is unexpected since we should own the lock, but since we cant
+                // verify ownership atomically, it's possible that another instance
+                // has legitimately already taken over the lock.
+                // Log as information and give up our leadership.
                 LogFailureReleasingLock(
                     LogLevel.Information,
                     _settings.LockKey,
-                    "Lock lost to another instance."
+                    string.IsNullOrEmpty(currentOwner)
+                        ? "Lock already expired."
+                        : "Lock lost to another instance."
                 );
             }
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            LogFailureReleasingLock(LogLevel.Warning, _settings.LockKey, ex.Message);
+            LogFailureReleasingLock(LogLevel.Error, _settings.LockKey, ex.Message);
         }
         finally
         {

--- a/src/LeaderElection.FusionCache/FusionCacheLeaderElection.cs
+++ b/src/LeaderElection.FusionCache/FusionCacheLeaderElection.cs
@@ -15,18 +15,14 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
 
     public FusionCacheLeaderElection(
         FusionCacheSettings settings,
+        IFusionCache cache,
         ILogger<FusionCacheLeaderElection>? logger = null,
         TimeProvider? timeProvider = null
     )
         : base(settings ?? throw new ArgumentNullException(nameof(settings)), logger, timeProvider)
     {
-        _ =
-            settings.CacheFactory
-            ?? throw new ArgumentException("CacheFactory must be provided.", nameof(settings));
-
-        _cache =
-            settings.CacheFactory.Invoke(settings)
-            ?? throw new InvalidOperationException("CacheFactory returned null.");
+        ArgumentNullException.ThrowIfNull(cache);
+        _cache = cache;
     }
 
     protected override async Task<bool> TryAcquireLeadershipInternalAsync(

--- a/src/LeaderElection.FusionCache/FusionCacheLeaderElection.cs
+++ b/src/LeaderElection.FusionCache/FusionCacheLeaderElection.cs
@@ -161,7 +161,7 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
             if (!success)
             {
                 // Abandon the lock locally if we failed to renew it for any reason.
-                _lockOwnedUntil = null;
+                await ResetLeadershipAsync().ConfigureAwait(false);
             }
         }
         return success;
@@ -219,7 +219,7 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
         finally
         {
             // Regardless of whether the release succeeded, we should consider the lock abandoned locally
-            _lockOwnedUntil = null;
+            await ResetLeadershipAsync().ConfigureAwait(false);
         }
     }
 
@@ -236,6 +236,12 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
             .SetSkipMemoryCacheWrite(useDistributedOnly);
 
         return options;
+    }
+
+    protected override ValueTask ResetLeadershipAsync()
+    {
+        _lockOwnedUntil = null;
+        return new ValueTask();
     }
 
     private ValueTask<string?> GetOwnershipAsync(

--- a/src/LeaderElection.FusionCache/FusionCacheLeaderElection.cs
+++ b/src/LeaderElection.FusionCache/FusionCacheLeaderElection.cs
@@ -103,8 +103,9 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
         }
 
         // We can't perform atomic read-modify-write operations with FusionCache,
-        // so we're relying on the fact that well-behaved ElectionLeaders will not
-        // expiry time.
+        // so renewal relies on the invariant that well-behaved ElectionLeaders
+        // will not modify the lock value (owner instance ID) or expiry time while
+        // another instance still owns the lock and is renewing it
         var success = false;
         try
         {
@@ -199,7 +200,7 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
             }
             else
             {
-                // this is unexpected since we should own the lock, but since we cant
+                // this is unexpected since we should own the lock, but since we can't
                 // verify ownership atomically, it's possible that another instance
                 // has legitimately already taken over the lock.
                 // Log as information and give up our leadership.

--- a/src/LeaderElection.FusionCache/FusionCacheLeaderElection.cs
+++ b/src/LeaderElection.FusionCache/FusionCacheLeaderElection.cs
@@ -1,5 +1,6 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using ZiggyCreatures.Caching.Fusion;
 
 namespace LeaderElection.FusionCache;
@@ -7,68 +8,94 @@ namespace LeaderElection.FusionCache;
 public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheSettings>
 {
     private readonly IFusionCache _cache;
+    private readonly ISystemClock _systemClock;
+    private DateTimeOffset? _lockOwnedUntil;
+
+    [MemberNotNullWhen(true, nameof(_lockOwnedUntil))]
+    private bool IsLockOwner =>
+        _lockOwnedUntil.HasValue && _systemClock.UtcNow < _lockOwnedUntil.Value;
 
     public FusionCacheLeaderElection(
-        IFusionCache cache,
-        IOptions<FusionCacheSettings> options,
-        ILogger<FusionCacheLeaderElection> logger
+        FusionCacheSettings settings,
+        ILogger<FusionCacheLeaderElection> logger,
+        ISystemClock? systemClock = null
     )
-        : base(options?.Value ?? throw new ArgumentNullException(nameof(options)), logger)
+        : base(settings ?? throw new ArgumentNullException(nameof(settings)), logger)
     {
-        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
-    }
+        _ =
+            settings.CacheFactory
+            ?? throw new ArgumentException("CacheFactory must be provided.", nameof(settings));
 
-    private FusionCacheEntryOptions CreateLockEntryOptions()
-    {
-        // If a distributed cache is configured, we should ignore memory cache reads/writes
-        // to always observe the actual shared lock state and promptly detect leadership loss.
-        var useDistributedOnly = _cache.HasDistributedCache;
+        _cache =
+            settings.CacheFactory.Invoke(settings)
+            ?? throw new InvalidOperationException("CacheFactory returned null.");
 
-        var options = new FusionCacheEntryOptions(_settings.LockExpiry)
-            .SetFailSafe(false)
-            .SetAllowStaleOnReadOnly(false)
-            .SetSkipMemoryCacheRead(useDistributedOnly)
-            .SetSkipMemoryCacheWrite(useDistributedOnly);
-
-        return options;
+        _systemClock = systemClock ?? new SystemClock();
     }
 
     protected override async Task<bool> TryAcquireLeadershipInternalAsync(
         CancellationToken cancellationToken
     )
     {
+        if (IsLockOwner)
+        {
+            LogLockAlreadyAcquired(_settings.LockKey);
+            return true;
+        }
+
         try
         {
             var entryOptions = CreateLockEntryOptions();
-
-            var currentValue = await _cache
-                .GetOrDefaultAsync<string?>(
-                    _settings.LockKey,
-                    null,
+            var (updatedKey, currentOwner, expiresAt) = await TryTakeOwnershipAsync(
                     entryOptions,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
-            if (!string.IsNullOrEmpty(currentValue))
+
+            if (!updatedKey && currentOwner == _settings.InstanceId)
+            {
+                // Apparently we already own the lock. Treat this as no-owner.
+                currentOwner = null;
+            }
+
+            if (string.IsNullOrEmpty(currentOwner))
+            {
+                // No owner. Take the lock...
+                expiresAt = await TakeOwnershipAsync(entryOptions, cancellationToken)
+                    .ConfigureAwait(false);
+                updatedKey = true;
+            }
+
+            if (updatedKey)
+            {
+                // Because we are using a distributed cache with a non-atomic read-modify-write
+                // operation to acquire the lock, there's a possibility that another instance
+                // could have updated the key concurrently. To mitigate this, we'll do a quick
+                // read after setting the lock to verify that we still hold it.
+                currentOwner = await GetOwnershipAsync(entryOptions, cancellationToken)
+                    .ConfigureAwait(false);
+                updatedKey = currentOwner == _settings.InstanceId;
+            }
+
+            if (updatedKey)
+            {
+                _lockOwnedUntil = expiresAt;
+                LogLockAcquired(_settings.LockKey, _settings.InstanceId);
+                return true;
+            }
+            else
+            {
+                LogFailureAcquiringLock(
+                    LogLevel.Debug,
+                    _settings.LockKey,
+                    "Locked by another instance."
+                );
                 return false;
-
-            await _cache
-                .SetAsync(_settings.LockKey, _settings.InstanceId, entryOptions, cancellationToken)
-                .ConfigureAwait(false);
-
-            var verifyValue = await _cache
-                .GetOrDefaultAsync<string?>(
-                    _settings.LockKey,
-                    null,
-                    entryOptions,
-                    cancellationToken
-                )
-                .ConfigureAwait(false);
-            return verifyValue == _settings.InstanceId;
+            }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            LogErrorAcquiringLeadership(_logger, ex);
+            LogFailureAcquiringLock(LogLevel.Warning, _settings.LockKey, ex.Message);
             return false;
         }
     }
@@ -77,74 +104,224 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
         CancellationToken cancellationToken
     )
     {
+        if (!IsLockOwner)
+        {
+            LogNoActiveLockToRenew(_settings.LockKey);
+            return false;
+        }
+
+        // We can't perform atomic read-modify-write operations with FusionCache,
+        // so we're relying on the fact that well-behaved ElectionLeaders will not
+        // expiry time.
+        var success = false;
         try
         {
             var entryOptions = CreateLockEntryOptions();
-
-            var currentValue = await _cache
-                .GetOrDefaultAsync<string?>(
-                    _settings.LockKey,
-                    null,
+            var (updatedKey, currentOwner, expiresAt) = await TryTakeOwnershipAsync(
                     entryOptions,
                     cancellationToken
                 )
                 .ConfigureAwait(false);
-            if (currentValue != _settings.InstanceId)
-                return false;
 
-            await _cache
-                .SetAsync(_settings.LockKey, _settings.InstanceId, entryOptions, cancellationToken)
-                .ConfigureAwait(false);
+            if (currentOwner == _settings.InstanceId && !updatedKey)
+            {
+                // We still own the lock, so we can renew it by updating the value with
+                // the same instance ID
+                expiresAt = await TakeOwnershipAsync(entryOptions, cancellationToken)
+                    .ConfigureAwait(false);
+                updatedKey = true;
+            }
 
-            return true;
+            if (updatedKey)
+            {
+                // Because we are using a distributed cache with a non-atomic read-modify-write
+                // operation to acquire the lock, there's a possibility that another instance
+                // could have updated the key concurrently. To mitigate this, we'll do a quick
+                // read after setting the lock to verify that we still hold it.
+                currentOwner = await GetOwnershipAsync(entryOptions, cancellationToken)
+                    .ConfigureAwait(false);
+                updatedKey = currentOwner == _settings.InstanceId;
+            }
+
+            if (updatedKey)
+            {
+                success = true;
+                _lockOwnedUntil = expiresAt;
+                LogLockRenewed(_settings.LockKey, _settings.InstanceId);
+            }
+            else
+            {
+                LogFailureRenewingLock(
+                    LogLevel.Warning,
+                    _settings.LockKey,
+                    "Lock lost to another instance."
+                );
+            }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            LogErrorRenewingLeadership(_logger, ex);
-            return false;
+            LogFailureRenewingLock(LogLevel.Warning, _settings.LockKey, ex.Message);
         }
+        finally
+        {
+            if (!success)
+            {
+                // Abandon the lock locally if we failed to renew it for any reason.
+                _lockOwnedUntil = null;
+            }
+        }
+        return success;
     }
 
     protected override async Task ReleaseLeadershipAsync()
     {
+        if (!IsLockOwner)
+        {
+            LogNoActiveLockToRelease(_settings.LockKey);
+            return;
+        }
+
         try
         {
-            var entryOptions = CreateLockEntryOptions();
-
-            var currentValue = await _cache
-                .GetOrDefaultAsync<string?>(
-                    _settings.LockKey,
-                    null,
-                    entryOptions,
-                    CancellationToken.None
-                )
+            // Only remove the lock if we still own it...
+            var entryOptions = CreateLockEntryOptions(TimeSpan.FromSeconds(1)); // short expiry
+            var currentOwner = await GetOwnershipAsync(entryOptions, CancellationToken.None)
                 .ConfigureAwait(false);
-            if (currentValue == _settings.InstanceId)
+
+            if (currentOwner == _settings.InstanceId)
             {
-                await _cache
-                    .RemoveAsync(_settings.LockKey, entryOptions, CancellationToken.None)
-                    .ConfigureAwait(false);
-                LogLeadershipReleasedForInstanceInstanceid(_logger, _settings.InstanceId);
+                // We can't perform atomic read-modify-write operations on the lock, so if we're
+                // too close to the lock expiry, we'll just abandon it, allowing it to
+                // expire naturally instead of risking a race condition with another instance.
+                // This also avoids unnecessary cache operations when we're about to lose the
+                // lock anyway.
+                var quietPeriod = TimeSpan.FromMilliseconds(50);
+                if (_systemClock.UtcNow + quietPeriod < _lockOwnedUntil)
+                {
+                    await ReleaseOwnershipAsync(entryOptions).ConfigureAwait(false);
+                }
+
+                LogLockReleased(_settings.LockKey, _settings.InstanceId);
+            }
+            else if (string.IsNullOrEmpty(currentOwner))
+            {
+                LogFailureReleasingLock(
+                    LogLevel.Information,
+                    _settings.LockKey,
+                    "Lock already expired."
+                );
+            }
+            else
+            {
+                LogFailureReleasingLock(
+                    LogLevel.Information,
+                    _settings.LockKey,
+                    "Lock lost to another instance."
+                );
             }
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            LogErrorReleasingLeadership(_logger, ex);
+            LogFailureReleasingLock(LogLevel.Warning, _settings.LockKey, ex.Message);
+        }
+        finally
+        {
+            // Regardless of whether the release succeeded, we should consider the lock abandoned locally
+            _lockOwnedUntil = null;
         }
     }
 
-    [LoggerMessage(LogLevel.Error, "Error acquiring leadership")]
-    static partial void LogErrorAcquiringLeadership(ILogger logger, Exception exception);
+    private FusionCacheEntryOptions CreateLockEntryOptions(TimeSpan? durationOverride = null)
+    {
+        // If a distributed cache is configured, we should ignore memory cache reads/writes
+        // to always observe the actual shared lock state and promptly detect leadership loss.
+        var useDistributedOnly = _cache.HasDistributedCache;
 
-    [LoggerMessage(LogLevel.Error, "Error renewing leadership")]
-    static partial void LogErrorRenewingLeadership(ILogger logger, Exception exception);
+        var options = new FusionCacheEntryOptions(durationOverride ?? _settings.LockExpiry)
+            .SetFailSafe(false)
+            .SetAllowStaleOnReadOnly(false)
+            .SetSkipMemoryCacheRead(useDistributedOnly)
+            .SetSkipMemoryCacheWrite(useDistributedOnly);
 
-    [LoggerMessage(LogLevel.Information, "Leadership released for instance {instanceId}")]
-    static partial void LogLeadershipReleasedForInstanceInstanceid(
-        ILogger logger,
-        string instanceId
-    );
+        return options;
+    }
 
-    [LoggerMessage(LogLevel.Error, "Error releasing leadership")]
-    static partial void LogErrorReleasingLeadership(ILogger logger, Exception exception);
+    private ValueTask<string?> GetOwnershipAsync(
+        FusionCacheEntryOptions entryOptions,
+        CancellationToken cancellationToken
+    ) =>
+        _cache.GetOrDefaultAsync<string?>(
+            _settings.LockKey,
+            null, // default
+            entryOptions,
+            cancellationToken
+        );
+
+    private async Task<(
+        bool updatedKey,
+        string currentOwner,
+        DateTimeOffset expiresAt
+    )> TryTakeOwnershipAsync(
+        FusionCacheEntryOptions entryOptions,
+        CancellationToken cancellationToken
+    )
+    {
+        var updatedKey = false;
+        var expiresAt = _systemClock.UtcNow + entryOptions.Duration;
+        var currentOwner = await _cache
+            .GetOrSetAsync<string>(
+                _settings.LockKey,
+                (_, _) =>
+                {
+                    updatedKey = true;
+                    return Task.FromResult(_settings.InstanceId);
+                },
+                entryOptions,
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+        return (updatedKey, currentOwner, expiresAt);
+    }
+
+    private async Task<DateTimeOffset> TakeOwnershipAsync(
+        FusionCacheEntryOptions entryOptions,
+        CancellationToken cancellationToken
+    )
+    {
+        var expiresAt = _systemClock.UtcNow + entryOptions.Duration;
+        await _cache
+            .SetAsync(_settings.LockKey, _settings.InstanceId, entryOptions, cancellationToken)
+            .ConfigureAwait(false);
+        return expiresAt;
+    }
+
+    private ValueTask ReleaseOwnershipAsync(FusionCacheEntryOptions entryOptions) =>
+        _cache.RemoveAsync(_settings.LockKey, entryOptions, CancellationToken.None);
+
+    [LoggerMessage(LogLevel.Information, "Lock already acquired for key {LockKey}.")]
+    partial void LogLockAlreadyAcquired(string lockKey);
+
+    [LoggerMessage(LogLevel.Debug, "Acquired lock for key {LockKey} by instance {InstanceId}.")]
+    partial void LogLockAcquired(string lockKey, string instanceId);
+
+    [LoggerMessage("Failure acquiring lock for key {LockKey}: {Reason}")]
+    partial void LogFailureAcquiringLock(LogLevel logLevel, string lockKey, string reason);
+
+    [LoggerMessage(LogLevel.Information, "No active lock to renew for key {LockKey}.")]
+    partial void LogNoActiveLockToRenew(string lockKey);
+
+    [LoggerMessage(LogLevel.Debug, "Lock renewed for key {LockKey} by instance {InstanceId}.")]
+    partial void LogLockRenewed(string lockKey, string instanceId);
+
+    [LoggerMessage("Failure renewing lock for key {LockKey}: {Reason}")]
+    partial void LogFailureRenewingLock(LogLevel logLevel, string lockKey, string reason);
+
+    [LoggerMessage(LogLevel.Information, "No active lock to release for key {LockKey}.")]
+    partial void LogNoActiveLockToRelease(string lockKey);
+
+    [LoggerMessage(LogLevel.Debug, "Lock released for key {LockKey} by instance {InstanceId}.")]
+    partial void LogLockReleased(string lockKey, string instanceId);
+
+    [LoggerMessage("Failure releasing lock for key {LockKey}: {Reason}")]
+    partial void LogFailureReleasingLock(LogLevel logLevel, string lockKey, string reason);
 }

--- a/src/LeaderElection.FusionCache/FusionCacheLeaderElection.cs
+++ b/src/LeaderElection.FusionCache/FusionCacheLeaderElection.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Logging;
 using ZiggyCreatures.Caching.Fusion;
 
@@ -8,19 +7,18 @@ namespace LeaderElection.FusionCache;
 public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheSettings>
 {
     private readonly IFusionCache _cache;
-    private readonly ISystemClock _systemClock;
     private DateTimeOffset? _lockOwnedUntil;
 
     [MemberNotNullWhen(true, nameof(_lockOwnedUntil))]
     private bool IsLockOwner =>
-        _lockOwnedUntil.HasValue && _systemClock.UtcNow < _lockOwnedUntil.Value;
+        _lockOwnedUntil.HasValue && _timeProvider.GetUtcNow() < _lockOwnedUntil.Value;
 
     public FusionCacheLeaderElection(
         FusionCacheSettings settings,
-        ILogger<FusionCacheLeaderElection> logger,
-        ISystemClock? systemClock = null
+        ILogger<FusionCacheLeaderElection>? logger = null,
+        TimeProvider? timeProvider = null
     )
-        : base(settings ?? throw new ArgumentNullException(nameof(settings)), logger)
+        : base(settings ?? throw new ArgumentNullException(nameof(settings)), logger, timeProvider)
     {
         _ =
             settings.CacheFactory
@@ -29,8 +27,6 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
         _cache =
             settings.CacheFactory.Invoke(settings)
             ?? throw new InvalidOperationException("CacheFactory returned null.");
-
-        _systemClock = systemClock ?? new SystemClock();
     }
 
     protected override async Task<bool> TryAcquireLeadershipInternalAsync(
@@ -196,7 +192,7 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
                 // This also avoids unnecessary cache operations when we're about to lose the
                 // lock anyway.
                 var quietPeriod = TimeSpan.FromMilliseconds(50);
-                if (_systemClock.UtcNow + quietPeriod < _lockOwnedUntil)
+                if (_timeProvider.GetUtcNow() + quietPeriod < _lockOwnedUntil)
                 {
                     await ReleaseOwnershipAsync(entryOptions).ConfigureAwait(false);
                 }
@@ -267,7 +263,7 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
     )
     {
         var updatedKey = false;
-        var expiresAt = _systemClock.UtcNow + entryOptions.Duration;
+        var expiresAt = _timeProvider.GetUtcNow() + entryOptions.Duration;
         var currentOwner = await _cache
             .GetOrSetAsync<string>(
                 _settings.LockKey,
@@ -288,7 +284,7 @@ public partial class FusionCacheLeaderElection : LeaderElectionBase<FusionCacheS
         CancellationToken cancellationToken
     )
     {
-        var expiresAt = _systemClock.UtcNow + entryOptions.Duration;
+        var expiresAt = _timeProvider.GetUtcNow() + entryOptions.Duration;
         await _cache
             .SetAsync(_settings.LockKey, _settings.InstanceId, entryOptions, cancellationToken)
             .ConfigureAwait(false);

--- a/src/LeaderElection.FusionCache/FusionCacheServiceBuilderExtensions.cs
+++ b/src/LeaderElection.FusionCache/FusionCacheServiceBuilderExtensions.cs
@@ -135,6 +135,21 @@ public static class FusionCacheServiceBuilderExtensions
     }
 
     /// <summary>
+    /// Specifies the default <see cref="FusionCacheSettings"/> used by
+    /// the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithSettings(
+        this ServiceBuilder builder,
+        FusionCacheSettings settings
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(settings);
+        builder.OptionsBuilder.Configure(options => FusionCacheSettings.Copy(settings, options));
+        return builder;
+    }
+
+    /// <summary>
     /// Configures the leader election settings.
     /// </summary>
     public static ServiceBuilder WithSettings(

--- a/src/LeaderElection.FusionCache/FusionCacheServiceBuilderExtensions.cs
+++ b/src/LeaderElection.FusionCache/FusionCacheServiceBuilderExtensions.cs
@@ -1,38 +1,190 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using ZiggyCreatures.Caching.Fusion;
 
 namespace LeaderElection.FusionCache;
 
+public sealed record ServiceBuilder(
+    string? ServiceKey,
+    OptionsBuilder<FusionCacheSettings> OptionsBuilder
+);
+
 public static class FusionCacheServiceBuilderExtensions
 {
+    /// <inheritdoc cref="AddFusionCacheLeaderElectionInternal"/>
+    /// <param name="configureOptions">Action to configure the FusionCacheSettings</param>
     public static IServiceCollection AddFusionCacheLeaderElection(
         this IServiceCollection services,
         Action<FusionCacheSettings> configureOptions
-    )
-    {
-        services
-            .AddOptionsWithValidateOnStart<FusionCacheSettings, FusionCacheSettingsValidator>()
-            .Configure(configureOptions);
+    ) =>
+        AddFusionCacheLeaderElectionInternal(
+            services,
+            builder => builder.WithSettings(configureOptions)
+        );
 
-        services.AddSingleton<ILeaderElection, FusionCacheLeaderElection>();
-        return services;
-    }
-
+    /// <inheritdoc cref="AddFusionCacheLeaderElectionInternal"/>
+    /// <param name="options">FusionCacheSettings instance to use for configuration</param>
     public static IServiceCollection AddFusionCacheLeaderElection(
         this IServiceCollection services,
         FusionCacheSettings options
+    ) =>
+        AddFusionCacheLeaderElectionInternal(
+            services,
+            builder => builder.WithSettings(opts => FusionCacheSettings.Copy(options, opts))
+        );
+
+    /// <inheritdoc cref="AddFusionCacheLeaderElectionInternal"/>
+    public static IServiceCollection AddFusionCacheLeaderElection(
+        this IServiceCollection services,
+        Action<ServiceBuilder> builder,
+        string? serviceKey = null
+    ) => AddFusionCacheLeaderElectionInternal(services, builder, serviceKey);
+
+    /// <summary>
+    /// Adds FusionCache leader election services to the service collection
+    /// </summary>
+    /// <param name="services">The service collection</param>
+    /// <param name="builder">Action to configure the service builder</param>
+    /// <param name="serviceKey">Optional service key for keyed services</param>
+    /// <returns>The service collection for chaining</returns>
+    private static IServiceCollection AddFusionCacheLeaderElectionInternal(
+        this IServiceCollection services,
+        Action<ServiceBuilder> builder,
+        string? serviceKey = null
     )
     {
-        services.AddFusionCacheLeaderElection(opt =>
-        {
-            opt.InstanceId = options.InstanceId;
-            opt.LockExpiry = options.LockExpiry;
-            opt.LockKey = options.LockKey;
-            opt.EnableGracefulShutdown = options.EnableGracefulShutdown;
-            opt.RenewInterval = options.RenewInterval;
-            opt.RetryInterval = options.RetryInterval;
-            opt.MaxRetryAttempts = options.MaxRetryAttempts;
-        });
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(builder);
+
+        var optionsBuilder = services.AddOptionsWithValidateOnStart<
+            FusionCacheSettings,
+            FusionCacheSettingsValidator
+        >(serviceKey);
+
+        services.AddKeyedSingleton<ILeaderElection>(
+            serviceKey,
+            static (sp, key) =>
+            {
+                // get options
+                var options = sp.GetRequiredService<IOptionsMonitor<FusionCacheSettings>>()
+                    .Get(key as string);
+
+                // create instance
+                return ActivatorUtilities.CreateInstance<FusionCacheLeaderElection>(sp, options);
+            }
+        );
+
+        builder.Invoke(new ServiceBuilder(serviceKey, optionsBuilder));
+
+        // ensure CacheFactory is set after all configurations
+        optionsBuilder.PostConfigure<IServiceProvider>(
+            (opts, sp) =>
+            {
+                opts.CacheFactory ??= _ => GetRegisteredCache(serviceKey, sp);
+            }
+        );
 
         return services;
     }
+
+    /// <summary>
+    /// Configures the leader election to use the specified configuration section.
+    /// </summary>
+    public static ServiceBuilder WithConfiguration(
+        this ServiceBuilder builder,
+        string configurationSectionName
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configurationSectionName);
+        builder.OptionsBuilder.Configure<IConfiguration>(
+            (opts, config) => config.GetSection(configurationSectionName).Bind(opts)
+        );
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the leader election to use the specified configuration section.
+    /// </summary>
+    public static ServiceBuilder WithConfiguration(
+        this ServiceBuilder builder,
+        IConfiguration configurationSection
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configurationSection);
+        builder.OptionsBuilder.Configure(configurationSection.Bind);
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the leader election settings.
+    /// </summary>
+    public static ServiceBuilder WithSettings(
+        this ServiceBuilder builder,
+        Action<FusionCacheSettings> configureOptions
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+        builder.OptionsBuilder.Configure(configureOptions);
+        return builder;
+    }
+
+    /// <summary>
+    /// Specifies the instance ID to use for the Leader Election.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="instanceId"></param>
+    /// <returns></returns>
+    public static ServiceBuilder WithInstanceId(this ServiceBuilder builder, string instanceId)
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(instanceId);
+        return builder.WithSettings(options => options.InstanceId = instanceId);
+    }
+
+    /// <summary>
+    /// Configures the leader election to use the IFusionCache registered
+    /// in the service provider.
+    /// </summary>
+    public static ServiceBuilder WithRegisteredCache(this ServiceBuilder builder) =>
+        builder.WithSettings(
+            (opts, sp, key) => opts.CacheFactory = _ => GetRegisteredCache(key, sp)
+        );
+
+    /// <summary>
+    /// Configures the leader election to use the specified IFusionCache instance.
+    /// </summary>
+    public static ServiceBuilder WithCache(this ServiceBuilder builder, IFusionCache cache)
+    {
+        ArgumentNullException.ThrowIfNull(cache);
+        return builder.WithSettings(opts => opts.CacheFactory = _ => cache);
+    }
+
+    /// <summary>
+    /// Configures the leader election settings using a configuration action which receives
+    /// the service provider and the optional service key.
+    /// </summary>
+    /// <remarks>
+    /// This is the most flexible configuration method, allowing for complex scenarios such as:
+    /// - Resolving different cache instances based on the service key
+    /// - Accessing other services from the service provider to configure the settings
+    /// - Dynamically determining configuration values at runtime
+    /// </remarks>
+    public static ServiceBuilder WithSettings(
+        this ServiceBuilder builder,
+        Action<FusionCacheSettings, IServiceProvider, string?> configAction
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configAction);
+        builder.OptionsBuilder.Configure<IServiceProvider>(
+            (opts, sp) => configAction(opts, sp, builder.ServiceKey)
+        );
+        return builder;
+    }
+
+    private static IFusionCache GetRegisteredCache(object? serviceKey, IServiceProvider sp) =>
+        sp.GetKeyedService<IFusionCache>(serviceKey) ?? sp.GetRequiredService<IFusionCache>();
 }

--- a/src/LeaderElection.FusionCache/FusionCacheServiceBuilderExtensions.cs
+++ b/src/LeaderElection.FusionCache/FusionCacheServiceBuilderExtensions.cs
@@ -66,12 +66,28 @@ public static class FusionCacheServiceBuilderExtensions
             serviceKey,
             static (sp, key) =>
             {
-                // get options
-                var options = sp.GetRequiredService<IOptionsMonitor<FusionCacheSettings>>()
+                // get settings
+                var settings = sp.GetRequiredService<IOptionsMonitor<FusionCacheSettings>>()
                     .Get(key as string);
 
+                // Note: We must resolve the cache here. If we don't do it now
+                // and the factory resolves it from DI, then the cache (or its dependencies)
+                // may be disposed before the LeaderElection resulting in a crash.
+                var cache =
+                    (
+                        settings.CacheFactory
+                        ?? throw new InvalidOperationException(
+                            "CacheFactory must be specified in settings."
+                        )
+                    ).Invoke(settings)
+                    ?? throw new InvalidOperationException("CacheFactory returned null.");
+
                 // create instance
-                return ActivatorUtilities.CreateInstance<FusionCacheLeaderElection>(sp, options);
+                return ActivatorUtilities.CreateInstance<FusionCacheLeaderElection>(
+                    sp,
+                    settings,
+                    cache
+                );
             }
         );
 

--- a/src/LeaderElection.FusionCache/FusionCacheServiceBuilderExtensions.cs
+++ b/src/LeaderElection.FusionCache/FusionCacheServiceBuilderExtensions.cs
@@ -97,7 +97,7 @@ public static class FusionCacheServiceBuilderExtensions
         optionsBuilder.PostConfigure<IServiceProvider>(
             (opts, sp) =>
             {
-                opts.CacheFactory ??= _ => GetRegisteredCache(serviceKey, sp);
+                opts.CacheFactory ??= _ => GetRegisteredCache(sp, serviceKey);
             }
         );
 
@@ -181,7 +181,7 @@ public static class FusionCacheServiceBuilderExtensions
     /// </summary>
     public static ServiceBuilder WithRegisteredCache(this ServiceBuilder builder) =>
         builder.WithSettings(
-            (opts, sp, key) => opts.CacheFactory = _ => GetRegisteredCache(key, sp)
+            (opts, sp, key) => opts.CacheFactory = _ => GetRegisteredCache(sp, key)
         );
 
     /// <summary>
@@ -216,6 +216,7 @@ public static class FusionCacheServiceBuilderExtensions
         return builder;
     }
 
-    private static IFusionCache GetRegisteredCache(object? serviceKey, IServiceProvider sp) =>
-        sp.GetKeyedService<IFusionCache>(serviceKey) ?? sp.GetRequiredService<IFusionCache>();
+    private static IFusionCache GetRegisteredCache(IServiceProvider sp, object? serviceKey) =>
+        (serviceKey != null ? sp.GetKeyedService<IFusionCache>(serviceKey) : null)
+        ?? sp.GetRequiredService<IFusionCache>();
 }

--- a/src/LeaderElection.FusionCache/FusionCacheSettings.cs
+++ b/src/LeaderElection.FusionCache/FusionCacheSettings.cs
@@ -1,9 +1,17 @@
 using System.ComponentModel.DataAnnotations;
+using ZiggyCreatures.Caching.Fusion;
 
 namespace LeaderElection.FusionCache;
 
 public class FusionCacheSettings : LeaderElectionSettingsBase
 {
+    /// <summary>
+    /// Factory function to create an instance of IFusionCache. This allows for
+    /// custom cache implementations or retrieval logic. If not set, the default
+    /// IFusionCache registered in the service provider will be used.
+    /// </summary>
+    public Func<FusionCacheSettings, IFusionCache>? CacheFactory { get; set; }
+
     /// <summary>
     /// The key used to acquire the lock in the cache.
     /// This should be unique to avoid conflicts with other locks in the cache.
@@ -25,4 +33,17 @@ public class FusionCacheSettings : LeaderElectionSettingsBase
         nameof(FusionCacheSettingsValidator.ValidateLockExpiry)
     )]
     public TimeSpan LockExpiry { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Copies the FusionCache settings from the source to the destination.
+    /// </summary>
+    public static void Copy(FusionCacheSettings src, FusionCacheSettings dst)
+    {
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(dst);
+        LeaderElectionSettingsBase.Copy(src, dst);
+        dst.LockKey = src.LockKey;
+        dst.LockExpiry = src.LockExpiry;
+        dst.CacheFactory = src.CacheFactory;
+    }
 }

--- a/src/LeaderElection.FusionCache/FusionCacheSettings.cs
+++ b/src/LeaderElection.FusionCache/FusionCacheSettings.cs
@@ -3,31 +3,39 @@ using ZiggyCreatures.Caching.Fusion;
 
 namespace LeaderElection.FusionCache;
 
+/// <summary>
+/// Settings for FusionCache-based leader election.
+/// </summary>
 public class FusionCacheSettings : LeaderElectionSettingsBase
 {
     /// <summary>
-    /// Factory function to create an instance of IFusionCache. This allows for
-    /// custom cache implementations or retrieval logic. If not set, the default
-    /// IFusionCache registered in the service provider will be used.
+    /// An optional factory function used to obtain an <see cref="IFusionCache"/>.
     /// </summary>
+    /// <remarks>
+    /// If not provided, it will attempt to obtain an <see cref="IFusionCache"/> from DI
+    /// (assuming the leader election is created via DI).
+    /// </remarks>
     public Func<FusionCacheSettings, IFusionCache>? CacheFactory { get; set; }
 
     /// <summary>
-    /// The key used to acquire the lock in the cache.
-    /// This should be unique to avoid conflicts with other locks in the cache.
-    /// <para/>
+    /// The key used for acquiring the leader lock.
     /// Default is "leader-election-lock".
     /// </summary>
+    /// <remarks>
+    /// This should be unique to avoid conflicts with other applications using the same cache.
+    /// </remarks>
     [Required]
     public string LockKey { get; set; } = "leader-election-lock";
 
     /// <summary>
-    /// The duration for which the lock will be held in the cache before it expires.
-    /// This should be set to a value that is long enough to allow the leader to perform
-    /// its duties, but not so long that it causes delays in failover if the leader goes down.
-    /// <para/>
+    /// The duration for which the leader lock will be held before it expires.
     /// Default is 30 seconds.
     /// </summary>
+    /// <remarks>
+    /// This should be set to a value that is long enough to allow the leader to
+    /// perform its duties, but short enough to allow for quick failover in case
+    /// the leader goes down.
+    /// </remarks>
     [CustomValidation(
         typeof(FusionCacheSettingsValidator),
         nameof(FusionCacheSettingsValidator.ValidateLockExpiry)
@@ -42,8 +50,8 @@ public class FusionCacheSettings : LeaderElectionSettingsBase
         ArgumentNullException.ThrowIfNull(src);
         ArgumentNullException.ThrowIfNull(dst);
         LeaderElectionSettingsBase.Copy(src, dst);
+        dst.CacheFactory = src.CacheFactory;
         dst.LockKey = src.LockKey;
         dst.LockExpiry = src.LockExpiry;
-        dst.CacheFactory = src.CacheFactory;
     }
 }

--- a/src/LeaderElection.FusionCache/LeaderElection.FusionCache.csproj
+++ b/src/LeaderElection.FusionCache/LeaderElection.FusionCache.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
     <PackageReference Include="ZiggyCreatures.FusionCache" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
   </ItemGroup>

--- a/src/LeaderElection.Postgres/LeaderElection.Postgres.csproj
+++ b/src/LeaderElection.Postgres/LeaderElection.Postgres.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Npgsql" VersionOverride="$(PostgresVersionNetStandard21)" Condition="'$(TargetFramework)' == 'netstandard2.1'" />

--- a/src/LeaderElection.Postgres/PostgresLeaderElection.cs
+++ b/src/LeaderElection.Postgres/PostgresLeaderElection.cs
@@ -6,33 +6,37 @@ using Npgsql;
 
 public sealed partial class PostgresLeaderElection : LeaderElectionBase<PostgresSettings>
 {
-    private NpgsqlConnection? _activeConnection;
+    private readonly NpgsqlConnection _connection;
+    private bool _ownsLock;
 
     public PostgresLeaderElection(
         PostgresSettings options,
+        NpgsqlConnection connection,
         ILogger<PostgresLeaderElection>? logger = null,
         TimeProvider? timeProvider = null
     )
         : base(options ?? throw new ArgumentNullException(nameof(options)), logger, timeProvider)
-    { }
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        _connection = connection;
+    }
 
     protected override async Task<bool> TryAcquireLeadershipInternalAsync(
         CancellationToken cancellationToken
     )
     {
-        if (_activeConnection != null)
+        if (_ownsLock)
         {
             LogLockAlreadyAcquired(_settings.LockId);
             return false;
         }
 
         var success = false;
-        var connection = GetConnection();
         try
         {
-            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            await _connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
-            using var cmd = new NpgsqlCommand("SELECT pg_try_advisory_lock(@LockId);", connection);
+            using var cmd = new NpgsqlCommand("SELECT pg_try_advisory_lock(@LockId);", _connection);
             cmd.Parameters.AddWithValue("LockId", _settings.LockId);
 
             var acquired =
@@ -42,7 +46,7 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
             if (acquired)
             {
                 success = true;
-                _activeConnection = connection;
+                _ownsLock = true;
                 LogAcquiredLock(_settings.LockId, _settings.InstanceId);
             }
             else
@@ -72,7 +76,8 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         {
             if (!success)
             {
-                await connection.DisposeAsync().ConfigureAwait(false);
+                // assume we lost the lock. Abandon it to clean up our state
+                await AbandonLockAsync().ConfigureAwait(false);
             }
         }
 
@@ -83,7 +88,7 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         CancellationToken cancellationToken
     )
     {
-        if (_activeConnection == null)
+        if (!_ownsLock)
         {
             LogNoActiveLockToRenew();
             return false;
@@ -93,7 +98,7 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         try
         {
             // The advisory lock is held as long as the connection is open; this is just a heartbeat.
-            using var cmd = new NpgsqlCommand("SELECT 1;", _activeConnection);
+            using var cmd = new NpgsqlCommand("SELECT 1;", _connection);
             await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
 
             success = true;
@@ -101,8 +106,10 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         }
         catch (PostgresException ex)
         {
+            // this is unexpected since we should have the lock.
+            // Log as a warning and give up our leadership.
             LogFailureRenewingLock(
-                LogLevel.Information,
+                LogLevel.Warning,
                 ex,
                 _settings.LockId,
                 ex.SqlState + ": " + ex.MessageText
@@ -110,15 +117,14 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         }
         catch (NpgsqlException ex)
         {
-            LogFailureRenewingLock(LogLevel.Information, ex, _settings.LockId, ex.Message);
+            LogFailureRenewingLock(LogLevel.Error, ex, _settings.LockId, ex.Message);
         }
         finally
         {
             if (!success)
             {
-                // Dispose the connection to release the lock if we failed to renew it
-                await _activeConnection.DisposeAsync().ConfigureAwait(false);
-                _activeConnection = null;
+                // assume we lost the lock. Abandon it to clean up our state
+                await AbandonLockAsync().ConfigureAwait(false);
             }
         }
 
@@ -127,7 +133,7 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
 
     protected override async Task ReleaseLeadershipAsync()
     {
-        if (_activeConnection == null)
+        if (!_ownsLock)
         {
             LogNoActiveLockToRelease();
             return;
@@ -135,11 +141,11 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
 
         try
         {
-            if (_activeConnection.State == ConnectionState.Open)
+            if (_connection.State == ConnectionState.Open)
             {
                 using var cmd = new NpgsqlCommand(
                     "SELECT pg_advisory_unlock(@LockId);",
-                    _activeConnection
+                    _connection
                 );
                 cmd.Parameters.AddWithValue("LockId", _settings.LockId);
                 await cmd.ExecuteScalarAsync(default).ConfigureAwait(false);
@@ -162,45 +168,16 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         }
         finally
         {
-            // Dispose the connection to ensure the lock is released even if the unlock
-            // command failed.
-            await _activeConnection.DisposeAsync().ConfigureAwait(false);
-            _activeConnection = null;
+            // always assume we lost the lock, even if there was an error
+            // releasing it in Postgres.
+            await AbandonLockAsync().ConfigureAwait(false);
         }
     }
 
-    protected override async ValueTask DisposeAsyncCore()
+    async Task AbandonLockAsync()
     {
-        await base.DisposeAsyncCore().ConfigureAwait(false);
-
-        if (_activeConnection != null)
-        {
-            await _activeConnection.DisposeAsync().ConfigureAwait(false);
-            _activeConnection = null;
-        }
-    }
-
-    private NpgsqlConnection GetConnection()
-    {
-        if (_settings.ConnectionFactory != null)
-        {
-            if (!string.IsNullOrWhiteSpace(_settings.ConnectionString))
-            {
-                LogIgnoringConnectionStringBecauseFactoryIsSet();
-            }
-
-            return _settings.ConnectionFactory(_settings)
-                ?? throw new InvalidOperationException("ConnectionFactory returned null.");
-        }
-
-        if (!string.IsNullOrWhiteSpace(_settings.ConnectionString))
-        {
-            return new NpgsqlConnection(_settings.ConnectionString);
-        }
-
-        throw new InvalidOperationException(
-            "Either ConnectionFactory must be provided or ConnectionString must be non-empty."
-        );
+        _ownsLock = false;
+        await _connection.CloseAsync().ConfigureAwait(false);
     }
 
     [LoggerMessage(LogLevel.Information, "Lock already acquired: {lockId}.")]
@@ -244,7 +221,4 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         long lockId,
         string reason
     );
-
-    [LoggerMessage(LogLevel.Warning, "Ignoring ConnectionString because ConnectionFactory is set.")]
-    partial void LogIgnoringConnectionStringBecauseFactoryIsSet();
 }

--- a/src/LeaderElection.Postgres/PostgresLeaderElection.cs
+++ b/src/LeaderElection.Postgres/PostgresLeaderElection.cs
@@ -8,8 +8,13 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
 {
     private NpgsqlConnection? _activeConnection;
 
-    public PostgresLeaderElection(PostgresSettings options, ILogger<PostgresLeaderElection> logger)
-        : base(options ?? throw new ArgumentNullException(nameof(options)), logger) { }
+    public PostgresLeaderElection(
+        PostgresSettings options,
+        ILogger<PostgresLeaderElection>? logger = null,
+        TimeProvider? timeProvider = null
+    )
+        : base(options ?? throw new ArgumentNullException(nameof(options)), logger, timeProvider)
+    { }
 
     protected override async Task<bool> TryAcquireLeadershipInternalAsync(
         CancellationToken cancellationToken

--- a/src/LeaderElection.Postgres/PostgresLeaderElection.cs
+++ b/src/LeaderElection.Postgres/PostgresLeaderElection.cs
@@ -2,88 +2,131 @@ namespace LeaderElection.Postgres;
 
 using System.Data;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Npgsql;
 
 public sealed partial class PostgresLeaderElection : LeaderElectionBase<PostgresSettings>
 {
     private NpgsqlConnection? _activeConnection;
 
-    public PostgresLeaderElection(
-        IOptions<PostgresSettings> options,
-        ILogger<PostgresLeaderElection> logger
-    )
-        : base(options?.Value ?? throw new ArgumentNullException(nameof(options)), logger) { }
+    public PostgresLeaderElection(PostgresSettings options, ILogger<PostgresLeaderElection> logger)
+        : base(options ?? throw new ArgumentNullException(nameof(options)), logger) { }
 
     protected override async Task<bool> TryAcquireLeadershipInternalAsync(
         CancellationToken cancellationToken
     )
     {
+        if (_activeConnection != null)
+        {
+            LogLockAlreadyAcquired(_settings.LockId);
+            return false;
+        }
+
+        var success = false;
+        var connection = GetConnection();
         try
         {
-            if (_activeConnection != null)
-            {
-                await _activeConnection.DisposeAsync().ConfigureAwait(false);
-                _activeConnection = null;
-            }
-
-            var connection = new NpgsqlConnection(_settings.ConnectionString);
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
             using var cmd = new NpgsqlCommand("SELECT pg_try_advisory_lock(@LockId);", connection);
             cmd.Parameters.AddWithValue("LockId", _settings.LockId);
 
-            var result = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
-            if (result is true)
-            {
-                _activeConnection = connection;
-                return true;
-            }
+            var acquired =
+                (bool?)await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false)
+                ?? false;
 
-            await connection.DisposeAsync().ConfigureAwait(false);
-            return false;
+            if (acquired)
+            {
+                success = true;
+                _activeConnection = connection;
+                LogAcquiredLock(_settings.LockId, _settings.InstanceId);
+            }
+            else
+            {
+                LogFailureAcquiringLock(
+                    LogLevel.Debug,
+                    null,
+                    _settings.LockId,
+                    "Lock is already held by another instance."
+                );
+            }
         }
-        catch (Exception ex)
+        catch (PostgresException ex)
         {
-            LogErrorAcquiringPostgresqlLeadership(_logger, ex);
-            return false;
+            LogFailureAcquiringLock(
+                LogLevel.Information,
+                ex,
+                _settings.LockId,
+                ex.SqlState + ": " + ex.MessageText
+            );
         }
+        catch (NpgsqlException ex)
+        {
+            LogFailureAcquiringLock(LogLevel.Warning, ex, _settings.LockId, ex.Message);
+        }
+        finally
+        {
+            if (!success)
+            {
+                await connection.DisposeAsync().ConfigureAwait(false);
+            }
+        }
+
+        return success;
     }
 
     protected override async Task<bool> RenewLeadershipInternalAsync(
         CancellationToken cancellationToken
     )
     {
-        if (_activeConnection is not { State: ConnectionState.Open })
+        if (_activeConnection == null)
         {
+            LogNoActiveLockToRenew();
             return false;
         }
 
+        var success = false;
         try
         {
             // The advisory lock is held as long as the connection is open; this is just a heartbeat.
             using var cmd = new NpgsqlCommand("SELECT 1;", _activeConnection);
             await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
-            return true;
-        }
-        catch (Exception ex)
-        {
-            LogErrorRenewingPostgresqlLeadershipConnectionLost(_logger, ex);
 
-            if (_activeConnection != null)
+            success = true;
+            LogRenewedLock(_settings.LockId, _settings.InstanceId);
+        }
+        catch (PostgresException ex)
+        {
+            LogFailureRenewingLock(
+                LogLevel.Information,
+                ex,
+                _settings.LockId,
+                ex.SqlState + ": " + ex.MessageText
+            );
+        }
+        catch (NpgsqlException ex)
+        {
+            LogFailureRenewingLock(LogLevel.Information, ex, _settings.LockId, ex.Message);
+        }
+        finally
+        {
+            if (!success)
             {
+                // Dispose the connection to release the lock if we failed to renew it
                 await _activeConnection.DisposeAsync().ConfigureAwait(false);
                 _activeConnection = null;
             }
-
-            return false;
         }
+
+        return success;
     }
 
     protected override async Task ReleaseLeadershipAsync()
     {
         if (_activeConnection == null)
+        {
+            LogNoActiveLockToRelease();
             return;
+        }
 
         try
         {
@@ -94,17 +137,28 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
                     _activeConnection
                 );
                 cmd.Parameters.AddWithValue("LockId", _settings.LockId);
-                await cmd.ExecuteScalarAsync(CancellationToken.None).ConfigureAwait(false);
+                await cmd.ExecuteScalarAsync(default).ConfigureAwait(false);
             }
 
-            LogLeadershipReleasedForInstanceInstanceId(_logger, _settings.InstanceId);
+            LogReleasedLock(_settings.LockId);
         }
-        catch (Exception ex)
+        catch (PostgresException ex)
         {
-            LogErrorReleasingPostgresqlLeadership(_logger, ex);
+            LogFailureReleasingLock(
+                LogLevel.Information,
+                ex,
+                _settings.LockId,
+                ex.SqlState + ": " + ex.MessageText
+            );
+        }
+        catch (NpgsqlException ex)
+        {
+            LogFailureReleasingLock(LogLevel.Information, ex, _settings.LockId, ex.Message);
         }
         finally
         {
+            // Dispose the connection to ensure the lock is released even if the unlock
+            // command failed.
             await _activeConnection.DisposeAsync().ConfigureAwait(false);
             _activeConnection = null;
         }
@@ -121,21 +175,71 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         }
     }
 
-    [LoggerMessage(LogLevel.Error, "Error acquiring PostgreSQL leadership")]
-    static partial void LogErrorAcquiringPostgresqlLeadership(ILogger logger, Exception exception);
+    private NpgsqlConnection GetConnection()
+    {
+        if (_settings.ConnectionFactory != null)
+        {
+            if (!string.IsNullOrWhiteSpace(_settings.ConnectionString))
+            {
+                LogIgnoringConnectionStringBecauseFactoryIsSet();
+            }
 
-    [LoggerMessage(LogLevel.Error, "Error renewing PostgreSQL leadership; connection lost")]
-    static partial void LogErrorRenewingPostgresqlLeadershipConnectionLost(
-        ILogger logger,
-        Exception exception
+            return _settings.ConnectionFactory(_settings)
+                ?? throw new InvalidOperationException("ConnectionFactory returned null.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(_settings.ConnectionString))
+        {
+            return new NpgsqlConnection(_settings.ConnectionString);
+        }
+
+        throw new InvalidOperationException(
+            "Either ConnectionFactory must be provided or ConnectionString must be non-empty."
+        );
+    }
+
+    [LoggerMessage(LogLevel.Information, "Lock already acquired: {lockId}.")]
+    partial void LogLockAlreadyAcquired(long lockId);
+
+    [LoggerMessage(LogLevel.Debug, "Acquired lock {lockId} for instance {instanceId}.")]
+    partial void LogAcquiredLock(long lockId, string instanceId);
+
+    [LoggerMessage("Failure acquiring lock {lockId}: {Reason}.")]
+    partial void LogFailureAcquiringLock(
+        LogLevel logLevel,
+        Exception? exception,
+        long lockId,
+        string reason
     );
 
-    [LoggerMessage(LogLevel.Information, "Leadership released for instance {instanceId}")]
-    static partial void LogLeadershipReleasedForInstanceInstanceId(
-        ILogger logger,
-        string instanceId
+    [LoggerMessage(LogLevel.Information, "No active lock to renew.")]
+    partial void LogNoActiveLockToRenew();
+
+    [LoggerMessage(LogLevel.Debug, "Renewed lock {lockId} for instance {instanceId}.")]
+    partial void LogRenewedLock(long lockId, string instanceId);
+
+    [LoggerMessage("Failure renewing lock {lockId}: {Reason}.")]
+    partial void LogFailureRenewingLock(
+        LogLevel logLevel,
+        Exception? exception,
+        long lockId,
+        string reason
     );
 
-    [LoggerMessage(LogLevel.Error, "Error releasing PostgreSQL leadership")]
-    static partial void LogErrorReleasingPostgresqlLeadership(ILogger logger, Exception exception);
+    [LoggerMessage(LogLevel.Information, "No active lock to release.")]
+    partial void LogNoActiveLockToRelease();
+
+    [LoggerMessage(LogLevel.Debug, "Released lock {lockId}.")]
+    partial void LogReleasedLock(long lockId);
+
+    [LoggerMessage("Failure releasing lock {lockId}: {Reason}.")]
+    partial void LogFailureReleasingLock(
+        LogLevel logLevel,
+        Exception? exception,
+        long lockId,
+        string reason
+    );
+
+    [LoggerMessage(LogLevel.Warning, "Ignoring ConnectionString because ConnectionFactory is set.")]
+    partial void LogIgnoringConnectionStringBecauseFactoryIsSet();
 }

--- a/src/LeaderElection.Postgres/PostgresLeaderElection.cs
+++ b/src/LeaderElection.Postgres/PostgresLeaderElection.cs
@@ -39,13 +39,12 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
             using var cmd = new NpgsqlCommand("SELECT pg_try_advisory_lock(@LockId);", _connection);
             cmd.Parameters.AddWithValue("LockId", _settings.LockId);
 
-            var acquired =
+            success =
                 (bool?)await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false)
                 ?? false;
 
-            if (acquired)
+            if (success)
             {
-                success = true;
                 _ownsLock = true;
                 LogAcquiredLock(_settings.LockId);
             }
@@ -71,14 +70,6 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         catch (NpgsqlException ex)
         {
             LogFailureAcquiringLock(LogLevel.Warning, ex, _settings.LockId, ex.Message);
-        }
-        finally
-        {
-            if (!success)
-            {
-                // assume we lost the lock. Abandon it to clean up our state
-                await AbandonLockAsync().ConfigureAwait(false);
-            }
         }
 
         return success;
@@ -124,7 +115,7 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
             if (!success)
             {
                 // assume we lost the lock. Abandon it to clean up our state
-                await AbandonLockAsync().ConfigureAwait(false);
+                await ResetLeadershipAsync().ConfigureAwait(false);
             }
         }
 
@@ -172,11 +163,11 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         {
             // always assume we lost the lock, even if there was an error
             // releasing it in Postgres.
-            await AbandonLockAsync().ConfigureAwait(false);
+            await ResetLeadershipAsync().ConfigureAwait(false);
         }
     }
 
-    async Task AbandonLockAsync()
+    protected override async ValueTask ResetLeadershipAsync()
     {
         _ownsLock = false;
         await _connection.CloseAsync().ConfigureAwait(false);

--- a/src/LeaderElection.Postgres/PostgresLeaderElection.cs
+++ b/src/LeaderElection.Postgres/PostgresLeaderElection.cs
@@ -47,7 +47,7 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
             {
                 success = true;
                 _ownsLock = true;
-                LogAcquiredLock(_settings.LockId, _settings.InstanceId);
+                LogAcquiredLock(_settings.LockId);
             }
             else
             {
@@ -102,7 +102,7 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
             await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
 
             success = true;
-            LogRenewedLock(_settings.LockId, _settings.InstanceId);
+            LogRenewedLock(_settings.LockId);
         }
         catch (PostgresException ex)
         {
@@ -183,8 +183,8 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
     [LoggerMessage(LogLevel.Information, "Lock already acquired: {lockId}.")]
     partial void LogLockAlreadyAcquired(long lockId);
 
-    [LoggerMessage(LogLevel.Debug, "Acquired lock {lockId} for instance {instanceId}.")]
-    partial void LogAcquiredLock(long lockId, string instanceId);
+    [LoggerMessage(LogLevel.Debug, "Acquired lock {lockId}.")]
+    partial void LogAcquiredLock(long lockId);
 
     [LoggerMessage("Failure acquiring lock {lockId}: {Reason}.")]
     partial void LogFailureAcquiringLock(
@@ -197,8 +197,8 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
     [LoggerMessage(LogLevel.Information, "No active lock to renew.")]
     partial void LogNoActiveLockToRenew();
 
-    [LoggerMessage(LogLevel.Debug, "Renewed lock {lockId} for instance {instanceId}.")]
-    partial void LogRenewedLock(long lockId, string instanceId);
+    [LoggerMessage(LogLevel.Debug, "Renewed lock {lockId}.")]
+    partial void LogRenewedLock(long lockId);
 
     [LoggerMessage("Failure renewing lock {lockId}: {Reason}.")]
     partial void LogFailureRenewingLock(

--- a/src/LeaderElection.Postgres/PostgresLeaderElection.cs
+++ b/src/LeaderElection.Postgres/PostgresLeaderElection.cs
@@ -155,8 +155,10 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         }
         catch (PostgresException ex)
         {
+            // this is unexpected since we should have the lock.
+            // Log as a warning and give up our leadership.
             LogFailureReleasingLock(
-                LogLevel.Information,
+                LogLevel.Warning,
                 ex,
                 _settings.LockId,
                 ex.SqlState + ": " + ex.MessageText
@@ -164,7 +166,7 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         }
         catch (NpgsqlException ex)
         {
-            LogFailureReleasingLock(LogLevel.Information, ex, _settings.LockId, ex.Message);
+            LogFailureReleasingLock(LogLevel.Error, ex, _settings.LockId, ex.Message);
         }
         finally
         {

--- a/src/LeaderElection.Postgres/PostgresLeaderElection.cs
+++ b/src/LeaderElection.Postgres/PostgresLeaderElection.cs
@@ -6,46 +6,96 @@ using Npgsql;
 
 public sealed partial class PostgresLeaderElection : LeaderElectionBase<PostgresSettings>
 {
-    private readonly NpgsqlConnection _connection;
-    private bool _ownsLock;
+    private readonly NpgsqlDataSource _dataSource;
+    private NpgsqlConnection? _connection;
 
     public PostgresLeaderElection(
         PostgresSettings options,
-        NpgsqlConnection connection,
+        NpgsqlDataSource dataSource,
         ILogger<PostgresLeaderElection>? logger = null,
         TimeProvider? timeProvider = null
     )
         : base(options ?? throw new ArgumentNullException(nameof(options)), logger, timeProvider)
     {
-        ArgumentNullException.ThrowIfNull(connection);
-        _connection = connection;
+        ArgumentNullException.ThrowIfNull(dataSource);
+        ValidateDataSource(dataSource);
+        _dataSource = dataSource;
+    }
+
+    // Validate that the provided DataSource is configured in a way that is compatible with
+    // advisory locks and won't lead to unexpected behavior.
+    private void ValidateDataSource(NpgsqlDataSource dataSource)
+    {
+        // Multiplexing is not allowed since each instance requires a dedicated connection
+        // (required for advisory locks)
+        var b = new NpgsqlConnectionStringBuilder(dataSource.ConnectionString);
+        if (b.Multiplexing)
+        {
+            throw new InvalidOperationException(
+                "Multiplexing must be disabled for leader election. Remove 'Multiplexing=true' from your connection string or provide a DataSource with multiplexing disabled."
+            );
+        }
+
+        // In multi-host configurations, Npgsql will automatically route to a standby if the primary
+        // is unavailable, resulting in unpredictable/orphaned locks. To avoid this, require an
+        // explicit TargetSessionAttributes in multi-host scenarios.
+        // Note that this assumes a Single-Primary topology, which is the only topology where
+        // advisory locks can be reliably used.
+        if (
+            b.Host?.Contains(',', StringComparison.OrdinalIgnoreCase) == true
+            && !"read-write".Equals(b.TargetSessionAttributes, StringComparison.OrdinalIgnoreCase)
+            && !"primary".Equals(b.TargetSessionAttributes, StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            throw new InvalidOperationException(
+                "TargetSessionAttributes must be 'read-write' or 'primary' for multi-host leader election. Add 'TargetSessionAttributes=read-write' or 'TargetSessionAttributes=primary' to your connection string or provide a DataSource with the correct settings."
+            );
+        }
+
+        // Warn if CommandTimeout is not set to a reasonable value, as a long CommandTimeout can
+        // lead to long waits if the database becomes unresponsive.
+        if (
+            b.CommandTimeout <= 0 /*infinity*/
+            || b.CommandTimeout > 5 /*seconds*/
+        )
+        {
+            LogUseRecommendedCommandTimeout(b.CommandTimeout);
+        }
     }
 
     protected override async Task<bool> TryAcquireLeadershipInternalAsync(
         CancellationToken cancellationToken
     )
     {
-        if (_ownsLock)
+        if (_connection != null)
         {
             LogLockAlreadyAcquired(_settings.LockId);
             return false;
         }
 
+        NpgsqlConnection? connection = null;
         var success = false;
         try
         {
-            await _connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            connection = await _dataSource
+                .OpenConnectionAsync(cancellationToken)
+                .ConfigureAwait(false);
 
-            using var cmd = new NpgsqlCommand("SELECT pg_try_advisory_lock(@LockId);", _connection);
-            cmd.Parameters.AddWithValue("LockId", _settings.LockId);
+            using var cmd = CreateCommand(
+                connection,
+                "SELECT pg_try_advisory_lock(@LockId);",
+                "LockId",
+                _settings.LockId
+            );
 
             success =
-                (bool?)await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false)
+                (await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) as bool?)
                 ?? false;
 
             if (success)
             {
-                _ownsLock = true;
+                _connection = connection;
+                connection = null; // ownership transferred, don't dispose in finally
                 LogAcquiredLock(_settings.LockId);
             }
             else
@@ -71,6 +121,13 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         {
             LogFailureAcquiringLock(LogLevel.Warning, ex, _settings.LockId, ex.Message);
         }
+        finally
+        {
+            if (connection != null)
+            {
+                await connection.DisposeAsync().ConfigureAwait(false);
+            }
+        }
 
         return success;
     }
@@ -79,7 +136,7 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         CancellationToken cancellationToken
     )
     {
-        if (!_ownsLock)
+        if (_connection == null)
         {
             LogNoActiveLockToRenew();
             return false;
@@ -89,8 +146,8 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         try
         {
             // The advisory lock is held as long as the connection is open; this is just a heartbeat.
-            using var cmd = new NpgsqlCommand("SELECT 1;", _connection);
-            await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            using var cmd = CreateCommand(_connection, "SELECT 1;");
+            await cmd.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
 
             success = true;
             LogRenewedLock(_settings.LockId);
@@ -124,7 +181,7 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
 
     protected override async Task ReleaseLeadershipAsync()
     {
-        if (!_ownsLock)
+        if (_connection == null)
         {
             LogNoActiveLockToRelease();
             return;
@@ -134,12 +191,13 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         {
             if (_connection.State == ConnectionState.Open)
             {
-                using var cmd = new NpgsqlCommand(
+                using var cmd = CreateCommand(
+                    _connection,
                     "SELECT pg_advisory_unlock(@LockId);",
-                    _connection
+                    "LockId",
+                    _settings.LockId
                 );
-                cmd.Parameters.AddWithValue("LockId", _settings.LockId);
-                await cmd.ExecuteScalarAsync(default).ConfigureAwait(false);
+                await cmd.ExecuteNonQueryAsync(default).ConfigureAwait(false);
             }
 
             LogReleasedLock(_settings.LockId);
@@ -169,8 +227,37 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
 
     protected override async ValueTask ResetLeadershipAsync()
     {
-        _ownsLock = false;
-        await _connection.CloseAsync().ConfigureAwait(false);
+        var connection = Interlocked.Exchange(ref _connection, null);
+        if (connection != null)
+        {
+            await connection.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    protected override async ValueTask DisposeAsyncCore()
+    {
+        await ResetLeadershipAsync().ConfigureAwait(false);
+        await base.DisposeAsyncCore().ConfigureAwait(false);
+    }
+
+    private static NpgsqlCommand CreateCommand(
+        NpgsqlConnection connection,
+        /* language=sql */string query,
+        string? argName = null,
+        object? argValue = null
+    )
+    {
+#pragma warning disable CA2100 // Review SQL queries for security vulnerabilities
+        var cmd = new NpgsqlCommand(query, connection)
+        {
+            // CommandTimeout = 3, // force a short timeout to avoid hanging
+        };
+#pragma warning restore CA2100
+        if (argName != null)
+        {
+            cmd.Parameters.AddWithValue(argName, argValue ?? DBNull.Value);
+        }
+        return cmd;
     }
 
     [LoggerMessage(LogLevel.Information, "Lock already acquired: {lockId}.")]
@@ -214,4 +301,10 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         long lockId,
         string reason
     );
+
+    [LoggerMessage(
+        LogLevel.Warning,
+        "CommandTimeout of {commandTimeout} seconds may be too high for reliable leader election. Consider setting 'CommandTimeout' to 3-5 seconds."
+    )]
+    partial void LogUseRecommendedCommandTimeout(int commandTimeout);
 }

--- a/src/LeaderElection.Postgres/PostgresLeaderElection.cs
+++ b/src/LeaderElection.Postgres/PostgresLeaderElection.cs
@@ -234,12 +234,6 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         }
     }
 
-    protected override async ValueTask DisposeAsyncCore()
-    {
-        await ResetLeadershipAsync().ConfigureAwait(false);
-        await base.DisposeAsyncCore().ConfigureAwait(false);
-    }
-
     private static NpgsqlCommand CreateCommand(
         NpgsqlConnection connection,
         /* language=sql */string query,

--- a/src/LeaderElection.Postgres/PostgresServiceBuilderExtensions.cs
+++ b/src/LeaderElection.Postgres/PostgresServiceBuilderExtensions.cs
@@ -1,40 +1,217 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Npgsql;
 
 namespace LeaderElection.Postgres;
 
+public sealed record ServiceBuilder(
+    string? ServiceKey,
+    OptionsBuilder<PostgresSettings> OptionsBuilder
+);
+
 public static class PostgresServiceBuilderExtensions
 {
+    /// <inheritdoc cref="AddPostgresLeaderElectionInternal"/>
+    /// <param name="configureOptions">Action to configure the PostgresSettings</param>
     public static IServiceCollection AddPostgresLeaderElection(
         this IServiceCollection services,
         Action<PostgresSettings> configureOptions
+    ) =>
+        AddPostgresLeaderElectionInternal(
+            services,
+            builder => builder.WithSettings(configureOptions)
+        );
+
+    /// <inheritdoc cref="AddPostgresLeaderElectionInternal"/>
+    /// <param name="options">PostgresSettings instance to use for configuration</param>
+    public static IServiceCollection AddPostgresLeaderElection(
+        this IServiceCollection services,
+        PostgresSettings options
+    ) => AddPostgresLeaderElectionInternal(services, builder => builder.WithSettings(options));
+
+    /// <inheritdoc cref="AddPostgresLeaderElectionInternal"/>
+    public static IServiceCollection AddPostgresLeaderElection(
+        this IServiceCollection services,
+        Action<ServiceBuilder> builder,
+        string? serviceKey = null
+    ) => AddPostgresLeaderElectionInternal(services, builder, serviceKey);
+
+    /// <summary>
+    /// Adds Postgres leader election services to the service collection
+    /// </summary>
+    /// <param name="services">The service collection</param>
+    /// <param name="builder">Action to configure the service builder</param>
+    /// <param name="serviceKey">Optional service key for keyed services</param>
+    /// <returns>The service collection for chaining</returns>
+    private static IServiceCollection AddPostgresLeaderElectionInternal(
+        this IServiceCollection services,
+        Action<ServiceBuilder> builder,
+        string? serviceKey = null
     )
     {
-        services
-            .AddOptionsWithValidateOnStart<PostgresSettings, PostgresSettingsValidator>()
-            .Configure(configureOptions);
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(builder);
 
-        services.AddSingleton<PostgresLeaderElection>();
-        services.AddSingleton<ILeaderElection>(sp =>
-            sp.GetRequiredService<PostgresLeaderElection>()
+        var configBuilder = services.AddOptionsWithValidateOnStart<
+            PostgresSettings,
+            PostgresSettingsValidator
+        >(serviceKey);
+
+        services.AddKeyedSingleton<PostgresLeaderElection>(
+            serviceKey,
+            static (sp, key) =>
+            {
+                // get options
+                var options = sp.GetRequiredService<IOptionsMonitor<PostgresSettings>>()
+                    .Get(key as string);
+
+                // create instance
+                return ActivatorUtilities.CreateInstance<PostgresLeaderElection>(sp, options);
+            }
+        );
+
+        services.AddKeyedSingleton<ILeaderElection>(
+            serviceKey,
+            static (sp, key) => sp.GetRequiredKeyedService<PostgresLeaderElection>(key)
+        );
+
+        builder.Invoke(new ServiceBuilder(serviceKey, configBuilder));
+
+        // resolve the connection from DI if a ConnectionFactory or ConnectionString is not set
+        configBuilder.PostConfigure<IServiceProvider>(
+            (opts, sp) =>
+            {
+                if (opts.ConnectionFactory is null && string.IsNullOrEmpty(opts.ConnectionString))
+                {
+                    opts.ConnectionFactory = _ => GetRegisteredConnection(sp, serviceKey);
+                }
+            }
         );
 
         return services;
     }
 
-    public static IServiceCollection AddPostgresLeaderElection(
-        this IServiceCollection services,
-        PostgresSettings options
+    /// <summary>
+    /// Configures the leader election settings using the specified configuration section.
+    /// </summary>
+    public static ServiceBuilder WithConfiguration(
+        this ServiceBuilder builder,
+        string configurationSectionName
     )
     {
-        services.AddPostgresLeaderElection(opt =>
-        {
-            opt.InstanceId = options.InstanceId;
-            opt.ConnectionString = options.ConnectionString;
-            opt.LockId = options.LockId;
-            opt.RetryInterval = options.RetryInterval;
-            opt.EnableGracefulShutdown = options.EnableGracefulShutdown;
-        });
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configurationSectionName);
+        builder.OptionsBuilder.Configure<IConfiguration>(
+            (opts, config) => config.GetSection(configurationSectionName).Bind(opts)
+        );
+        return builder;
+    }
 
-        return services;
+    /// <summary>
+    /// Configures the leader election settings using the specified configuration section.
+    /// </summary>
+    public static ServiceBuilder WithConfiguration(
+        this ServiceBuilder builder,
+        IConfiguration configurationSection
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configurationSection);
+        builder.OptionsBuilder.Configure(configurationSection.Bind);
+        return builder;
+    }
+
+    /// <summary>
+    /// Specifies the <see cref="PostgresSettings"/> used by the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithSettings(
+        this ServiceBuilder builder,
+        PostgresSettings settings
+    )
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        return builder.WithSettings(opts => PostgresSettings.Copy(settings, opts));
+    }
+
+    /// <summary>
+    /// Configures the leader election settings using the specified action.
+    /// </summary>
+    public static ServiceBuilder WithSettings(
+        this ServiceBuilder builder,
+        Action<PostgresSettings> configureOptions
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+        builder.OptionsBuilder.Configure(configureOptions);
+        return builder;
+    }
+
+    /// <summary>
+    /// Specifies the instance ID to use for the Leader Election.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="instanceId"></param>
+    /// <returns></returns>
+    public static ServiceBuilder WithInstanceId(this ServiceBuilder builder, string instanceId)
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(instanceId);
+        return builder.WithSettings(options => options.InstanceId = instanceId);
+    }
+
+    /// <summary>
+    /// Configures the leader election to use the NpgsqlConnection registered
+    /// in the DI container.
+    /// </summary>
+    public static ServiceBuilder WithRegisteredConnection(this ServiceBuilder builder)
+    {
+        return builder.WithSettings(
+            (opts, sp, key) => opts.ConnectionFactory = _ => GetRegisteredConnection(sp, key)
+        );
+    }
+
+    /// <summary>
+    /// Configures the leader election to use the specified connection factory.
+    /// </summary>
+    public static ServiceBuilder WithConnectionFactory(
+        this ServiceBuilder builder,
+        Func<PostgresSettings, NpgsqlConnection> connectionFactory
+    )
+    {
+        ArgumentNullException.ThrowIfNull(connectionFactory);
+        return builder.WithSettings(opts => opts.ConnectionFactory = connectionFactory);
+    }
+
+    /// <summary>
+    /// Configures the leader election settings using a configuration action which receives
+    /// the service provider and the optional service key.
+    /// </summary>
+    /// <remarks>
+    /// This is the most flexible configuration method, allowing for complex scenarios such as:
+    /// - Resolving different cache instances based on the service key
+    /// - Accessing other services from the service provider to configure the settings
+    /// - Dynamically determining configuration values at runtime
+    /// </remarks>
+    public static ServiceBuilder WithSettings(
+        this ServiceBuilder builder,
+        Action<PostgresSettings, IServiceProvider, string?> configAction
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configAction);
+        builder.OptionsBuilder.Configure<IServiceProvider>(
+            (opts, sp) => configAction(opts, sp, builder.ServiceKey)
+        );
+        return builder;
+    }
+
+    private static NpgsqlConnection GetRegisteredConnection(
+        IServiceProvider sp,
+        string? serviceKey = null
+    )
+    {
+        return sp.GetKeyedService<NpgsqlConnection>(serviceKey)
+            ?? sp.GetRequiredService<NpgsqlConnection>();
     }
 }

--- a/src/LeaderElection.Postgres/PostgresServiceBuilderExtensions.cs
+++ b/src/LeaderElection.Postgres/PostgresServiceBuilderExtensions.cs
@@ -58,16 +58,34 @@ public static class PostgresServiceBuilderExtensions
             PostgresSettingsValidator
         >(serviceKey);
 
+        services.AddTransient<ConnectionCreator>();
+
         services.AddKeyedSingleton<PostgresLeaderElection>(
             serviceKey,
             static (sp, key) =>
             {
-                // get options
-                var options = sp.GetRequiredService<IOptionsMonitor<PostgresSettings>>()
+                // get settings
+                var settings = sp.GetRequiredService<IOptionsMonitor<PostgresSettings>>()
                     .Get(key as string);
 
+                // Note: We must resolve the connection here. If we don't do it now
+                // and the factory resolves it from DI, then the connection (or its dependencies)
+                // may be disposed before the LeaderElection resulting in a crash.
+                var connection =
+                    (
+                        settings.ConnectionFactory
+                        ?? throw new InvalidOperationException(
+                            "ConnectionFactory must be specified in settings."
+                        )
+                    ).Invoke(settings)
+                    ?? throw new InvalidOperationException("ConnectionFactory returned null.");
+
                 // create instance
-                return ActivatorUtilities.CreateInstance<PostgresLeaderElection>(sp, options);
+                return ActivatorUtilities.CreateInstance<PostgresLeaderElection>(
+                    sp,
+                    settings,
+                    connection
+                );
             }
         );
 
@@ -81,12 +99,18 @@ public static class PostgresServiceBuilderExtensions
         // resolve the connection from DI if a ConnectionFactory or ConnectionString is not set
         configBuilder.PostConfigure<IServiceProvider>(
             (opts, sp) =>
-            {
-                if (opts.ConnectionFactory is null && string.IsNullOrEmpty(opts.ConnectionString))
+                opts.ConnectionFactory ??= settings =>
                 {
-                    opts.ConnectionFactory = _ => GetRegisteredConnection(sp, serviceKey);
+                    // If a ConnectionString is provided, use the default factory which creates
+                    // and disposes the connection for each instance.
+                    if (!string.IsNullOrEmpty(settings.ConnectionString))
+                    {
+                        return sp.GetRequiredService<ConnectionCreator>()
+                            .CreateConnection(settings);
+                    }
+
+                    return GetRegisteredConnection(sp, serviceKey);
                 }
-            }
         );
 
         return services;
@@ -172,18 +196,6 @@ public static class PostgresServiceBuilderExtensions
     }
 
     /// <summary>
-    /// Configures the leader election to use the specified connection factory.
-    /// </summary>
-    public static ServiceBuilder WithConnectionFactory(
-        this ServiceBuilder builder,
-        Func<PostgresSettings, NpgsqlConnection> connectionFactory
-    )
-    {
-        ArgumentNullException.ThrowIfNull(connectionFactory);
-        return builder.WithSettings(opts => opts.ConnectionFactory = connectionFactory);
-    }
-
-    /// <summary>
     /// Configures the leader election settings using a configuration action which receives
     /// the service provider and the optional service key.
     /// </summary>
@@ -213,5 +225,28 @@ public static class PostgresServiceBuilderExtensions
     {
         return sp.GetKeyedService<NpgsqlConnection>(serviceKey)
             ?? sp.GetRequiredService<NpgsqlConnection>();
+    }
+
+    // A private class used to create and dispose a connection when the
+    // connection string settings are used.
+    private class ConnectionCreator : IAsyncDisposable
+    {
+        public NpgsqlConnection? _connection;
+
+        public NpgsqlConnection CreateConnection(PostgresSettings settings)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            if (string.IsNullOrWhiteSpace(settings.ConnectionString))
+            {
+                throw new InvalidOperationException(
+                    "ConnectionString must be specified in settings to use the default Connection factory."
+                );
+            }
+
+            _connection = new NpgsqlConnection(settings.ConnectionString);
+            return _connection;
+        }
+
+        public ValueTask DisposeAsync() => _connection?.DisposeAsync() ?? new ValueTask();
     }
 }

--- a/src/LeaderElection.Postgres/PostgresServiceBuilderExtensions.cs
+++ b/src/LeaderElection.Postgres/PostgresServiceBuilderExtensions.cs
@@ -186,22 +186,31 @@ public static class PostgresServiceBuilderExtensions
     /// in the DI container.
     /// </summary>
     /// <param name="builder">The service builder.</param>
-    /// <param name="datasourceServiceKey">Optional service key to resolve a specific <see cref="NpgsqlDataSource"/>
-    /// instance if multiple are registered. Defaults to the service key of the registered
-    /// <see cref="PostgresLeaderElection"/>. Use an empty string ("") to resolve the default
-    /// <see cref="NpgsqlDataSource"/> instance.</param>
+    /// <returns>The service builder.</returns>
+    public static ServiceBuilder WithRegisteredDataSource(this ServiceBuilder builder)
+    {
+        return builder.WithSettings(
+            (opts, sp, key) => opts.DataSourceFactory = _ => GetRegisteredDataSource(sp, key)
+        );
+    }
+
+    /// <summary>
+    /// Configures the leader election to use the <see cref="NpgsqlDataSource"/> registered
+    /// in the DI container with the specified service key.
+    /// </summary>
+    /// <param name="builder">The service builder.</param>
+    /// <param name="datasourceServiceKey">The service key of the specific <see cref="NpgsqlDataSource"/>
+    /// instance to resolve. Use <c>null</c> to resolve the default instance.</param>
     /// <returns>The service builder.</returns>
     public static ServiceBuilder WithRegisteredDataSource(
         this ServiceBuilder builder,
-        object? datasourceServiceKey = null
+        object? datasourceServiceKey
     )
     {
         return builder.WithSettings(
             (opts, sp, key) =>
                 opts.DataSourceFactory = _ =>
-                    datasourceServiceKey != null
-                        ? sp.GetRequiredKeyedService<NpgsqlDataSource>(datasourceServiceKey)
-                        : GetRegisteredDataSource(sp, key)
+                    sp.GetRequiredKeyedService<NpgsqlDataSource>(datasourceServiceKey)
         );
     }
 

--- a/src/LeaderElection.Postgres/PostgresServiceBuilderExtensions.cs
+++ b/src/LeaderElection.Postgres/PostgresServiceBuilderExtensions.cs
@@ -58,7 +58,7 @@ public static class PostgresServiceBuilderExtensions
             PostgresSettingsValidator
         >(serviceKey);
 
-        services.AddTransient<ConnectionCreator>();
+        services.AddTransient<DataSourceCreator>();
 
         services.AddKeyedSingleton<PostgresLeaderElection>(
             serviceKey,
@@ -68,23 +68,23 @@ public static class PostgresServiceBuilderExtensions
                 var settings = sp.GetRequiredService<IOptionsMonitor<PostgresSettings>>()
                     .Get(key as string);
 
-                // Note: We must resolve the connection here. If we don't do it now
-                // and the factory resolves it from DI, then the connection (or its dependencies)
+                // Note: We must resolve the DataSource here. If we don't do it now
+                // and the factory resolves it from DI later, then the DataSource
                 // may be disposed before the LeaderElection resulting in a crash.
-                var connection =
+                var datasource =
                     (
-                        settings.ConnectionFactory
+                        settings.DataSourceFactory
                         ?? throw new InvalidOperationException(
-                            "ConnectionFactory must be specified in settings."
+                            "DataSourceFactory must be specified in settings."
                         )
                     ).Invoke(settings)
-                    ?? throw new InvalidOperationException("ConnectionFactory returned null.");
+                    ?? throw new InvalidOperationException("DataSourceFactory returned null.");
 
                 // create instance
                 return ActivatorUtilities.CreateInstance<PostgresLeaderElection>(
                     sp,
                     settings,
-                    connection
+                    datasource
                 );
             }
         );
@@ -96,21 +96,18 @@ public static class PostgresServiceBuilderExtensions
 
         builder.Invoke(new ServiceBuilder(serviceKey, configBuilder));
 
-        // resolve the connection from DI if a ConnectionFactory or ConnectionString is not set
+        // resolve the datasource from DI if a DataSourceFactory or ConnectionString is not set
         configBuilder.PostConfigure<IServiceProvider>(
             (opts, sp) =>
-                opts.ConnectionFactory ??= settings =>
+            {
+                opts.DataSourceFactory ??= settings =>
                 {
-                    // If a ConnectionString is provided, use the default factory which creates
-                    // and disposes the connection for each instance.
-                    if (!string.IsNullOrEmpty(settings.ConnectionString))
-                    {
-                        return sp.GetRequiredService<ConnectionCreator>()
-                            .CreateConnection(settings);
-                    }
-
-                    return GetRegisteredConnection(sp, serviceKey);
-                }
+                    // If a ConnectionString is provided, use a DataSourceCreator else use the registered DataSource
+                    return !string.IsNullOrEmpty(settings.ConnectionString)
+                        ? sp.GetRequiredService<DataSourceCreator>().CreateDataSource(settings)
+                        : GetRegisteredDataSource(sp, serviceKey);
+                };
+            }
         );
 
         return services;
@@ -175,9 +172,9 @@ public static class PostgresServiceBuilderExtensions
     /// <summary>
     /// Specifies the instance ID to use for the Leader Election.
     /// </summary>
-    /// <param name="builder"></param>
-    /// <param name="instanceId"></param>
-    /// <returns></returns>
+    /// <param name="builder">The service builder.</param>
+    /// <param name="instanceId">The instance ID to use.</param>
+    /// <returns>The service builder.</returns>
     public static ServiceBuilder WithInstanceId(this ServiceBuilder builder, string instanceId)
     {
         ArgumentNullException.ThrowIfNullOrEmpty(instanceId);
@@ -185,13 +182,26 @@ public static class PostgresServiceBuilderExtensions
     }
 
     /// <summary>
-    /// Configures the leader election to use the NpgsqlConnection registered
+    /// Configures the leader election to use the <see cref="NpgsqlDataSource"/> registered
     /// in the DI container.
     /// </summary>
-    public static ServiceBuilder WithRegisteredConnection(this ServiceBuilder builder)
+    /// <param name="builder">The service builder.</param>
+    /// <param name="datasourceServiceKey">Optional service key to resolve a specific <see cref="NpgsqlDataSource"/>
+    /// instance if multiple are registered. Defaults to the service key of the registered
+    /// <see cref="PostgresLeaderElection"/>. Use an empty string ("") to resolve the default
+    /// <see cref="NpgsqlDataSource"/> instance.</param>
+    /// <returns>The service builder.</returns>
+    public static ServiceBuilder WithRegisteredDataSource(
+        this ServiceBuilder builder,
+        object? datasourceServiceKey = null
+    )
     {
         return builder.WithSettings(
-            (opts, sp, key) => opts.ConnectionFactory = _ => GetRegisteredConnection(sp, key)
+            (opts, sp, key) =>
+                opts.DataSourceFactory = _ =>
+                    datasourceServiceKey != null
+                        ? sp.GetRequiredKeyedService<NpgsqlDataSource>(datasourceServiceKey)
+                        : GetRegisteredDataSource(sp, key)
         );
     }
 
@@ -218,35 +228,72 @@ public static class PostgresServiceBuilderExtensions
         return builder;
     }
 
-    private static NpgsqlConnection GetRegisteredConnection(
+    private static NpgsqlDataSource GetRegisteredDataSource(
         IServiceProvider sp,
-        string? serviceKey = null
-    )
-    {
-        return sp.GetKeyedService<NpgsqlConnection>(serviceKey)
-            ?? sp.GetRequiredService<NpgsqlConnection>();
-    }
+        object? serviceKey = null
+    ) =>
+        (serviceKey != null ? sp.GetKeyedService<NpgsqlDataSource>(serviceKey) : null)
+        ?? sp.GetRequiredService<NpgsqlDataSource>();
 
-    // A private class used to create and dispose a connection when the
-    // connection string settings are used.
-    private class ConnectionCreator : IAsyncDisposable
+    // A private class used to create and dispose a DataSource when the
+    // connection string settings are used. This class is registered with a transient
+    // lifetime, so a new instance will be created each time it's needed, and it will
+    // be disposed after use. In our use case (creating a singleton LeaderElection),
+    // the DataSourceCreator's lifetime will be extended to match the LeaderElection.
+    private class DataSourceCreator : IAsyncDisposable
     {
-        public NpgsqlConnection? _connection;
+        private NpgsqlDataSource? _dataSource;
 
-        public NpgsqlConnection CreateConnection(PostgresSettings settings)
+        public NpgsqlDataSource CreateDataSource(PostgresSettings settings)
         {
-            ArgumentNullException.ThrowIfNull(settings);
-            if (string.IsNullOrWhiteSpace(settings.ConnectionString))
+            ArgumentNullException.ThrowIfNullOrEmpty(settings.ConnectionString);
+            var builder = new NpgsqlDataSourceBuilder(settings.ConnectionString);
+
+            // Let's configure the DataSource with some sane defaults for LeaderElection
+            // use cases (e.g. advisory locks). The user can always override these settings
+            // by including them in the connection string or by providing their own
+            // DataSourceFactory.
+
+            void SetDefault<T>(string key, T value)
             {
-                throw new InvalidOperationException(
-                    "ConnectionString must be specified in settings to use the default Connection factory."
+                if (!builder.ConnectionStringBuilder.ContainsKey(key))
+                {
+                    builder.ConnectionStringBuilder[key] = value;
+                }
+            }
+
+            // In multi-host configurations, Npgsql will automatically route to a backup if the primary
+            // is unavailable, resulting in unpredictable/orphaned locks. To avoid this, always specify
+            // a TargetSessionAttributes value...
+            if (
+                builder.ConnectionStringBuilder.Host?.Contains(
+                    ',',
+                    StringComparison.OrdinalIgnoreCase
+                ) == true
+            )
+            {
+                // Connect to the primary (read-write) server (advisory locks do not replicate)
+                // "primary" also works, although the primary is not always writable, so
+                // "read-write" is safer when the connection might be used for more than locking.
+                SetDefault(
+                    nameof(builder.ConnectionStringBuilder.TargetSessionAttributes),
+                    "read-write"
                 );
             }
 
-            _connection = new NpgsqlConnection(settings.ConnectionString);
-            return _connection;
+            // Use a short keep-alive to detect connection issues faster (e.g. if the database goes away or there's a network partition).
+            SetDefault(nameof(builder.ConnectionStringBuilder.KeepAlive), 20); // max idle connection (in seconds)
+            SetDefault(nameof(builder.ConnectionStringBuilder.TcpKeepAlive), true); // enable aggressive TCP keep-alive
+            SetDefault(nameof(builder.ConnectionStringBuilder.TcpKeepAliveTime), 5); // may be ignored by OS
+
+            // Use short timeouts to avoid long waits if the database becomes unresponsive.
+            SetDefault(nameof(builder.ConnectionStringBuilder.Timeout), 5); // connection timeout
+            SetDefault(nameof(builder.ConnectionStringBuilder.CommandTimeout), 3); // command timeout
+
+            _dataSource = builder.Build();
+            return _dataSource;
         }
 
-        public ValueTask DisposeAsync() => _connection?.DisposeAsync() ?? new ValueTask();
+        public ValueTask DisposeAsync() => _dataSource?.DisposeAsync() ?? new();
     }
 }

--- a/src/LeaderElection.Postgres/PostgresServiceBuilderExtensions.cs
+++ b/src/LeaderElection.Postgres/PostgresServiceBuilderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Data.Common;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -262,14 +263,13 @@ public static class PostgresServiceBuilderExtensions
             // use cases (e.g. advisory locks). The user can always override these settings
             // by including them in the connection string or by providing their own
             // DataSourceFactory.
-
-            void SetDefault<T>(string key, T value)
+            // NpgsqlConnectionStringBuilder pre-populates some keys making it impossible
+            // to check if they were set by the user or not, so use DbConnectionStringBuilder
+            // to check for the presence of keys.
+            var rawCheck = new DbConnectionStringBuilder
             {
-                if (!builder.ConnectionStringBuilder.ContainsKey(key))
-                {
-                    builder.ConnectionStringBuilder[key] = value;
-                }
-            }
+                ConnectionString = settings.ConnectionString,
+            };
 
             // In multi-host configurations, Npgsql will automatically route to a backup if the primary
             // is unavailable, resulting in unpredictable/orphaned locks. To avoid this, always specify
@@ -284,22 +284,28 @@ public static class PostgresServiceBuilderExtensions
                 // Connect to the primary (read-write) server (advisory locks do not replicate)
                 // "primary" also works, although the primary is not always writable, so
                 // "read-write" is safer when the connection might be used for more than locking.
-                SetDefault(
-                    nameof(builder.ConnectionStringBuilder.TargetSessionAttributes),
-                    "read-write"
-                );
+                if (
+                    !rawCheck.ContainsKey("TargetSessionAttributes")
+                    && !rawCheck.ContainsKey("Target Session Attributes")
+                    //spell:ignore PGTARGETSESSIONATTRS
+                    && Environment.GetEnvironmentVariable("PGTARGETSESSIONATTRS") == null
+                )
+                {
+                    builder.ConnectionStringBuilder.TargetSessionAttributes = "read-write";
+                }
             }
 
-            // Use a short keep-alive to detect connection issues faster (e.g. if the database goes away or there's a network partition).
-            SetDefault(nameof(builder.ConnectionStringBuilder.KeepAlive), 20); // max idle connection (in seconds)
-            SetDefault(nameof(builder.ConnectionStringBuilder.TcpKeepAlive), true); // enable aggressive TCP keep-alive
-            SetDefault(nameof(builder.ConnectionStringBuilder.TcpKeepAliveTime), 5); // may be ignored by OS
-
             // Use short timeouts to avoid long waits if the database becomes unresponsive.
-            SetDefault(nameof(builder.ConnectionStringBuilder.Timeout), 5); // connection timeout
-            SetDefault(nameof(builder.ConnectionStringBuilder.CommandTimeout), 3); // command timeout
+            if (!rawCheck.ContainsKey("Timeout"))
+                builder.ConnectionStringBuilder.Timeout = 5; // Connection timeout
+            if (!rawCheck.ContainsKey("CommandTimeout") && !rawCheck.ContainsKey("Command Timeout"))
+                builder.ConnectionStringBuilder.CommandTimeout = 3;
 
             _dataSource = builder.Build();
+
+            // Update settings with the final connection string (including any defaults we applied)
+            settings.ConnectionString = _dataSource.ConnectionString;
+
             return _dataSource;
         }
 

--- a/src/LeaderElection.Postgres/PostgresSettings.cs
+++ b/src/LeaderElection.Postgres/PostgresSettings.cs
@@ -2,23 +2,28 @@ using Npgsql;
 
 namespace LeaderElection.Postgres;
 
+/// <summary>
+/// Settings for PostgreSQL-based leader election.
+/// </summary>
 public class PostgresSettings : LeaderElectionSettingsBase
 {
     /// <summary>
-    /// Factory function to create a new <see cref="NpgsqlConnection"/>.
+    /// An optional factory function used to obtain an <see cref="NpgsqlConnection"/>.
     /// </summary>
     /// <remarks>
     /// If not provided, a connection will be created using the
-    /// <see cref="ConnectionString"/> property, or if that is not set,
+    /// <see cref="ConnectionString"/> property. If that is null or empty,
     /// it will attempt to obtain a <see cref="NpgsqlConnection"/> from DI
     /// (assuming the leader election is created via DI).
     /// </remarks>
     public Func<PostgresSettings, NpgsqlConnection>? ConnectionFactory { get; set; }
 
     /// <summary>
-    /// Connection string for the <see cref="NpgsqlConnection"/>.
-    /// Ignored if <see cref="ConnectionFactory"/> is set.
+    /// Optional connection string for the <see cref="NpgsqlConnection"/>.
     /// </summary>
+    /// <remarks>
+    /// Ignored if <see cref="ConnectionFactory"/> is set.
+    /// </remarks>
     public string? ConnectionString { get; set; }
 
     /// <summary>
@@ -34,8 +39,8 @@ public class PostgresSettings : LeaderElectionSettingsBase
         ArgumentNullException.ThrowIfNull(src);
         ArgumentNullException.ThrowIfNull(dst);
         LeaderElectionSettingsBase.Copy(src, dst);
-        dst.ConnectionString = src.ConnectionString;
         dst.ConnectionFactory = src.ConnectionFactory;
+        dst.ConnectionString = src.ConnectionString;
         dst.LockId = src.LockId;
     }
 }

--- a/src/LeaderElection.Postgres/PostgresSettings.cs
+++ b/src/LeaderElection.Postgres/PostgresSettings.cs
@@ -1,21 +1,41 @@
-using System.ComponentModel.DataAnnotations;
+using Npgsql;
 
 namespace LeaderElection.Postgres;
 
 public class PostgresSettings : LeaderElectionSettingsBase
 {
     /// <summary>
-    /// Connection string for the PostgreSQL database.
+    /// Factory function to create a new <see cref="NpgsqlConnection"/>.
     /// </summary>
-    [Required]
-#if NET7_0_OR_GREATER
-    public required string ConnectionString { get; set; }
-#else
-    public string ConnectionString { get; set; } = null!;
-#endif
+    /// <remarks>
+    /// If not provided, a connection will be created using the
+    /// <see cref="ConnectionString"/> property, or if that is not set,
+    /// it will attempt to obtain a <see cref="NpgsqlConnection"/> from DI
+    /// (assuming the leader election is created via DI).
+    /// </remarks>
+    public Func<PostgresSettings, NpgsqlConnection>? ConnectionFactory { get; set; }
+
+    /// <summary>
+    /// Connection string for the <see cref="NpgsqlConnection"/>.
+    /// Ignored if <see cref="ConnectionFactory"/> is set.
+    /// </summary>
+    public string? ConnectionString { get; set; }
 
     /// <summary>
     /// The 64-bit advisory lock key to use for leader election.
     /// </summary>
     public long LockId { get; set; }
+
+    /// <summary>
+    /// Copies the PostgreSQL settings from the source to the destination.
+    /// </summary>
+    public static void Copy(PostgresSettings src, PostgresSettings dst)
+    {
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(dst);
+        LeaderElectionSettingsBase.Copy(src, dst);
+        dst.ConnectionString = src.ConnectionString;
+        dst.ConnectionFactory = src.ConnectionFactory;
+        dst.LockId = src.LockId;
+    }
 }

--- a/src/LeaderElection.Postgres/PostgresSettings.cs
+++ b/src/LeaderElection.Postgres/PostgresSettings.cs
@@ -8,21 +8,21 @@ namespace LeaderElection.Postgres;
 public class PostgresSettings : LeaderElectionSettingsBase
 {
     /// <summary>
-    /// An optional factory function used to obtain an <see cref="NpgsqlConnection"/>.
+    /// An optional factory function used to obtain an <see cref="NpgsqlDataSource"/>.
     /// </summary>
     /// <remarks>
-    /// If not provided, a connection will be created using the
+    /// If not provided, a DataSource will be created using the
     /// <see cref="ConnectionString"/> property. If that is null or empty,
-    /// it will attempt to obtain a <see cref="NpgsqlConnection"/> from DI
+    /// it will attempt to obtain a <see cref="NpgsqlDataSource"/> from DI
     /// (assuming the leader election is created via DI).
     /// </remarks>
-    public Func<PostgresSettings, NpgsqlConnection>? ConnectionFactory { get; set; }
+    public Func<PostgresSettings, NpgsqlDataSource>? DataSourceFactory { get; set; }
 
     /// <summary>
-    /// Optional connection string for the <see cref="NpgsqlConnection"/>.
+    /// Optional connection string for the <see cref="NpgsqlDataSource"/>.
     /// </summary>
     /// <remarks>
-    /// Ignored if <see cref="ConnectionFactory"/> is set.
+    /// Ignored if <see cref="DataSourceFactory"/> is set.
     /// </remarks>
     public string? ConnectionString { get; set; }
 
@@ -39,7 +39,7 @@ public class PostgresSettings : LeaderElectionSettingsBase
         ArgumentNullException.ThrowIfNull(src);
         ArgumentNullException.ThrowIfNull(dst);
         LeaderElectionSettingsBase.Copy(src, dst);
-        dst.ConnectionFactory = src.ConnectionFactory;
+        dst.DataSourceFactory = src.DataSourceFactory;
         dst.ConnectionString = src.ConnectionString;
         dst.LockId = src.LockId;
     }

--- a/src/LeaderElection.Postgres/README.md
+++ b/src/LeaderElection.Postgres/README.md
@@ -96,7 +96,7 @@ public class Worker : BackgroundService
 | :----------------------- | :--------------- | :------------------------------------------------------------------------------------------------------------------------------ |
 | `DataSourceFactory`      | `null`           | A factory function used to create an `NpgsqlDataSource`. If not specified, the `ConnectionString` will be tried.                |
 | `ConnectionString`       | `null`           | The connection string for the PostgreSQL database. If not specified, the `NpgsqlDataSource` from the DI container will be used. |
-| `LockId`                 | (required)       | The unique 64-bit advisory lock id to use for leader election.                                                                  |
+| `LockId`                 | `0`              | The unique 64-bit advisory lock id to use for leader election.                                                                  |
 | `InstanceId`             | `Guid.NewGuid()` | Unique ID for this node.                                                                                                        |
 | `RetryInterval`          | `5s`             | The interval to wait before retrying a failed leadership acquisition.                                                           |
 | `RenewInterval`          | `10s`            | The interval at which the leader will attempt to renew its leadership.                                                          |

--- a/src/LeaderElection.Postgres/README.md
+++ b/src/LeaderElection.Postgres/README.md
@@ -28,16 +28,32 @@ dotnet add package LeaderElection.Postgres
 
 ```csharp
 using LeaderElection.Postgres;
+using Npgsql;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// Add Postgres leader election
-builder.Services.AddPostgresLeaderElection(options =>
-{
-    options.ConnectionString = "Host=localhost;Database=mydb;Username=myuser;Password=mypass";
-    options.LockId = 1337; // A unique 64-bit integer representing this specific lock
-    options.RetryInterval = TimeSpan.FromSeconds(5);
-});
+// Register a NpgsqlDataSource (from Npgsql.DependencyInjection) specifically for
+// Leader Election use...
+const string postgresLeaderElectionDataSource = "PostgresLeaderElectionDataSource";
+builder.Services.AddNpgsqlDataSource(
+    // Use short CommandTimeout to avoid long waits if the database becomes unresponsive.
+    "Host=localhost;Database=mydb;Username=myuser;Password=mypass;Timeout=5;CommandTimeout=3;",
+    serviceKey: postgresLeaderElectionDataSource,
+);
+
+builder.Services.AddPostgresLeaderElection(builder =>
+    builder
+        .WithRegisteredDataSource(postgresLeaderElectionDataSource)
+        .WithSettings(options =>
+        {
+            options.LockId = 1337; // A unique 64-bit integer representing this specific lock
+
+            // Use a short RenewInterval to quickly detect and recover from failed leaders.
+            // Note that the actual detection time will be at least the sum of the CommandTimeout
+            // and RenewInterval, so keep CommandTimeout low as well.
+            options.RenewInterval = TimeSpan.FromSeconds(5); // aggressive renew
+        })
+);
 ```
 
 ### 3. Use in Your Service
@@ -76,13 +92,15 @@ public class Worker : BackgroundService
 
 ## Configuration (PostgresSettings)
 
-| Property                 | Default                   | Description                                                           |
-| :----------------------- | :------------------------ | :-------------------------------------------------------------------- |
-| `ConnectionString`       | `(required)`              | The connection string for the PostgreSQL database.                    |
-| `LockId`                 | `(required)`              | The unique 64-bit advisory lock key to use for leader election.       |
-| `InstanceId`             | `Environment.MachineName` | Unique ID for this node.                                              |
-| `RetryInterval`          | `5s`                      | The interval to wait before retrying a failed leadership acquisition. |
-| `EnableGracefulShutdown` | `true`                    | If true, explicitly unlocks via `pg_advisory_unlock` on stop.         |
+| Property                 | Default          | Description                                                                                                                     |
+| :----------------------- | :--------------- | :------------------------------------------------------------------------------------------------------------------------------ |
+| `DataSourceFactory`      | `null`           | A factory function used to create an `NpgsqlDataSource`. If not specified, the `ConnectionString` will be tried.                |
+| `ConnectionString`       | `null`           | The connection string for the PostgreSQL database. If not specified, the `NpgsqlDataSource` from the DI container will be used. |
+| `LockId`                 | (required)       | The unique 64-bit advisory lock id to use for leader election.                                                                  |
+| `InstanceId`             | `Guid.NewGuid()` | Unique ID for this node.                                                                                                        |
+| `RetryInterval`          | `5s`             | The interval to wait before retrying a failed leadership acquisition.                                                           |
+| `RenewInterval`          | `10s`            | The interval at which the leader will attempt to renew its leadership.                                                          |
+| `EnableGracefulShutdown` | `true`           | If true, explicitly unlocks via `pg_advisory_unlock` on stop. It is highly recommended to leave this enabled.                   |
 
 ## PostgreSQL Specifics
 
@@ -97,6 +115,22 @@ for traditional polling or lease-expiration timers.
 Additionally, to prevent silent network partitions from locking up the system, the leader election
 class periodically executes a lightweight `SELECT 1;` to verify the physical connection is still
 healthy and the lock holds true.
+
+## PostgreSQL Requirements
+
+- The database is required to implement a **Single-Primary** topology since this Leader Election
+  algorithm relies on **advisory locks**, which are not replicated in multi-host configurations.
+
+- In multi-host configurations (e.g., `host=host1,host2,etc`), an explicit
+  `TargetSessionAttributes=read-write` (or `primary`) is required in order to ensure all
+  leader-election candidates are connected to the same instance. An error will be thrown if the
+  connection string contains multiple hosts without the required `TargetSessionAttributes`.
+
+- Multiplexing is not supported. An error will be thrown if the connection string contains
+  `Multiplexing=true`.
+
+- The PostgreSQL user must have permissions to execute `pg_try_advisory_lock` and
+  `pg_advisory_unlock` functions, which are typically granted by default to all users.
 
 ## Contributing
 

--- a/src/LeaderElection.Redis/LeaderElection.Redis.csproj
+++ b/src/LeaderElection.Redis/LeaderElection.Redis.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="StackExchange.Redis" />

--- a/src/LeaderElection.Redis/RedisLeaderElection.cs
+++ b/src/LeaderElection.Redis/RedisLeaderElection.cs
@@ -106,7 +106,7 @@ public partial class RedisLeaderElection : LeaderElectionBase<RedisSettings>
             if (!success)
             {
                 // give up the lock in our state to avoid being stuck in a bad state
-                ForceReset();
+                await ResetLeadershipAsync().ConfigureAwait(false);
             }
         }
 
@@ -149,13 +149,14 @@ public partial class RedisLeaderElection : LeaderElectionBase<RedisSettings>
         finally
         {
             // give up the lock in our state to avoid being stuck in a bad state
-            ForceReset();
+            await ResetLeadershipAsync().ConfigureAwait(false);
         }
     }
 
-    void ForceReset()
+    protected override ValueTask ResetLeadershipAsync()
     {
         _redis = null;
+        return new ValueTask();
     }
 
     [LoggerMessage(LogLevel.Debug, "Lock already acquired on {LockKey}.")]

--- a/src/LeaderElection.Redis/RedisLeaderElection.cs
+++ b/src/LeaderElection.Redis/RedisLeaderElection.cs
@@ -10,15 +10,20 @@ namespace LeaderElection.Redis;
 /// </summary>
 public partial class RedisLeaderElection : LeaderElectionBase<RedisSettings>
 {
+    private readonly IConnectionMultiplexer _connectionMultiplexer;
     private IDatabase? _redis;
 
     public RedisLeaderElection(
         RedisSettings options,
+        IConnectionMultiplexer connectionMultiplexer,
         ILogger<RedisLeaderElection>? logger = null,
         TimeProvider? timeProvider = null
     )
         : base(options ?? throw new ArgumentNullException(nameof(options)), logger, timeProvider)
-    { }
+    {
+        ArgumentNullException.ThrowIfNull(connectionMultiplexer);
+        _connectionMultiplexer = connectionMultiplexer;
+    }
 
     protected override async Task<bool> TryAcquireLeadershipInternalAsync(
         CancellationToken cancellationToken
@@ -30,9 +35,7 @@ public partial class RedisLeaderElection : LeaderElectionBase<RedisSettings>
             return false;
         }
 
-        var connectionMultiplexer = await GetConnectionMultiplexer(cancellationToken)
-            .ConfigureAwait(false);
-        var redis = connectionMultiplexer.GetDatabase(_settings.Database);
+        var redis = _connectionMultiplexer.GetDatabase(_settings.Database);
 
         var success = await redis
             .StringSetAsync(
@@ -150,50 +153,10 @@ public partial class RedisLeaderElection : LeaderElectionBase<RedisSettings>
         }
     }
 
-    private async Task<IConnectionMultiplexer> GetConnectionMultiplexer(CancellationToken ct)
-    {
-        if (_settings.ConnectionMultiplexerFactory != null)
-        {
-            if (!string.IsNullOrWhiteSpace(_settings.Host))
-            {
-                LogIgnoringHostBecauseFactoryIsSet();
-            }
-
-            var multiplexer = await _settings
-                .ConnectionMultiplexerFactory(_settings, ct)
-                .ConfigureAwait(false);
-            return multiplexer
-                ?? throw new InvalidOperationException(
-                    "ConnectionMultiplexerFactory returned null."
-                );
-        }
-
-        if (!string.IsNullOrWhiteSpace(_settings.Host))
-        {
-            return await ConnectionMultiplexer
-                .ConnectAsync(
-                    new ConfigurationOptions
-                    {
-                        EndPoints = { { _settings.Host, _settings.Port } },
-                        Password = _settings.Password,
-                        DefaultDatabase = _settings.Database,
-                    }
-                )
-                .ConfigureAwait(false);
-        }
-
-        throw new InvalidOperationException(
-            "Either ConnectionMultiplexerFactory or Host must be specified in settings."
-        );
-    }
-
     void ForceReset()
     {
         _redis = null;
     }
-
-    [LoggerMessage(LogLevel.Warning, "Ignoring Host because ConnectionMultiplexerFactory is set.")]
-    partial void LogIgnoringHostBecauseFactoryIsSet();
 
     [LoggerMessage(LogLevel.Debug, "Lock already acquired on {LockKey}.")]
     partial void LogLockAlreadyAcquired(string lockKey);

--- a/src/LeaderElection.Redis/RedisLeaderElection.cs
+++ b/src/LeaderElection.Redis/RedisLeaderElection.cs
@@ -132,12 +132,12 @@ public partial class RedisLeaderElection : LeaderElectionBase<RedisSettings>
                 end
                 """;
 
-            var keysRemoves = (int)
+            var keysRemoved = (int)
                 await _redis
                     .ScriptEvaluateAsync(script, [_settings.LockKey], [_settings.InstanceId])
                     .ConfigureAwait(false);
 
-            if (keysRemoves > 0)
+            if (keysRemoved > 0)
             {
                 LogLockReleased(_settings.LockKey);
             }

--- a/src/LeaderElection.Redis/RedisLeaderElection.cs
+++ b/src/LeaderElection.Redis/RedisLeaderElection.cs
@@ -173,7 +173,8 @@ public partial class RedisLeaderElection : LeaderElectionBase<RedisSettings>
     [LoggerMessage(LogLevel.Debug, "Lock renewed on {LockKey}.")]
     partial void LogLockRenewed(string lockKey);
 
-    [LoggerMessage(LogLevel.Information, "Failure renewing lock on {LockKey}.")]
+    // this is unexpected since we should have the lock. Log as a warning.
+    [LoggerMessage(LogLevel.Warning, "Failure renewing lock on {LockKey}.")]
     partial void LogFailureRenewingLock(string lockKey);
 
     [LoggerMessage(LogLevel.Error, "No lock to release.")]
@@ -182,6 +183,7 @@ public partial class RedisLeaderElection : LeaderElectionBase<RedisSettings>
     [LoggerMessage(LogLevel.Debug, "Lock released on {LockKey}.")]
     partial void LogLockReleased(string lockKey);
 
-    [LoggerMessage(LogLevel.Information, "Failure releasing lock on {LockKey}.")]
+    // this is unexpected since we should have the lock. Log as a warning.
+    [LoggerMessage(LogLevel.Warning, "Failure releasing lock on {LockKey}.")]
     partial void LogFailureReleasingLock(string lockKey);
 }

--- a/src/LeaderElection.Redis/RedisLeaderElection.cs
+++ b/src/LeaderElection.Redis/RedisLeaderElection.cs
@@ -12,8 +12,13 @@ public partial class RedisLeaderElection : LeaderElectionBase<RedisSettings>
 {
     private IDatabase? _redis;
 
-    public RedisLeaderElection(RedisSettings options, ILogger<RedisLeaderElection> logger)
-        : base(options ?? throw new ArgumentNullException(nameof(options)), logger) { }
+    public RedisLeaderElection(
+        RedisSettings options,
+        ILogger<RedisLeaderElection>? logger = null,
+        TimeProvider? timeProvider = null
+    )
+        : base(options ?? throw new ArgumentNullException(nameof(options)), logger, timeProvider)
+    { }
 
     protected override async Task<bool> TryAcquireLeadershipInternalAsync(
         CancellationToken cancellationToken

--- a/src/LeaderElection.Redis/RedisLeaderElection.cs
+++ b/src/LeaderElection.Redis/RedisLeaderElection.cs
@@ -1,119 +1,219 @@
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 
 namespace LeaderElection.Redis;
 
+/// <summary>
+/// Leader Election implementation that uses Redis for leader election. Each contender
+/// will attempt to set a "lock key" in Redis with a unique instance ID and an expiration
+/// time. The instance that successfully sets the lock key is considered the leader.
+/// </summary>
 public partial class RedisLeaderElection : LeaderElectionBase<RedisSettings>
 {
-    private readonly IDatabase _redis;
+    private IDatabase? _redis;
 
-    public RedisLeaderElection(
-        IConnectionMultiplexer connectionMultiplexer,
-        IOptions<RedisSettings> options,
-        ILogger<RedisLeaderElection> logger
-    )
-        : base(options?.Value ?? throw new ArgumentNullException(nameof(options)), logger)
-    {
-        _ = connectionMultiplexer ?? throw new ArgumentNullException(nameof(connectionMultiplexer));
-        this._redis =
-            connectionMultiplexer.GetDatabase()
-            ?? throw new ArgumentNullException(nameof(connectionMultiplexer));
-    }
+    public RedisLeaderElection(RedisSettings options, ILogger<RedisLeaderElection> logger)
+        : base(options ?? throw new ArgumentNullException(nameof(options)), logger) { }
 
     protected override async Task<bool> TryAcquireLeadershipInternalAsync(
         CancellationToken cancellationToken
     )
     {
-        try
+        if (_redis != null)
         {
-            var result = await _redis
-                .StringSetAsync(
-                    key: _settings.LockKey,
-                    value: _settings.InstanceId,
-                    expiry: _settings.LockExpiry,
-                    when: When.NotExists
-                )
-                .ConfigureAwait(false);
-
-            return result;
-        }
-        catch (Exception ex)
-        {
-            LogErrorAcquiringLeadership(_logger, ex);
+            LogLockAlreadyAcquired(_settings.LockKey);
             return false;
         }
+
+        var connectionMultiplexer = await GetConnectionMultiplexer(cancellationToken)
+            .ConfigureAwait(false);
+        var redis = connectionMultiplexer.GetDatabase(_settings.Database);
+
+        var success = await redis
+            .StringSetAsync(
+                key: _settings.LockKey,
+                value: _settings.InstanceId,
+                expiry: _settings.LockExpiry,
+                when: When.NotExists
+            )
+            .ConfigureAwait(false);
+
+        if (success)
+        {
+            _redis = redis;
+            LogLockAcquired(_settings.LockKey);
+        }
+        else
+        {
+            // Log at debug level since it's expected that multiple contenders will fail to acquire the lock
+            LogFailureAcquiringLock(_settings.LockKey);
+        }
+
+        return success;
     }
 
     protected override async Task<bool> RenewLeadershipInternalAsync(
         CancellationToken cancellationToken
     )
     {
+        if (_redis == null)
+        {
+            LogNoLockToRenew();
+            return false;
+        }
+
+        var success = false;
         try
         {
-            var script =
-                @"
+            var script = """
                 if redis.call('GET', KEYS[1]) == ARGV[1]
                 then
                     return redis.call('PEXPIRE', KEYS[1], ARGV[2])
                 else
                     return 0
-                end";
+                end
+                """;
 
-            var result = await _redis
-                .ScriptEvaluateAsync(
-                    script,
-                    [_settings.LockKey],
-                    [_settings.InstanceId, (int)_settings.LockExpiry.TotalMilliseconds]
-                )
-                .ConfigureAwait(false);
+            var result = (int)
+                await _redis
+                    .ScriptEvaluateAsync(
+                        script,
+                        [_settings.LockKey],
+                        [_settings.InstanceId, (int)_settings.LockExpiry.TotalMilliseconds]
+                    )
+                    .ConfigureAwait(false);
 
-            return (int)result != 0;
+            if (result > 0)
+            {
+                success = true;
+                LogLockRenewed(_settings.LockKey);
+            }
+            else
+            {
+                LogFailureRenewingLock(_settings.LockKey);
+            }
         }
-        catch (Exception ex)
+        finally
         {
-            LogErrorRenewingLeadership(_logger, ex);
-            return false;
+            if (!success)
+            {
+                // give up the lock in our state to avoid being stuck in a bad state
+                ForceReset();
+            }
         }
+
+        return success;
     }
 
     protected override async Task ReleaseLeadershipAsync()
     {
+        if (_redis == null)
+        {
+            LogNoLockToRelease();
+            return;
+        }
+
         try
         {
-            var script =
-                @"
+            var script = """
                 if redis.call('GET', KEYS[1]) == ARGV[1]
                 then
                     return redis.call('DEL', KEYS[1])
                 else
                     return 0
-                end";
+                end
+                """;
 
-            await _redis
-                .ScriptEvaluateAsync(script, [_settings.LockKey], [_settings.InstanceId])
-                .ConfigureAwait(false);
+            var keysRemoves = (int)
+                await _redis
+                    .ScriptEvaluateAsync(script, [_settings.LockKey], [_settings.InstanceId])
+                    .ConfigureAwait(false);
 
-            LogLeadershipReleasedForInstanceInstanceId(_logger, _settings.InstanceId);
+            if (keysRemoves > 0)
+            {
+                LogLockReleased(_settings.LockKey);
+            }
+            else
+            {
+                LogFailureReleasingLock(_settings.LockKey);
+            }
         }
-        catch (Exception ex)
+        finally
         {
-            LogErrorReleasingLeadership(_logger, ex);
+            // give up the lock in our state to avoid being stuck in a bad state
+            ForceReset();
         }
     }
 
-    [LoggerMessage(LogLevel.Error, "Error acquiring leadership")]
-    static partial void LogErrorAcquiringLeadership(ILogger logger, Exception exception);
+    private async Task<IConnectionMultiplexer> GetConnectionMultiplexer(CancellationToken ct)
+    {
+        if (_settings.ConnectionMultiplexerFactory != null)
+        {
+            if (!string.IsNullOrWhiteSpace(_settings.Host))
+            {
+                LogIgnoringHostBecauseFactoryIsSet();
+            }
 
-    [LoggerMessage(LogLevel.Error, "Error renewing leadership")]
-    static partial void LogErrorRenewingLeadership(ILogger logger, Exception exception);
+            var multiplexer = await _settings
+                .ConnectionMultiplexerFactory(_settings, ct)
+                .ConfigureAwait(false);
+            return multiplexer
+                ?? throw new InvalidOperationException(
+                    "ConnectionMultiplexerFactory returned null."
+                );
+        }
 
-    [LoggerMessage(LogLevel.Information, "Leadership released for instance {instanceId}")]
-    static partial void LogLeadershipReleasedForInstanceInstanceId(
-        ILogger logger,
-        string instanceId
-    );
+        if (!string.IsNullOrWhiteSpace(_settings.Host))
+        {
+            return await ConnectionMultiplexer
+                .ConnectAsync(
+                    new ConfigurationOptions
+                    {
+                        EndPoints = { { _settings.Host, _settings.Port } },
+                        Password = _settings.Password,
+                        DefaultDatabase = _settings.Database,
+                    }
+                )
+                .ConfigureAwait(false);
+        }
 
-    [LoggerMessage(LogLevel.Error, "Error releasing leadership")]
-    static partial void LogErrorReleasingLeadership(ILogger logger, Exception exception);
+        throw new InvalidOperationException(
+            "Either ConnectionMultiplexerFactory or Host must be specified in settings."
+        );
+    }
+
+    void ForceReset()
+    {
+        _redis = null;
+    }
+
+    [LoggerMessage(LogLevel.Warning, "Ignoring Host because ConnectionMultiplexerFactory is set.")]
+    partial void LogIgnoringHostBecauseFactoryIsSet();
+
+    [LoggerMessage(LogLevel.Debug, "Lock already acquired on {LockKey}.")]
+    partial void LogLockAlreadyAcquired(string lockKey);
+
+    [LoggerMessage(LogLevel.Debug, "Lock acquired on {LockKey}.")]
+    partial void LogLockAcquired(string lockKey);
+
+    [LoggerMessage(LogLevel.Debug, "Failure acquiring lock on {LockKey}.")]
+    partial void LogFailureAcquiringLock(string lockKey);
+
+    [LoggerMessage(LogLevel.Error, "No lock to renew.")]
+    partial void LogNoLockToRenew();
+
+    [LoggerMessage(LogLevel.Debug, "Lock renewed on {LockKey}.")]
+    partial void LogLockRenewed(string lockKey);
+
+    [LoggerMessage(LogLevel.Information, "Failure renewing lock on {LockKey}.")]
+    partial void LogFailureRenewingLock(string lockKey);
+
+    [LoggerMessage(LogLevel.Error, "No lock to release.")]
+    partial void LogNoLockToRelease();
+
+    [LoggerMessage(LogLevel.Debug, "Lock released on {LockKey}.")]
+    partial void LogLockReleased(string lockKey);
+
+    [LoggerMessage(LogLevel.Information, "Failure releasing lock on {LockKey}.")]
+    partial void LogFailureReleasingLock(string lockKey);
 }

--- a/src/LeaderElection.Redis/RedisServiceBuilderExtensions.cs
+++ b/src/LeaderElection.Redis/RedisServiceBuilderExtensions.cs
@@ -73,6 +73,11 @@ public static class RedisServiceBuilderExtensions
             RedisSettingsValidator
         >(serviceKey);
 
+        // Register a factory for creating and disposing a Redis connection multiplexer
+        // when the host/port settings are used. This is needed to ensure the connection
+        // multiplexer is disposed.
+        services.AddTransient<ConnectionMultiplexerCreator>();
+
         // Register the RedisLeaderElection as a keyed singleton. The factory
         // creates a new instance of the RedisLeaderElection for each unique
         // service key, using the corresponding settings and Redis connection multiplexer.
@@ -81,12 +86,30 @@ public static class RedisServiceBuilderExtensions
             serviceKey,
             static (sp, key) =>
             {
-                // get keyed settings
+                // get settings
                 var settings = sp.GetRequiredService<IOptionsMonitor<RedisSettings>>()
                     .Get(key as string);
 
+                // Note: We must resolve the connection multiplexer here. If we don't do it now
+                // and the factory resolves it from DI, then the connection multiplexer will be
+                // disposed before the LeaderElection resulting in a crash.
+                var connectionMultiplexer =
+                    (
+                        settings.ConnectionMultiplexerFactory
+                        ?? throw new InvalidOperationException(
+                            "ConnectionMultiplexerFactory must be specified in settings."
+                        )
+                    ).Invoke(settings)
+                    ?? throw new InvalidOperationException(
+                        "ConnectionMultiplexerFactory returned null."
+                    );
+
                 // create a new instance...
-                return ActivatorUtilities.CreateInstance<RedisLeaderElection>(sp, settings);
+                return ActivatorUtilities.CreateInstance<RedisLeaderElection>(
+                    sp,
+                    settings,
+                    connectionMultiplexer
+                );
             }
         );
 
@@ -103,11 +126,8 @@ public static class RedisServiceBuilderExtensions
         optionsBuilder.PostConfigure<IServiceProvider>(
             (opts, sp) =>
             {
-                if (string.IsNullOrWhiteSpace(opts.Host))
-                {
-                    opts.ConnectionMultiplexerFactory ??= (_, _) =>
-                        Task.FromResult(GetConnectionMultiplexer(sp, serviceKey));
-                }
+                opts.ConnectionMultiplexerFactory ??= settings =>
+                    GetDefaultConnectionMultiplexer(settings, sp, serviceKey);
             }
         );
 
@@ -217,22 +237,23 @@ public static class RedisServiceBuilderExtensions
     public static ServiceBuilder WithRegisteredCache(this ServiceBuilder builder) =>
         builder.WithSettings(
             (opts, sp, key) =>
-                opts.ConnectionMultiplexerFactory = (_, _) =>
-                    Task.FromResult(GetConnectionMultiplexer(sp, key))
+                opts.ConnectionMultiplexerFactory = _ => GetRegisteredConnectionMultiplexer(sp, key)
         );
 
     /// <summary>
     /// Specifies the connection multiplexer factory to use with the Leader Election.
     /// </summary>
+    /// <remarks>
+    /// This caller is responsible for ensuring the connection multiplexer is properly
+    /// disposed since it will be resolved from the factory and not tracked by the DI container.
+    /// </remarks>
     public static ServiceBuilder WithConnectionMultiplexer(
         this ServiceBuilder builder,
         IConnectionMultiplexer connectionMultiplexer
     )
     {
         ArgumentNullException.ThrowIfNull(connectionMultiplexer);
-        return builder.WithConnectionMultiplexerFactory(
-            (_, _, _) => Task.FromResult(connectionMultiplexer)
-        );
+        return builder.WithConnectionMultiplexerFactory((_, _) => connectionMultiplexer);
     }
 
     /// <summary>
@@ -240,22 +261,63 @@ public static class RedisServiceBuilderExtensions
     /// </summary>
     public static ServiceBuilder WithConnectionMultiplexerFactory(
         this ServiceBuilder builder,
-        Func<
-            IServiceProvider,
-            RedisSettings,
-            CancellationToken,
-            Task<IConnectionMultiplexer>
-        > factoryFunc
+        Func<IServiceProvider, RedisSettings, IConnectionMultiplexer> factoryFunc
     )
     {
         ArgumentNullException.ThrowIfNull(factoryFunc);
         return builder.WithSettings(
             (opts, sp, _) =>
-                opts.ConnectionMultiplexerFactory = (settings, ct) => factoryFunc(sp, settings, ct)
+                opts.ConnectionMultiplexerFactory = settings => factoryFunc(sp, settings)
         );
     }
 
-    private static IConnectionMultiplexer GetConnectionMultiplexer(
+    // A private class used to create and dispose a Redis connection multiplexer when the
+    // host/port settings are used.
+    private class ConnectionMultiplexerCreator : IDisposable
+    {
+        public ConnectionMultiplexer? _connectionMultiplexer;
+
+        public ConnectionMultiplexer CreateMultiplexer(RedisSettings settings)
+        {
+            ArgumentNullException.ThrowIfNull(settings);
+            if (string.IsNullOrWhiteSpace(settings.Host))
+            {
+                throw new InvalidOperationException(
+                    "Host must be specified in settings to use the default ConnectionMultiplexer factory."
+                );
+            }
+
+            _connectionMultiplexer = ConnectionMultiplexer.Connect(
+                new ConfigurationOptions
+                {
+                    EndPoints = { { settings.Host, settings.Port } },
+                    Password = settings.Password,
+                    DefaultDatabase = settings.Database,
+                }
+            );
+            return _connectionMultiplexer;
+        }
+
+        public void Dispose() => _connectionMultiplexer?.Dispose();
+    }
+
+    private static IConnectionMultiplexer GetDefaultConnectionMultiplexer(
+        RedisSettings settings,
+        IServiceProvider sp,
+        string? serviceKey
+    )
+    {
+        // If host is specified, use the default factory which creates a new connection multiplexer
+        if (!string.IsNullOrWhiteSpace(settings.Host))
+        {
+            return sp.GetRequiredService<ConnectionMultiplexerCreator>()
+                .CreateMultiplexer(settings);
+        }
+
+        return GetRegisteredConnectionMultiplexer(sp, serviceKey);
+    }
+
+    private static IConnectionMultiplexer GetRegisteredConnectionMultiplexer(
         IServiceProvider sp,
         string? serviceKey
     ) =>

--- a/src/LeaderElection.Redis/RedisServiceBuilderExtensions.cs
+++ b/src/LeaderElection.Redis/RedisServiceBuilderExtensions.cs
@@ -6,7 +6,6 @@ using StackExchange.Redis;
 namespace LeaderElection.Redis;
 
 public sealed record ServiceBuilder(
-    IServiceCollection Services,
     string? ServiceKey,
     OptionsBuilder<RedisSettings> OptionsBuilder
 );
@@ -120,7 +119,7 @@ public static class RedisServiceBuilderExtensions
 
         // Invoke builder action to allow user to specify a connection multiplexer
         // factory and settings
-        builder(new ServiceBuilder(services, serviceKey, optionsBuilder));
+        builder(new ServiceBuilder(serviceKey, optionsBuilder));
 
         // Ensure a default connection multiplexer factory is specified...
         optionsBuilder.PostConfigure<IServiceProvider>(

--- a/src/LeaderElection.Redis/RedisServiceBuilderExtensions.cs
+++ b/src/LeaderElection.Redis/RedisServiceBuilderExtensions.cs
@@ -13,11 +13,6 @@ public sealed record ServiceBuilder(
 public static class RedisServiceBuilderExtensions
 {
     /// <inheritdoc cref="AddRedisLeaderElectionInternal" />
-    /// <remarks>
-    /// This overload registers an unnamed ILeaderElection service which uses the
-    /// default Redis connection multiplexer factory (uses the host/port setting
-    /// if specified, otherwise it will use the registered IConnectionMultiplexer).
-    /// </remarks>
     /// <param name="configureOptions">An action to configure the <see cref="RedisSettings"/>
     /// used by the Leader Election.</param>
     public static IServiceCollection AddRedisLeaderElection(
@@ -26,11 +21,6 @@ public static class RedisServiceBuilderExtensions
     ) => services.AddRedisLeaderElection(builder => builder.WithSettings(configureOptions));
 
     /// <inheritdoc cref="AddRedisLeaderElectionInternal" />
-    /// <remarks>
-    /// This overload registers an unnamed ILeaderElection service which uses the
-    /// default Redis connection multiplexer factory (uses the host/port setting
-    /// if specified, otherwise it will use the registered IConnectionMultiplexer).
-    /// </remarks>
     /// <param name="options">The <see cref="RedisSettings"/> used by the Leader Election.</param>
     public static IServiceCollection AddRedisLeaderElection(
         this IServiceCollection services,
@@ -71,11 +61,6 @@ public static class RedisServiceBuilderExtensions
             RedisSettings,
             RedisSettingsValidator
         >(serviceKey);
-
-        // Register a factory for creating and disposing a Redis connection multiplexer
-        // when the host/port settings are used. This is needed to ensure the connection
-        // multiplexer is disposed.
-        services.AddTransient<ConnectionMultiplexerCreator>();
 
         // Register the RedisLeaderElection as a keyed singleton. The factory
         // creates a new instance of the RedisLeaderElection for each unique
@@ -125,8 +110,8 @@ public static class RedisServiceBuilderExtensions
         optionsBuilder.PostConfigure<IServiceProvider>(
             (opts, sp) =>
             {
-                opts.ConnectionMultiplexerFactory ??= settings =>
-                    GetDefaultConnectionMultiplexer(settings, sp, serviceKey);
+                opts.ConnectionMultiplexerFactory ??= _ =>
+                    GetRegisteredConnectionMultiplexer(sp, serviceKey);
             }
         );
 
@@ -268,52 +253,6 @@ public static class RedisServiceBuilderExtensions
             (opts, sp, _) =>
                 opts.ConnectionMultiplexerFactory = settings => factoryFunc(sp, settings)
         );
-    }
-
-    // A private class used to create and dispose a Redis connection multiplexer when the
-    // host/port settings are used.
-    private class ConnectionMultiplexerCreator : IDisposable
-    {
-        public ConnectionMultiplexer? _connectionMultiplexer;
-
-        public ConnectionMultiplexer CreateMultiplexer(RedisSettings settings)
-        {
-            ArgumentNullException.ThrowIfNull(settings);
-            if (string.IsNullOrWhiteSpace(settings.Host))
-            {
-                throw new InvalidOperationException(
-                    "Host must be specified in settings to use the default ConnectionMultiplexer factory."
-                );
-            }
-
-            _connectionMultiplexer = ConnectionMultiplexer.Connect(
-                new ConfigurationOptions
-                {
-                    EndPoints = { { settings.Host, settings.Port } },
-                    Password = settings.Password,
-                    DefaultDatabase = settings.Database,
-                }
-            );
-            return _connectionMultiplexer;
-        }
-
-        public void Dispose() => _connectionMultiplexer?.Dispose();
-    }
-
-    private static IConnectionMultiplexer GetDefaultConnectionMultiplexer(
-        RedisSettings settings,
-        IServiceProvider sp,
-        string? serviceKey
-    )
-    {
-        // If host is specified, use the default factory which creates a new connection multiplexer
-        if (!string.IsNullOrWhiteSpace(settings.Host))
-        {
-            return sp.GetRequiredService<ConnectionMultiplexerCreator>()
-                .CreateMultiplexer(settings);
-        }
-
-        return GetRegisteredConnectionMultiplexer(sp, serviceKey);
     }
 
     private static IConnectionMultiplexer GetRegisteredConnectionMultiplexer(

--- a/src/LeaderElection.Redis/RedisServiceBuilderExtensions.cs
+++ b/src/LeaderElection.Redis/RedisServiceBuilderExtensions.cs
@@ -46,7 +46,7 @@ public static class RedisServiceBuilderExtensions
     /// application. If not provided, the services and settings will be registered
     /// without a key.</param>
     /// <returns>The updated service collection.</returns>
-    public static IServiceCollection AddRedisLeaderElectionInternal(
+    private static IServiceCollection AddRedisLeaderElectionInternal(
         IServiceCollection services,
         Action<ServiceBuilder> builder,
         string? serviceKey = null

--- a/src/LeaderElection.Redis/RedisServiceBuilderExtensions.cs
+++ b/src/LeaderElection.Redis/RedisServiceBuilderExtensions.cs
@@ -1,44 +1,264 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
 
 namespace LeaderElection.Redis;
 
+public sealed record ServiceBuilder(
+    IServiceCollection Services,
+    string? ServiceKey,
+    OptionsBuilder<RedisSettings> OptionsBuilder
+);
+
 public static class RedisServiceBuilderExtensions
 {
+    /// <inheritdoc cref="AddRedisLeaderElectionInternal" />
+    /// <remarks>
+    /// This overload registers an unnamed ILeaderElection service which uses the
+    /// default Redis connection multiplexer factory (uses the host/port setting
+    /// if specified, otherwise it will use the registered IConnectionMultiplexer).
+    /// </remarks>
+    /// <param name="configureOptions">An action to configure the <see cref="RedisSettings"/>
+    /// used by the Leader Election.</param>
     public static IServiceCollection AddRedisLeaderElection(
         this IServiceCollection services,
         Action<RedisSettings> configureOptions
-    )
-    {
-        services
-            .AddOptionsWithValidateOnStart<RedisSettings, RedisSettingsValidator>()
-            .Configure(configureOptions);
+    ) => services.AddRedisLeaderElection(builder => builder.WithSettings(configureOptions));
 
-        services.AddSingleton<RedisLeaderElection>();
-        services.AddSingleton<ILeaderElection>(sp => sp.GetRequiredService<RedisLeaderElection>());
-
-        return services;
-    }
-
+    /// <inheritdoc cref="AddRedisLeaderElectionInternal" />
+    /// <remarks>
+    /// This overload registers an unnamed ILeaderElection service which uses the
+    /// default Redis connection multiplexer factory (uses the host/port setting
+    /// if specified, otherwise it will use the registered IConnectionMultiplexer).
+    /// </remarks>
+    /// <param name="options">The <see cref="RedisSettings"/> used by the Leader Election.</param>
     public static IServiceCollection AddRedisLeaderElection(
         this IServiceCollection services,
         RedisSettings options
+    ) => services.AddRedisLeaderElection(builder => builder.WithSettings(options));
+
+    /// <inheritdoc cref="AddRedisLeaderElectionInternal" />
+    public static IServiceCollection AddRedisLeaderElection(
+        this IServiceCollection services,
+        Action<ServiceBuilder> builder,
+        string? serviceKey = null
+    ) => AddRedisLeaderElectionInternal(services, builder, serviceKey);
+
+    /// <summary>
+    /// Adds Redis based leader election services to the specified
+    /// <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The service collection to add the services to.</param>
+    /// <param name="builder">An action used to configure the settings and Redis
+    /// connection multiplexer factory.</param>
+    /// <param name="serviceKey">An optional key to register the services and settings
+    /// with. This allows for multiple leader election registrations in the same
+    /// application. If not provided, the services and settings will be registered
+    /// without a key.</param>
+    /// <returns>The updated service collection.</returns>
+    public static IServiceCollection AddRedisLeaderElectionInternal(
+        IServiceCollection services,
+        Action<ServiceBuilder> builder,
+        string? serviceKey = null
     )
     {
-        services.AddRedisLeaderElection(opt =>
-        {
-            opt.Host = options.Host;
-            opt.Port = options.Port;
-            opt.Password = options.Password;
-            opt.Database = options.Database;
-            opt.LockKey = options.LockKey;
-            opt.InstanceId = options.InstanceId;
-            opt.LockExpiry = options.LockExpiry;
-            opt.RenewInterval = options.RenewInterval;
-            opt.RetryInterval = options.RetryInterval;
-            opt.MaxRetryAttempts = options.MaxRetryAttempts;
-            opt.EnableGracefulShutdown = options.EnableGracefulShutdown;
-        });
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(builder);
+
+        // Register options and leader election services with the specified service key
+        // (or no key if serviceKey is null)
+        var optionsBuilder = services.AddOptionsWithValidateOnStart<
+            RedisSettings,
+            RedisSettingsValidator
+        >(serviceKey);
+
+        // Register the RedisLeaderElection as a keyed singleton. The factory
+        // creates a new instance of the RedisLeaderElection for each unique
+        // service key, using the corresponding settings and Redis connection multiplexer.
+        // Note: AddKeyedSingleton(serviceKey: null) is the same as AddSingleton().
+        services.AddKeyedSingleton(
+            serviceKey,
+            static (sp, key) =>
+            {
+                // get keyed settings
+                var settings = sp.GetRequiredService<IOptionsMonitor<RedisSettings>>()
+                    .Get(key as string);
+
+                // create a new instance...
+                return ActivatorUtilities.CreateInstance<RedisLeaderElection>(sp, settings);
+            }
+        );
+
+        services.AddKeyedSingleton<ILeaderElection>(
+            serviceKey,
+            static (sp, key) => sp.GetRequiredKeyedService<RedisLeaderElection>(key)
+        );
+
+        // Invoke builder action to allow user to specify a connection multiplexer
+        // factory and settings
+        builder(new ServiceBuilder(services, serviceKey, optionsBuilder));
+
+        // Ensure a default connection multiplexer factory is specified...
+        optionsBuilder.PostConfigure<IServiceProvider>(
+            (opts, sp) =>
+            {
+                if (string.IsNullOrWhiteSpace(opts.Host))
+                {
+                    opts.ConnectionMultiplexerFactory ??= (_, _) =>
+                        Task.FromResult(GetConnectionMultiplexer(sp, serviceKey));
+                }
+            }
+        );
 
         return services;
     }
+
+    //
+    // Extension methods for specifying the RedisClient factory for the
+    // RedisLeaderElection builder
+    //
+
+    /// <summary>
+    /// Specifies a Configuration section to bind to the default
+    /// <see cref="RedisSettings"/> used by the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithConfiguration(
+        this ServiceBuilder builder,
+        IConfiguration configureSection
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureSection);
+        builder.OptionsBuilder.Configure(configureSection.Bind);
+        return builder;
+    }
+
+    /// <summary>
+    /// Specifies a Configuration section name to bind to the default
+    /// <see cref="RedisSettings"/> used by the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithConfiguration(
+        this ServiceBuilder builder,
+        string configurationSectionName
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configurationSectionName);
+        builder.OptionsBuilder.Configure<IConfiguration>(
+            (opts, configuration) => configuration.GetSection(configurationSectionName).Bind(opts)
+        );
+        return builder;
+    }
+
+    /// <summary>
+    /// Specifies an action to configure the <see cref="RedisSettings"/>
+    /// used by the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithSettings(
+        this ServiceBuilder builder,
+        Action<RedisSettings> configureOptions
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+        builder.OptionsBuilder.Configure(configureOptions);
+        return builder;
+    }
+
+    /// <summary>
+    /// Specifies the <see cref="RedisSettings"/> used by the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithSettings(this ServiceBuilder builder, RedisSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        return builder.WithSettings(opts => RedisSettings.Copy(settings, opts));
+    }
+
+    /// <summary>
+    /// Configures the leader election settings using a configuration action which receives
+    /// the service provider and the optional service key.
+    /// </summary>
+    /// <remarks>
+    /// This is the most flexible configuration method, allowing for complex scenarios such as:
+    /// - Resolving different cache instances based on the service key
+    /// - Accessing other services from the service provider to configure the settings
+    /// - Dynamically determining configuration values at runtime
+    /// </remarks>
+    public static ServiceBuilder WithSettings(
+        this ServiceBuilder builder,
+        Action<RedisSettings, IServiceProvider, string?> configAction
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configAction);
+        builder.OptionsBuilder.Configure<IServiceProvider>(
+            (opts, sp) => configAction(opts, sp, builder.ServiceKey)
+        );
+        return builder;
+    }
+
+    /// <summary>
+    /// Specifies the instance ID to use for the Leader Election.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="instanceId"></param>
+    /// <returns></returns>
+    public static ServiceBuilder WithInstanceId(this ServiceBuilder builder, string instanceId)
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(instanceId);
+        return builder.WithSettings(options => options.InstanceId = instanceId);
+    }
+
+    /// <summary>
+    /// Configures the leader election to use the connection multiplexer registered
+    /// in the service provider.
+    /// </summary>
+    public static ServiceBuilder WithRegisteredCache(this ServiceBuilder builder) =>
+        builder.WithSettings(
+            (opts, sp, key) =>
+                opts.ConnectionMultiplexerFactory = (_, _) =>
+                    Task.FromResult(GetConnectionMultiplexer(sp, key))
+        );
+
+    /// <summary>
+    /// Specifies the connection multiplexer factory to use with the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithConnectionMultiplexer(
+        this ServiceBuilder builder,
+        IConnectionMultiplexer connectionMultiplexer
+    )
+    {
+        ArgumentNullException.ThrowIfNull(connectionMultiplexer);
+        return builder.WithConnectionMultiplexerFactory(
+            (_, _, _) => Task.FromResult(connectionMultiplexer)
+        );
+    }
+
+    /// <summary>
+    /// Specifies the connection multiplexer factory to use with the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithConnectionMultiplexerFactory(
+        this ServiceBuilder builder,
+        Func<
+            IServiceProvider,
+            RedisSettings,
+            CancellationToken,
+            Task<IConnectionMultiplexer>
+        > factoryFunc
+    )
+    {
+        ArgumentNullException.ThrowIfNull(factoryFunc);
+        return builder.WithSettings(
+            (opts, sp, _) =>
+                opts.ConnectionMultiplexerFactory = (settings, ct) => factoryFunc(sp, settings, ct)
+        );
+    }
+
+    private static IConnectionMultiplexer GetConnectionMultiplexer(
+        IServiceProvider sp,
+        string? serviceKey
+    ) =>
+        sp.GetKeyedService<IConnectionMultiplexer>(serviceKey)
+        ?? sp.GetRequiredService<IConnectionMultiplexer>();
 }

--- a/src/LeaderElection.Redis/RedisServiceBuilderExtensions.cs
+++ b/src/LeaderElection.Redis/RedisServiceBuilderExtensions.cs
@@ -257,8 +257,8 @@ public static class RedisServiceBuilderExtensions
 
     private static IConnectionMultiplexer GetRegisteredConnectionMultiplexer(
         IServiceProvider sp,
-        string? serviceKey
+        object? serviceKey
     ) =>
-        sp.GetKeyedService<IConnectionMultiplexer>(serviceKey)
+        (serviceKey != null ? sp.GetKeyedService<IConnectionMultiplexer>(serviceKey) : null)
         ?? sp.GetRequiredService<IConnectionMultiplexer>();
 }

--- a/src/LeaderElection.Redis/RedisSettings.cs
+++ b/src/LeaderElection.Redis/RedisSettings.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using StackExchange.Redis;
 
 namespace LeaderElection.Redis;
 
@@ -7,15 +8,19 @@ public class RedisSettings : LeaderElectionSettingsBase
     /// <summary>
     /// The Redis server host name or IP address.
     /// <para/>
-    /// Default is "localhost".
+    /// Ignored if a <see cref="ConnectionMultiplexerFactory"/> is set.
+    /// <para/>
+    /// If neither <see cref="ConnectionMultiplexerFactory"/> nor <see cref="Host"/>
+    /// are set, the leader election will resolve a ConnectionMultiplexer from the DI container.
     /// </summary>
-    [Required]
-    public string Host { get; set; } = "localhost";
+    public string? Host { get; set; }
 
     /// <summary>
     /// The Redis server port number.
     /// <para/>
     /// Default is 6379.
+    /// <para/>
+    /// Ignored if a <see cref="ConnectionMultiplexerFactory"/> is set.
     /// </summary>
     [Range(1, 65535)]
     public int Port { get; set; } = 6379;
@@ -23,10 +28,9 @@ public class RedisSettings : LeaderElectionSettingsBase
     /// <summary>
     /// The password for authenticating with the Redis server, if required.
     /// <para/>
-    /// Default is an empty string, which means no password.
+    /// Ignored if a <see cref="ConnectionMultiplexerFactory"/> is set.
     /// </summary>
-    [Required(AllowEmptyStrings = true)]
-    public string Password { get; set; } = string.Empty;
+    public string? Password { get; set; }
 
     /// <summary>
     /// The Redis database number.
@@ -57,4 +61,36 @@ public class RedisSettings : LeaderElectionSettingsBase
         nameof(RedisSettingsValidator.ValidateLockExpiry)
     )]
     public TimeSpan LockExpiry { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// An optional factory function to get a Redis connection multiplexer.
+    /// <para/>
+    /// If set, this factory will be used to get a connection multiplexer
+    /// instead of using the Host/Port/Password settings.
+    /// <para/>
+    /// If neither <see cref="ConnectionMultiplexerFactory"/> nor <see cref="Host"/>
+    /// are set, the leader election will resolve a ConnectionMultiplexer from the DI container.
+    /// </summary>
+    public Func<
+        RedisSettings,
+        CancellationToken,
+        Task<IConnectionMultiplexer>
+    >? ConnectionMultiplexerFactory { get; set; }
+
+    /// <summary>
+    /// Copies the Redis settings from the source to the destination.
+    /// </summary>
+    public static void Copy(RedisSettings src, RedisSettings dst)
+    {
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(dst);
+        LeaderElectionSettingsBase.Copy(src, dst);
+        dst.Host = src.Host;
+        dst.Port = src.Port;
+        dst.Password = src.Password;
+        dst.Database = src.Database;
+        dst.LockKey = src.LockKey;
+        dst.LockExpiry = src.LockExpiry;
+        dst.ConnectionMultiplexerFactory = src.ConnectionMultiplexerFactory;
+    }
 }

--- a/src/LeaderElection.Redis/RedisSettings.cs
+++ b/src/LeaderElection.Redis/RedisSettings.cs
@@ -3,75 +3,77 @@ using StackExchange.Redis;
 
 namespace LeaderElection.Redis;
 
+/// <summary>
+/// Settings for Redis-based leader election.
+/// </summary>
 public class RedisSettings : LeaderElectionSettingsBase
 {
     /// <summary>
-    /// The Redis server host name or IP address.
-    /// <para/>
-    /// Ignored if a <see cref="ConnectionMultiplexerFactory"/> is set.
-    /// <para/>
-    /// If neither <see cref="ConnectionMultiplexerFactory"/> nor <see cref="Host"/>
-    /// are set, the leader election will resolve a ConnectionMultiplexer from the DI container.
+    /// An optional factory function used to obtain an <see cref="IConnectionMultiplexer"/>.
     /// </summary>
+    /// <remarks>
+    /// If not provided, a connection will be created using the <see cref="Host"/>,
+    /// <see cref="Port"/>, and <see cref="Password"/> properties.
+    /// If <see cref="Host"/> is null or empty, it will attempt to obtain an
+    /// <see cref="IConnectionMultiplexer"/> from DI (assuming the leader election is created via DI).
+    /// </remarks>
+    public Func<RedisSettings, IConnectionMultiplexer>? ConnectionMultiplexerFactory { get; set; }
+
+    /// <summary>
+    /// The Redis server host name or IP address.
+    /// </summary>
+    /// <remarks>
+    /// Ignored if a <see cref="ConnectionMultiplexerFactory"/> is set.
+    /// </remarks>
     public string? Host { get; set; }
 
     /// <summary>
-    /// The Redis server port number.
-    /// <para/>
-    /// Default is 6379.
-    /// <para/>
-    /// Ignored if a <see cref="ConnectionMultiplexerFactory"/> is set.
+    /// The Redis server port number. Default is 6379.
     /// </summary>
+    /// <remarks>
+    /// Ignored if a <see cref="ConnectionMultiplexerFactory"/> is set.
+    /// </remarks>
     [Range(1, 65535)]
     public int Port { get; set; } = 6379;
 
     /// <summary>
     /// The password for authenticating with the Redis server, if required.
-    /// <para/>
-    /// Ignored if a <see cref="ConnectionMultiplexerFactory"/> is set.
     /// </summary>
+    /// <remarks>
+    /// Ignored if a <see cref="ConnectionMultiplexerFactory"/> is set.
+    /// </remarks>
     public string? Password { get; set; }
 
     /// <summary>
-    /// The Redis database number.
-    /// <para/>
-    /// Default is 0.
+    /// The Redis database number. Default is 0.
     /// </summary>
     [Range(0, int.MaxValue)]
     public int Database { get; set; } = 0;
 
     /// <summary>
-    /// The key used for acquiring the leader lock in Redis.
-    /// <para/>
+    /// The key used for acquiring the leader lock.
     /// Default is "leader-election-lock".
     /// </summary>
+    /// <remarks>
+    /// This should be unique to avoid conflicts with other applications using the same cache.
+    /// </remarks>
     [Required]
     public string LockKey { get; set; } = "leader-election-lock";
 
     /// <summary>
-    /// The duration for which the leader lock will be held in Redis before it expires.
-    /// <para/>
+    /// The duration for which the leader lock will be held before it expires.
+    /// Default is 30 seconds.
+    /// </summary>
+    /// <remarks>
     /// This should be set to a value that is long enough to allow the leader to
     /// perform its duties, but short enough to allow for quick failover in case
     /// the leader goes down.
-    /// Default is 30 seconds.
-    /// </summary>
+    /// </remarks>
     [CustomValidation(
         typeof(RedisSettingsValidator),
         nameof(RedisSettingsValidator.ValidateLockExpiry)
     )]
     public TimeSpan LockExpiry { get; set; } = TimeSpan.FromSeconds(30);
-
-    /// <summary>
-    /// An optional factory function to get a Redis connection multiplexer.
-    /// <para/>
-    /// If set, this factory will be used to get a connection multiplexer
-    /// instead of using the Host/Port/Password settings.
-    /// <para/>
-    /// If neither <see cref="ConnectionMultiplexerFactory"/> nor <see cref="Host"/>
-    /// are set, the leader election will resolve a ConnectionMultiplexer from the DI container.
-    /// </summary>
-    public Func<RedisSettings, IConnectionMultiplexer>? ConnectionMultiplexerFactory { get; set; }
 
     /// <summary>
     /// Copies the Redis settings from the source to the destination.
@@ -81,12 +83,12 @@ public class RedisSettings : LeaderElectionSettingsBase
         ArgumentNullException.ThrowIfNull(src);
         ArgumentNullException.ThrowIfNull(dst);
         LeaderElectionSettingsBase.Copy(src, dst);
+        dst.ConnectionMultiplexerFactory = src.ConnectionMultiplexerFactory;
         dst.Host = src.Host;
         dst.Port = src.Port;
         dst.Password = src.Password;
         dst.Database = src.Database;
         dst.LockKey = src.LockKey;
         dst.LockExpiry = src.LockExpiry;
-        dst.ConnectionMultiplexerFactory = src.ConnectionMultiplexerFactory;
     }
 }

--- a/src/LeaderElection.Redis/RedisSettings.cs
+++ b/src/LeaderElection.Redis/RedisSettings.cs
@@ -71,11 +71,7 @@ public class RedisSettings : LeaderElectionSettingsBase
     /// If neither <see cref="ConnectionMultiplexerFactory"/> nor <see cref="Host"/>
     /// are set, the leader election will resolve a ConnectionMultiplexer from the DI container.
     /// </summary>
-    public Func<
-        RedisSettings,
-        CancellationToken,
-        Task<IConnectionMultiplexer>
-    >? ConnectionMultiplexerFactory { get; set; }
+    public Func<RedisSettings, IConnectionMultiplexer>? ConnectionMultiplexerFactory { get; set; }
 
     /// <summary>
     /// Copies the Redis settings from the source to the destination.

--- a/src/LeaderElection.Redis/RedisSettings.cs
+++ b/src/LeaderElection.Redis/RedisSettings.cs
@@ -12,10 +12,8 @@ public class RedisSettings : LeaderElectionSettingsBase
     /// An optional factory function used to obtain an <see cref="IConnectionMultiplexer"/>.
     /// </summary>
     /// <remarks>
-    /// If not provided, a connection will be created using the <see cref="Host"/>,
-    /// <see cref="Port"/>, and <see cref="Password"/> properties.
-    /// If <see cref="Host"/> is null or empty, it will attempt to obtain an
-    /// <see cref="IConnectionMultiplexer"/> from DI (assuming the leader election is created via DI).
+    /// If not provided, it will attempt to obtain an <see cref="IConnectionMultiplexer"/>
+    /// from DI (assuming the leader election is created via DI).
     /// </remarks>
     public Func<RedisSettings, IConnectionMultiplexer>? ConnectionMultiplexerFactory { get; set; }
 
@@ -23,25 +21,33 @@ public class RedisSettings : LeaderElectionSettingsBase
     /// The Redis server host name or IP address.
     /// </summary>
     /// <remarks>
-    /// Ignored if a <see cref="ConnectionMultiplexerFactory"/> is set.
+    /// Unused and will be removed in a future version.
     /// </remarks>
+    [Obsolete(
+        "The Host/Port/Password properties are deprecated and will be removed in a future version. Use ConnectionMultiplexerFactory or DI instead."
+    )]
     public string? Host { get; set; }
 
     /// <summary>
     /// The Redis server port number. Default is 6379.
     /// </summary>
     /// <remarks>
-    /// Ignored if a <see cref="ConnectionMultiplexerFactory"/> is set.
+    /// Unused and will be removed in a future version.
     /// </remarks>
-    [Range(1, 65535)]
+    [Obsolete(
+        "The Host/Port/Password properties are deprecated and will be removed in a future version. Use ConnectionMultiplexerFactory or DI instead."
+    )]
     public int Port { get; set; } = 6379;
 
     /// <summary>
     /// The password for authenticating with the Redis server, if required.
     /// </summary>
     /// <remarks>
-    /// Ignored if a <see cref="ConnectionMultiplexerFactory"/> is set.
+    /// Unused and will be removed in a future version.
     /// </remarks>
+    [Obsolete(
+        "The Host/Port/Password properties are deprecated and will be removed in a future version. Use ConnectionMultiplexerFactory or DI instead."
+    )]
     public string? Password { get; set; }
 
     /// <summary>
@@ -84,9 +90,11 @@ public class RedisSettings : LeaderElectionSettingsBase
         ArgumentNullException.ThrowIfNull(dst);
         LeaderElectionSettingsBase.Copy(src, dst);
         dst.ConnectionMultiplexerFactory = src.ConnectionMultiplexerFactory;
+#pragma warning disable CS0618 // Type or member is obsolete
         dst.Host = src.Host;
         dst.Port = src.Port;
         dst.Password = src.Password;
+#pragma warning restore CS0618 // Type or member is obsolete
         dst.Database = src.Database;
         dst.LockKey = src.LockKey;
         dst.LockExpiry = src.LockExpiry;

--- a/src/LeaderElection.S3/LeaderElection.S3.csproj
+++ b/src/LeaderElection.S3/LeaderElection.S3.csproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <!-- Inherits settings from Directory.Build.props -->
   <PropertyGroup>
     <PackageTags>S3;$(PackageTags)</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Minio" />

--- a/src/LeaderElection.S3/LeaseRecord.cs
+++ b/src/LeaderElection.S3/LeaseRecord.cs
@@ -8,5 +8,5 @@ internal sealed class LeaseRecord
     public string HolderId { get; init; } = "";
 
     [JsonPropertyName("leaseUntilUtc")]
-    public DateTime LeaseUntilUtc { get; init; }
+    public DateTimeOffset LeaseUntilUtc { get; init; }
 }

--- a/src/LeaderElection.S3/S3LeaderElection.cs
+++ b/src/LeaderElection.S3/S3LeaderElection.cs
@@ -162,7 +162,7 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
             {
                 // Clear the ETag regardless of the error to avoid being stuck in
                 // a state where we think we have the lease when we don't.
-                _lastEtag = null;
+                await ResetLeadershipAsync().ConfigureAwait(false);
             }
         }
         return success;
@@ -191,7 +191,6 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
             _ = await PutLeaseAsync(emptyLease, _lastEtag, CancellationToken.None)
                 .ConfigureAwait(false);
 
-            _lastEtag = null;
             LogLeaseReleased(_settings.BucketName, _settings.ObjectKey);
         }
         catch (ObjectNotFoundException)
@@ -231,8 +230,14 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
         {
             // Clear the ETag regardless of success to avoid being stuck in
             // a state where we think we have the lease when we don't.
-            _lastEtag = null;
+            await ResetLeadershipAsync().ConfigureAwait(false);
         }
+    }
+
+    protected override ValueTask ResetLeadershipAsync()
+    {
+        _lastEtag = null;
+        return new ValueTask();
     }
 
     private async Task<string> WriteLeaseAsync(

--- a/src/LeaderElection.S3/S3LeaderElection.cs
+++ b/src/LeaderElection.S3/S3LeaderElection.cs
@@ -139,7 +139,7 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
             // This should not normally happen since the lease record should only be
             // modified by the current holder, but we handle it just in case.
             LogFailureRenewingLease(
-                LogLevel.Information,
+                LogLevel.Warning,
                 _settings.BucketName,
                 _settings.ObjectKey,
                 "ETag mismatch, likely due to another instance acquiring leadership concurrently."
@@ -196,8 +196,10 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
         }
         catch (ObjectNotFoundException)
         {
+            // this is unexpected since we should own the lease.
+            // Log as a warning and give up our leadership.
             LogFailureReleasingLease(
-                LogLevel.Information,
+                LogLevel.Warning,
                 _settings.BucketName,
                 _settings.ObjectKey,
                 "Object not found, likely deleted."
@@ -205,9 +207,10 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
         }
         catch (PreconditionFailedException)
         {
-            // This should not normally happen, but not a problem if it does.
+            // this is unexpected since we should own the lease.
+            // Log as a warning and give up our leadership.
             LogFailureReleasingLease(
-                LogLevel.Information,
+                LogLevel.Warning,
                 _settings.BucketName,
                 _settings.ObjectKey,
                 "ETag mismatch, likely due to another instance acquiring leadership concurrently."

--- a/src/LeaderElection.S3/S3LeaderElection.cs
+++ b/src/LeaderElection.S3/S3LeaderElection.cs
@@ -263,7 +263,8 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
     // - If the object exists but can't be deserialized, returns (etag, null) and logs a warning.
     // - If the object exists and is successfully deserialized, returns (etag, leaseRecord).
     // - Any exceptions thrown by the Minio client (e.g., due to permissions issues, network issues, etc.)
-    //   are caught and logged, and it returns (null, null) to indicate no valid lease record could be read.
+    //   are caught and treated as if no valid lease record could be read, so it returns (null, null).
+    //   Those exceptions are not logged here; if they also prevent acquiring the lease, that failure is logged later.
     private async Task<(string? currentEtag, LeaseRecord? currentLease)> TryReadLeaseAsync(
         CancellationToken cancellationToken
     )

--- a/src/LeaderElection.S3/S3LeaderElection.cs
+++ b/src/LeaderElection.S3/S3LeaderElection.cs
@@ -1,7 +1,5 @@
-using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Minio;
 using Minio.DataModel.Args;
 using Minio.Exceptions;
@@ -14,99 +12,91 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
     private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
     private string? _lastEtag;
 
-    public S3LeaderElection(
-        IMinioClient client,
-        IOptions<S3Settings> options,
-        ILogger<S3LeaderElection> logger
-    )
-        : base(options?.Value ?? throw new ArgumentNullException(nameof(options)), logger)
+    public S3LeaderElection(S3Settings settings, ILogger<S3LeaderElection> logger)
+        : base(settings, logger)
     {
-        _client = client ?? throw new ArgumentNullException(nameof(client));
+        if (_settings.MinioClientFactory == null)
+        {
+            throw new ArgumentException(
+                "MinioClientFactory must be provided in S3Settings.",
+                nameof(settings)
+            );
+        }
+
+        _client =
+            _settings.MinioClientFactory(_settings)
+            ?? throw new InvalidOperationException("MinioClientFactory returned null.");
     }
 
     protected override async Task<bool> TryAcquireLeadershipInternalAsync(
         CancellationToken cancellationToken
     )
     {
-        try
+        if (_lastEtag != null)
         {
-            // First check if the lease is current by trying to read it
-            LeaseRecord? currentLease = null;
-            string? currentEtag = null;
-            try
-            {
-                var stat = await _client
-                    .StatObjectAsync(
-                        new StatObjectArgs()
-                            .WithBucket(_settings.BucketName)
-                            .WithObject(_settings.ObjectKey),
-                        cancellationToken
-                    )
-                    .ConfigureAwait(false);
-                currentEtag = NormalizeETag(stat.ETag);
-
-                var memoryStream = new MemoryStream();
-                await _client
-                    .GetObjectAsync(
-                        new GetObjectArgs()
-                            .WithBucket(_settings.BucketName)
-                            .WithObject(_settings.ObjectKey)
-                            .WithCallbackStream((stream) => stream.CopyTo(memoryStream)),
-                        cancellationToken
-                    )
-                    .ConfigureAwait(false);
-
-                memoryStream.Position = 0;
-                currentLease = await JsonSerializer
-                    .DeserializeAsync<LeaseRecord>(memoryStream, _jsonOptions, cancellationToken)
-                    .ConfigureAwait(false);
-                await memoryStream.DisposeAsync().ConfigureAwait(false);
-            }
-            catch (ObjectNotFoundException)
-            {
-                LogObjectNotFoundTryingToCreateIt(_logger);
-            }
-
-            var now = DateTime.UtcNow;
-            if (
-                currentLease != null
-                && currentLease.LeaseUntilUtc > now
-                && currentLease.HolderId != _settings.InstanceId
-            )
-            {
-                // Lease is still valid and held by someone else
-                return false;
-            }
-
-            var leaseRecord = new LeaseRecord
-            {
-                HolderId = _settings.InstanceId,
-                LeaseUntilUtc = now.Add(_settings.LeaseDuration),
-            };
-
-            // We use the etag here to prevent race conditions of multiple instances going for leadership at once
-            var headers = new Dictionary<string, string>();
-            if (currentEtag != null)
-            {
-                headers["If-Match"] = currentEtag;
-            }
-            else
-            {
-                headers["If-None-Match"] = "*";
-            }
-
-            _lastEtag = await PutLeaseAsync(leaseRecord, headers, cancellationToken)
-                .ConfigureAwait(false);
-            return true;
-        }
-        catch (ErrorResponseException ex)
-            when (ex.Response.Code is "PreconditionFailed" or "AccessDenied")
-        {
+            LogLeaseAlreadyAcquired(_settings.BucketName, _settings.ObjectKey);
             return false;
         }
-        catch (Exception ex)
+
+        // Try to read the current lease...
+        var (currentEtag, currentLease) = await TryReadLeaseAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var now = DateTime.UtcNow;
+        if (
+            currentLease != null
+            && currentLease.LeaseUntilUtc > now
+            && currentLease.HolderId != _settings.InstanceId
+        )
         {
-            LogErrorAcquiringS3Leadership(_logger, ex);
+            // Lease is still valid and held by someone else
+            LogFailureAcquiringLease(
+                LogLevel.Debug,
+                _settings.BucketName,
+                _settings.ObjectKey,
+                "Lease is currently held by another instance."
+            );
+
+            return false; // failed to acquire leadership
+        }
+
+        // Try to acquire the lease by writing a new LeaseRecord using the
+        // currentEtag. If currentEtag is null, it will create the object
+        // if it doesn't exist.
+        var leaseRecord = new LeaseRecord
+        {
+            HolderId = _settings.InstanceId,
+            LeaseUntilUtc = now.Add(_settings.LeaseDuration),
+        };
+        try
+        {
+            _lastEtag = await WriteLeaseAsync(leaseRecord, currentEtag, cancellationToken)
+                .ConfigureAwait(false);
+
+            // success!
+            LogAcquiredLease(_settings.BucketName, _settings.ObjectKey, _settings.InstanceId);
+            return true;
+        }
+        catch (PreconditionFailedException)
+        {
+            LogFailureAcquiringLease(
+                LogLevel.Debug,
+                _settings.BucketName,
+                _settings.ObjectKey,
+                "ETag mismatch, likely due to another instance acquiring leadership concurrently."
+            );
+            return false;
+        }
+        catch (MinioException ex)
+        {
+            // failure due to an error accessing S3 (e.g., network issue,
+            // permissions issue, etc.)
+            LogFailureAcquiringLease(
+                LogLevel.Error,
+                _settings.BucketName,
+                _settings.ObjectKey,
+                ex.GetType().FullName + ": " + ex.Message
+            );
             return false;
         }
     }
@@ -115,148 +105,255 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
         CancellationToken cancellationToken
     )
     {
+        if (_lastEtag == null)
+        {
+            LogNoCurrentLeaseToRenew();
+            return false;
+        }
+
+        // To renew the lease, we write a new record with the same InstanceId and
+        // a new expiry time, but we must include the ETag of the current record to
+        // ensure we only succeed if the record hasn't been modified by another instance.
+        // If we succeed, we have effectively renewed the lease. If we fail with a
+        // PreconditionFailed, it likely means we lost leadership due to another instance
+        // acquiring leadership, but we treat it as a failure to renew since we no longer
+        // hold the lease. For other errors, we log them and treat it as a failure to
+        // renew; if it's a transient error, someone will become the leader when the lease
+        // naturally expires.
+        var success = false;
+        var now = DateTime.UtcNow;
+        var leaseRecord = new LeaseRecord
+        {
+            HolderId = _settings.InstanceId,
+            LeaseUntilUtc = now.Add(_settings.LeaseDuration),
+        };
+
         try
         {
-            if (string.IsNullOrEmpty(_lastEtag))
-            {
-                return await TryAcquireLeadershipInternalAsync(cancellationToken)
-                    .ConfigureAwait(false);
-            }
-
-            var now = DateTime.UtcNow;
-            var leaseRecord = new LeaseRecord
-            {
-                HolderId = _settings.InstanceId,
-                LeaseUntilUtc = now.Add(_settings.LeaseDuration),
-            };
-
-            // Read current record to verify ETag
-            try
-            {
-                var stat = await _client
-                    .StatObjectAsync(
-                        new StatObjectArgs()
-                            .WithBucket(_settings.BucketName)
-                            .WithObject(_settings.ObjectKey),
-                        cancellationToken
-                    )
-                    .ConfigureAwait(false);
-
-                var etag = NormalizeETag(stat.ETag);
-                if (etag != _lastEtag)
-                {
-                    LogS3EtagMismatchDuringRenewalExpectedExpectedGotActual(
-                        _logger,
-                        _lastEtag,
-                        etag ?? string.Empty
-                    );
-                    return false;
-                }
-
-                var memoryStream = new MemoryStream();
-                await _client
-                    .GetObjectAsync(
-                        new GetObjectArgs()
-                            .WithBucket(_settings.BucketName)
-                            .WithObject(_settings.ObjectKey)
-                            .WithCallbackStream((stream) => stream.CopyTo(memoryStream)),
-                        cancellationToken
-                    )
-                    .ConfigureAwait(false);
-
-                memoryStream.Position = 0;
-                var currentLease = await JsonSerializer
-                    .DeserializeAsync<LeaseRecord>(memoryStream, _jsonOptions, cancellationToken)
-                    .ConfigureAwait(false);
-                if (currentLease?.HolderId != _settings.InstanceId)
-                {
-                    return false;
-                }
-
-                await memoryStream.DisposeAsync().ConfigureAwait(false);
-            }
-            catch (Exception)
-            {
-                return false;
-            }
-
-            _lastEtag = await PutLeaseAsync(
-                    leaseRecord,
-                    new Dictionary<string, string> { ["If-Match"] = _lastEtag },
-                    cancellationToken
-                )
+            _lastEtag = await WriteLeaseAsync(leaseRecord, _lastEtag, cancellationToken)
                 .ConfigureAwait(false);
-            return true;
+
+            success = true;
+            LogLeaseRenewed(_settings.BucketName, _settings.ObjectKey, _settings.InstanceId);
         }
-        catch (ErrorResponseException ex)
-            when (ex.Response.Code is "PreconditionFailed" or "AccessDenied")
+        catch (PreconditionFailedException)
         {
-            return false;
+            // Lost leadership because the record was modified by another instance
+            // (e.g., another instance acquired leadership).
+            // This should not normally happen since the lease record should only be
+            // modified by the current holder, but we handle it just in case.
+            LogFailureRenewingLease(
+                LogLevel.Information,
+                _settings.BucketName,
+                _settings.ObjectKey,
+                "ETag mismatch, likely due to another instance acquiring leadership concurrently."
+            );
         }
-        catch (Exception ex)
+        catch (MinioException ex)
         {
-            LogErrorRenewingS3Leadership(_logger, ex);
-            return false;
+            // Lost leadership due to an error accessing S3 (e.g., network issue,
+            // permissions issue, etc.)
+            LogFailureRenewingLease(
+                LogLevel.Error,
+                _settings.BucketName,
+                _settings.ObjectKey,
+                ex.GetType().FullName + ": " + ex.Message
+            );
         }
+        finally
+        {
+            if (!success)
+            {
+                // Clear the ETag regardless of the error to avoid being stuck in
+                // a state where we think we have the lease when we don't.
+                _lastEtag = null;
+            }
+        }
+        return success;
     }
 
     protected override async Task ReleaseLeadershipAsync()
     {
+        if (_lastEtag == null)
+        {
+            LogNoCurrentLeaseToRelease();
+            return;
+        }
+
+        // To release the lease, we write an empty record with an old expiry time, but we
+        // must include the ETag of the current record to ensure we only succeed if the
+        // record hasn't been modified by another instance (e.g., another instance acquired
+        // leadership). If we succeed, we have effectively released the lease. If we fail with
+        // a PreconditionFailed, it likely means we lost leadership due to another instance
+        // acquiring leadership, but we treat it as a successful release since we no longer
+        // hold the lease. For other errors, we log them but there's not much else we can do;
+        // if it's a transient error, someone will become the leader when the lease naturally
+        // expires.
+        var emptyLease = new LeaseRecord();
         try
         {
-            if (string.IsNullOrEmpty(_lastEtag))
-                return;
-
-            var now = DateTime.UtcNow;
-            var leaseRecord = new LeaseRecord
-            {
-                HolderId = _settings.InstanceId,
-                LeaseUntilUtc = now.AddSeconds(-1),
-            };
-
-            await PutLeaseAsync(
-                    leaseRecord,
-                    new Dictionary<string, string> { ["If-Match"] = _lastEtag },
-                    CancellationToken.None
-                )
+            _ = await PutLeaseAsync(emptyLease, _lastEtag, CancellationToken.None)
                 .ConfigureAwait(false);
-            LogLeadershipReleasedForInstanceInstanceId(_logger, _settings.InstanceId);
+
+            _lastEtag = null;
+            LogLeaseReleased(_settings.BucketName, _settings.ObjectKey, _settings.InstanceId);
         }
-        catch (Exception ex)
+        catch (ObjectNotFoundException)
         {
-            LogErrorReleasingS3Leadership(_logger, ex);
+            LogFailureReleasingLease(
+                LogLevel.Information,
+                _settings.BucketName,
+                _settings.ObjectKey,
+                "Object not found, likely deleted."
+            );
+        }
+        catch (PreconditionFailedException)
+        {
+            // This should not normally happen, but not a problem if it does.
+            LogFailureReleasingLease(
+                LogLevel.Information,
+                _settings.BucketName,
+                _settings.ObjectKey,
+                "ETag mismatch, likely due to another instance acquiring leadership concurrently."
+            );
+        }
+        catch (MinioException ex)
+        {
+            // failure due to an error accessing S3 (e.g., network issue,
+            // permissions issue, etc.)
+            LogFailureReleasingLease(
+                LogLevel.Error,
+                _settings.BucketName,
+                _settings.ObjectKey,
+                ex.GetType().FullName + ": " + ex.Message
+            );
+        }
+        finally
+        {
+            // Clear the ETag regardless of success to avoid being stuck in
+            // a state where we think we have the lease when we don't.
+            _lastEtag = null;
         }
     }
 
+    private async Task<string> WriteLeaseAsync(
+        LeaseRecord leaseRecord,
+        string? currentEtag,
+        CancellationToken cancellationToken
+    )
+    {
+        try
+        {
+            return await PutLeaseAsync(leaseRecord, currentEtag, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (ObjectNotFoundException) when (currentEtag != null)
+        {
+            // Try again without an ETag, i.e., create it if it doesn't exist.
+            return await PutLeaseAsync(leaseRecord, null, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    // Attempts to read the lease record from S3:
+    // - If the object doesn't exist, returns (null, null).
+    // - If the object exists but can't be deserialized, returns (etag, null) and logs a warning.
+    // - If the object exists and is successfully deserialized, returns (etag, leaseRecord).
+    // - Any exceptions thrown by the Minio client (e.g., due to permissions issues, network issues, etc.)
+    //   are caught and logged, and it returns (null, null) to indicate no valid lease record could be read.
+    private async Task<(string? currentEtag, LeaseRecord? currentLease)> TryReadLeaseAsync(
+        CancellationToken cancellationToken
+    )
+    {
+        string? currentEtag = null;
+        LeaseRecord? currentLease = null;
+        try
+        {
+            using var memoryStream = new MemoryStream();
+            var stat = await _client
+                .GetObjectAsync(
+                    new GetObjectArgs()
+                        .WithBucket(_settings.BucketName)
+                        .WithObject(_settings.ObjectKey)
+                        .WithCallbackStream(stream => stream.CopyTo(memoryStream)),
+                    cancellationToken
+                )
+                .ConfigureAwait(false);
+
+            // It exists.
+            currentEtag = NormalizeETag(stat.ETag);
+
+            // Deserialize the content...
+            try
+            {
+                memoryStream.Position = 0;
+                currentLease = await JsonSerializer
+                    .DeserializeAsync<LeaseRecord>(memoryStream, _jsonOptions, cancellationToken)
+                    .ConfigureAwait(false);
+
+                // Appears to be a valid record
+            }
+            catch (JsonException ex)
+            {
+                // If we can't deserialize the content, we treat it as if there was no
+                // valid lease record, i.e., we'll overwrite it and acquire leadership.
+                // This is a bit of a safety valve in case the content gets corrupted somehow,
+                // but we log it just in case.
+                LogFailedToDeserializeLeaseRecord(ex, _settings.BucketName, _settings.ObjectKey);
+            }
+        }
+        catch (ObjectNotFoundException)
+        {
+            // Okay. We'll create it when we acquire the lease.
+        }
+        catch (MinioException)
+        {
+            // ignore other Minio exceptions (e.g., access denied) and just treat it
+            // as if there was no current lease, which means we'll try to acquire it.
+            // If it's an access issue or something else that would prevent us from
+            // acquiring the lease, that will just cause the PutLeaseAsync call to fail
+            // and we'll log it there.
+        }
+
+        return (currentEtag, currentLease);
+    }
+
+    // Writes the lease record to S3 with the specified ETag for concurrency control.
+    // - If currentEtag is null, it will attempt to create the object if it doesn't exist.
+    // - Returns the new ETag if successful.
     private async Task<string> PutLeaseAsync(
         LeaseRecord record,
-        IDictionary<string, string> headers,
+        string? etag,
         CancellationToken token
     )
     {
-        var json = JsonSerializer.Serialize(record, _jsonOptions);
-        var bytes = Encoding.UTF8.GetBytes(json);
-        using var stream = new MemoryStream(bytes, writable: false);
+        using var stream = new MemoryStream(
+            JsonSerializer.SerializeToUtf8Bytes(record, _jsonOptions)
+        );
 
         var request = new PutObjectArgs()
             .WithBucket(_settings.BucketName)
             .WithObject(_settings.ObjectKey)
             .WithStreamData(stream)
             .WithObjectSize(stream.Length)
-            .WithContentType("application/json")
-            .WithHeaders(new Dictionary<string, string>(headers));
+            .WithContentType("application/json");
 
-        var response = await _client.PutObjectAsync(request, token).ConfigureAwait(false);
-        var etag = NormalizeETag(response?.Etag);
-
-        if (string.IsNullOrEmpty(etag))
+        if (!string.IsNullOrEmpty(etag))
         {
-            throw new InvalidOperationException(
-                "PutObjectAsync succeeded but no ETag was returned."
-            );
+            request.WithMatchETag(etag);
+        }
+        else
+        {
+            request.WithNotMatchETag("*"); // "if does not exist"
         }
 
-        return etag;
+        var response = await _client.PutObjectAsync(request, token).ConfigureAwait(false);
+        var newEtag = NormalizeETag(response.Etag);
+
+        return string.IsNullOrEmpty(newEtag)
+            ? throw new InvalidOperationException(
+                "PutObjectAsync succeeded but no ETag was returned."
+            )
+            : newEtag;
     }
 
     // Minio's ETag handling can be inconsistent, so we normalize it by adding
@@ -267,31 +364,64 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
         : etag[0] == '"' && etag[^1] == '"' ? etag // already quoted
         : $"\"{etag}\""; // add quotes
 
-    [LoggerMessage(LogLevel.Debug, "Object not found, Trying to create it.")]
-    static partial void LogObjectNotFoundTryingToCreateIt(ILogger logger);
-
-    [LoggerMessage(LogLevel.Error, "Error acquiring S3 leadership")]
-    static partial void LogErrorAcquiringS3Leadership(ILogger logger, Exception exception);
+    [LoggerMessage(LogLevel.Information, "Lease already acquired for {BucketName}/{ObjectKey}.")]
+    partial void LogLeaseAlreadyAcquired(string bucketName, string objectKey);
 
     [LoggerMessage(
-        LogLevel.Warning,
-        "S3 ETag mismatch during renewal. Expected {expected}, got {actual}"
+        LogLevel.Debug,
+        "Lease acquired on {BucketName}/{ObjectKey} by instance {InstanceId}."
     )]
-    static partial void LogS3EtagMismatchDuringRenewalExpectedExpectedGotActual(
-        ILogger logger,
-        string expected,
-        string actual
+    partial void LogAcquiredLease(string bucketName, string objectKey, string instanceId);
+
+    [LoggerMessage("Failure acquiring lease on {BucketName}/{ObjectKey}: {Reason}")]
+    partial void LogFailureAcquiringLease(
+        LogLevel logLevel,
+        string bucketName,
+        string objectKey,
+        string reason
     );
 
-    [LoggerMessage(LogLevel.Error, "Error renewing S3 leadership")]
-    static partial void LogErrorRenewingS3Leadership(ILogger logger, Exception exception);
+    [LoggerMessage(LogLevel.Information, "No current lease to renew.")]
+    partial void LogNoCurrentLeaseToRenew();
 
-    [LoggerMessage(LogLevel.Information, "Leadership released for instance {instanceId}")]
-    static partial void LogLeadershipReleasedForInstanceInstanceId(
-        ILogger logger,
-        string instanceId
+    [LoggerMessage(
+        LogLevel.Debug,
+        "Lease renewed on {BucketName}/{ObjectKey} by instance {InstanceId}."
+    )]
+    partial void LogLeaseRenewed(string bucketName, string objectKey, string instanceId);
+
+    [LoggerMessage("Failure renewing lease for {BucketName}/{ObjectKey}: {Reason}")]
+    partial void LogFailureRenewingLease(
+        LogLevel logLevel,
+        string bucketName,
+        string objectKey,
+        string reason
     );
 
-    [LoggerMessage(LogLevel.Error, "Error releasing S3 leadership")]
-    static partial void LogErrorReleasingS3Leadership(ILogger logger, Exception exception);
+    [LoggerMessage(LogLevel.Information, "No current lease to release.")]
+    partial void LogNoCurrentLeaseToRelease();
+
+    [LoggerMessage(
+        LogLevel.Debug,
+        "Lease released for {BucketName}/{ObjectKey} by instance {InstanceId}."
+    )]
+    partial void LogLeaseReleased(string bucketName, string objectKey, string instanceId);
+
+    [LoggerMessage("Failure releasing lease for {BucketName}/{ObjectKey}: {Reason}")]
+    partial void LogFailureReleasingLease(
+        LogLevel logLevel,
+        string bucketName,
+        string objectKey,
+        string reason
+    );
+
+    [LoggerMessage(
+        LogLevel.Error,
+        "Failed to deserialize lease record for {BucketName}/{ObjectKey}."
+    )]
+    partial void LogFailedToDeserializeLeaseRecord(
+        Exception exception,
+        string bucketName,
+        string objectKey
+    );
 }

--- a/src/LeaderElection.S3/S3LeaderElection.cs
+++ b/src/LeaderElection.S3/S3LeaderElection.cs
@@ -14,22 +14,14 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
 
     public S3LeaderElection(
         S3Settings settings,
+        IMinioClient client,
         ILogger<S3LeaderElection>? logger = null,
         TimeProvider? timeProvider = null
     )
         : base(settings ?? throw new ArgumentNullException(nameof(settings)), logger, timeProvider)
     {
-        if (_settings.MinioClientFactory == null)
-        {
-            throw new ArgumentException(
-                "MinioClientFactory must be provided in S3Settings.",
-                nameof(settings)
-            );
-        }
-
-        _client =
-            _settings.MinioClientFactory(_settings)
-            ?? throw new InvalidOperationException("MinioClientFactory returned null.");
+        ArgumentNullException.ThrowIfNull(client);
+        _client = client;
     }
 
     protected override async Task<bool> TryAcquireLeadershipInternalAsync(

--- a/src/LeaderElection.S3/S3LeaderElection.cs
+++ b/src/LeaderElection.S3/S3LeaderElection.cs
@@ -12,8 +12,12 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
     private readonly JsonSerializerOptions _jsonOptions = new(JsonSerializerDefaults.Web);
     private string? _lastEtag;
 
-    public S3LeaderElection(S3Settings settings, ILogger<S3LeaderElection> logger)
-        : base(settings, logger)
+    public S3LeaderElection(
+        S3Settings settings,
+        ILogger<S3LeaderElection>? logger = null,
+        TimeProvider? timeProvider = null
+    )
+        : base(settings ?? throw new ArgumentNullException(nameof(settings)), logger, timeProvider)
     {
         if (_settings.MinioClientFactory == null)
         {
@@ -42,7 +46,7 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
         var (currentEtag, currentLease) = await TryReadLeaseAsync(cancellationToken)
             .ConfigureAwait(false);
 
-        var now = DateTime.UtcNow;
+        var now = _timeProvider.GetUtcNow();
         if (
             currentLease != null
             && currentLease.LeaseUntilUtc > now
@@ -121,7 +125,7 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
         // renew; if it's a transient error, someone will become the leader when the lease
         // naturally expires.
         var success = false;
-        var now = DateTime.UtcNow;
+        var now = _timeProvider.GetUtcNow();
         var leaseRecord = new LeaseRecord
         {
             HolderId = _settings.InstanceId,

--- a/src/LeaderElection.S3/S3LeaderElection.cs
+++ b/src/LeaderElection.S3/S3LeaderElection.cs
@@ -70,7 +70,7 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
                 .ConfigureAwait(false);
 
             // success!
-            LogAcquiredLease(_settings.BucketName, _settings.ObjectKey, _settings.InstanceId);
+            LogAcquiredLease(_settings.BucketName, _settings.ObjectKey);
             return true;
         }
         catch (PreconditionFailedException)
@@ -130,7 +130,7 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
                 .ConfigureAwait(false);
 
             success = true;
-            LogLeaseRenewed(_settings.BucketName, _settings.ObjectKey, _settings.InstanceId);
+            LogLeaseRenewed(_settings.BucketName, _settings.ObjectKey);
         }
         catch (PreconditionFailedException)
         {
@@ -192,7 +192,7 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
                 .ConfigureAwait(false);
 
             _lastEtag = null;
-            LogLeaseReleased(_settings.BucketName, _settings.ObjectKey, _settings.InstanceId);
+            LogLeaseReleased(_settings.BucketName, _settings.ObjectKey);
         }
         catch (ObjectNotFoundException)
         {
@@ -363,11 +363,8 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
     [LoggerMessage(LogLevel.Information, "Lease already acquired for {BucketName}/{ObjectKey}.")]
     partial void LogLeaseAlreadyAcquired(string bucketName, string objectKey);
 
-    [LoggerMessage(
-        LogLevel.Debug,
-        "Lease acquired on {BucketName}/{ObjectKey} by instance {InstanceId}."
-    )]
-    partial void LogAcquiredLease(string bucketName, string objectKey, string instanceId);
+    [LoggerMessage(LogLevel.Debug, "Lease acquired on {BucketName}/{ObjectKey}.")]
+    partial void LogAcquiredLease(string bucketName, string objectKey);
 
     [LoggerMessage("Failure acquiring lease on {BucketName}/{ObjectKey}: {Reason}")]
     partial void LogFailureAcquiringLease(
@@ -380,11 +377,8 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
     [LoggerMessage(LogLevel.Information, "No current lease to renew.")]
     partial void LogNoCurrentLeaseToRenew();
 
-    [LoggerMessage(
-        LogLevel.Debug,
-        "Lease renewed on {BucketName}/{ObjectKey} by instance {InstanceId}."
-    )]
-    partial void LogLeaseRenewed(string bucketName, string objectKey, string instanceId);
+    [LoggerMessage(LogLevel.Debug, "Lease renewed on {BucketName}/{ObjectKey}.")]
+    partial void LogLeaseRenewed(string bucketName, string objectKey);
 
     [LoggerMessage("Failure renewing lease for {BucketName}/{ObjectKey}: {Reason}")]
     partial void LogFailureRenewingLease(
@@ -397,11 +391,8 @@ public sealed partial class S3LeaderElection : LeaderElectionBase<S3Settings>
     [LoggerMessage(LogLevel.Information, "No current lease to release.")]
     partial void LogNoCurrentLeaseToRelease();
 
-    [LoggerMessage(
-        LogLevel.Debug,
-        "Lease released for {BucketName}/{ObjectKey} by instance {InstanceId}."
-    )]
-    partial void LogLeaseReleased(string bucketName, string objectKey, string instanceId);
+    [LoggerMessage(LogLevel.Debug, "Lease released for {BucketName}/{ObjectKey}.")]
+    partial void LogLeaseReleased(string bucketName, string objectKey);
 
     [LoggerMessage("Failure releasing lease for {BucketName}/{ObjectKey}: {Reason}")]
     partial void LogFailureReleasingLease(

--- a/src/LeaderElection.S3/S3ServiceBuilderExtensions.cs
+++ b/src/LeaderElection.S3/S3ServiceBuilderExtensions.cs
@@ -71,7 +71,7 @@ public static class S3ServiceBuilderExtensions
             static (sp, key) =>
             {
                 // get settings
-                var settings = sp.GetRequiredService<IOptionsSnapshot<S3Settings>>()
+                var settings = sp.GetRequiredService<IOptionsMonitor<S3Settings>>()
                     .Get(key as string);
 
                 // Note: We must resolve the Minio client here. If we don't do it now

--- a/src/LeaderElection.S3/S3ServiceBuilderExtensions.cs
+++ b/src/LeaderElection.S3/S3ServiceBuilderExtensions.cs
@@ -1,41 +1,240 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Minio;
 
 namespace LeaderElection.S3;
 
+public sealed record ServiceBuilder(
+    IServiceCollection Services,
+    string? ServiceKey,
+    OptionsBuilder<S3Settings> OptionsBuilder
+);
+
 public static class S3ServiceBuilderExtensions
 {
+    /// <inheritdoc cref="AddS3LeaderElectionInternal"/>
+    /// <exception cref="ArgumentNullException">Thrown if the configureOptions parameter is null.</exception>
     public static IServiceCollection AddS3LeaderElection(
         this IServiceCollection services,
         Action<S3Settings> configureOptions
+    ) => AddS3LeaderElection(services, builder => builder.WithSettings(configureOptions));
+
+    /// <inheritdoc cref="AddS3LeaderElectionInternal"/>
+    /// <param name="options">The S3Settings used by the Leader Election.</param>
+    /// <exception cref="ArgumentNullException">Thrown if the options parameter is null.</exception>
+    public static IServiceCollection AddS3LeaderElection(
+        this IServiceCollection services,
+        S3Settings options
+    ) => AddS3LeaderElection(services, builder => builder.WithSettings(options));
+
+    /// <inheritdoc cref="AddS3LeaderElectionInternal"/>
+    /// <remarks>
+    /// This overload allows for named registrations of the leader election services
+    /// and settings, enabling multiple leader election registrations in the same
+    /// application.
+    /// </remarks>
+    public static IServiceCollection AddS3LeaderElection(
+        this IServiceCollection services,
+        Action<ServiceBuilder> builder,
+        string? serviceKey = null
+    ) => AddS3LeaderElectionInternal(services, builder, serviceKey);
+
+    /// <summary>
+    /// Adds S3-based leader election services to the specified specified
+    /// <see cref="IServiceCollection"/>.
+    /// </summary>
+    /// <param name="services">The service collection to add the services to.</param>
+    /// <param name="builder">An action used to configure the settings.</param>
+    /// <param name="serviceKey">An optional key to register the services and settings
+    /// with. This allows for multiple leader election registrations in the same
+    /// application. If not provided, the services and settings will be registered
+    /// without a key.</param>
+    /// <returns>The updated service collection.</returns>
+    public static IServiceCollection AddS3LeaderElectionInternal(
+        IServiceCollection services,
+        Action<ServiceBuilder> builder,
+        string? serviceKey = null
     )
     {
-        services
-            .AddOptionsWithValidateOnStart<S3Settings, S3SettingsValidator>()
-            .Configure(configureOptions);
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(builder);
 
-        services.AddSingleton<S3LeaderElection>();
-        services.AddSingleton<ILeaderElection>(sp => sp.GetRequiredService<S3LeaderElection>());
+        // Register options and leader election services with the specified service key
+        var optionsBuilder = services.AddOptionsWithValidateOnStart<
+            S3Settings,
+            S3SettingsValidator
+        >(serviceKey);
+
+        services.AddKeyedSingleton(
+            serviceKey,
+            static (sp, key) =>
+            {
+                // get keyed settings
+                var settings = sp.GetRequiredService<IOptionsSnapshot<S3Settings>>()
+                    .Get(key as string);
+
+                return ActivatorUtilities.CreateInstance<S3LeaderElection>(sp, settings);
+            }
+        );
+
+        services.AddKeyedSingleton<ILeaderElection>(
+            serviceKey,
+            static (sp, key) => sp.GetRequiredKeyedService<S3LeaderElection>(key)
+        );
+
+        // Invoke builder action to allow user to specify a minio client
+        // factory and settings
+        builder.Invoke(new ServiceBuilder(services, serviceKey, optionsBuilder));
+
+        // Ensure the MinioClientFactory is set. If not, configure
+        // it using DI, first trying to resolve a keyed instance.
+        optionsBuilder.PostConfigure<IServiceProvider>(
+            (opts, sp) => opts.MinioClientFactory ??= _ => GetMinioClient(serviceKey, sp)
+        );
 
         return services;
     }
 
-    public static IServiceCollection AddS3LeaderElection(
-        this IServiceCollection services,
-        S3Settings options
+    //
+    // Extension methods for configuring the S3Settings.
+    //
+
+    /// <summary>
+    /// Specifies a Configuration section to bind to the default
+    /// <see cref="S3Settings"/> used by the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithConfiguration(
+        this ServiceBuilder builder,
+        IConfiguration configureSection
     )
     {
-        services.AddS3LeaderElection(opt =>
-        {
-            opt.InstanceId = options.InstanceId;
-            opt.BucketName = options.BucketName;
-            opt.LeaseDuration = options.LeaseDuration;
-            opt.RetryInterval = options.RetryInterval;
-            opt.RenewInterval = options.RenewInterval;
-            opt.ObjectKey = options.ObjectKey;
-            opt.EnableGracefulShutdown = options.EnableGracefulShutdown;
-            opt.MaxRetryAttempts = options.MaxRetryAttempts;
-        });
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureSection);
+        builder.OptionsBuilder.Configure(configureSection.Bind);
+        return builder;
+    }
 
-        return services;
+    /// <summary>
+    /// Specifies a Configuration section name to bind to the default
+    /// <see cref="S3Settings"/> used by the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithConfiguration(
+        this ServiceBuilder builder,
+        string configurationSectionName
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configurationSectionName);
+        builder.OptionsBuilder.Configure<IConfiguration>(
+            (opts, configuration) => configuration.GetSection(configurationSectionName).Bind(opts)
+        );
+        return builder;
+    }
+
+    /// <summary>
+    /// Specifies the default <see cref="S3Settings"/> used by
+    /// the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithSettings(this ServiceBuilder builder, S3Settings settings)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(settings);
+        builder.OptionsBuilder.Configure(dst => S3Settings.Copy(settings, dst));
+        return builder;
+    }
+
+    /// <summary>
+    /// Specifies an action to configure the <see cref="S3Settings"/>
+    /// used by the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithSettings(
+        this ServiceBuilder builder,
+        Action<S3Settings> configureOptions
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configureOptions);
+        builder.OptionsBuilder.Configure(configureOptions);
+        return builder;
+    }
+
+    /// <summary>
+    /// Configures the leader election settings using a configuration action which receives
+    /// the service provider and the optional service key.
+    /// </summary>
+    /// <remarks>
+    /// This is the most flexible configuration method, allowing for complex scenarios such as:
+    /// - Resolving different cache instances based on the service key
+    /// - Accessing other services from the service provider to configure the settings
+    /// - Dynamically determining configuration values at runtime
+    /// </remarks>
+    public static ServiceBuilder WithSettings(
+        this ServiceBuilder builder,
+        Action<S3Settings, IServiceProvider, string?> configAction
+    )
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+        ArgumentNullException.ThrowIfNull(configAction);
+        builder.OptionsBuilder.Configure<IServiceProvider>(
+            (opts, sp) => configAction(opts, sp, builder.ServiceKey)
+        );
+        return builder;
+    }
+
+    /// <summary>
+    /// Specifies the instance ID to use for the Leader Election.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="instanceId"></param>
+    /// <returns></returns>
+    public static ServiceBuilder WithInstanceId(this ServiceBuilder builder, string instanceId)
+    {
+        ArgumentNullException.ThrowIfNullOrEmpty(instanceId);
+        return builder.WithSettings(options => options.InstanceId = instanceId);
+    }
+
+    /// <summary>
+    /// Specifies a specific IMinioClient to use with the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithMinioClient(
+        this ServiceBuilder builder,
+        IMinioClient minioClient
+    )
+    {
+        ArgumentNullException.ThrowIfNull(minioClient);
+        return builder.WithMinioClientFactory(_ => minioClient);
+    }
+
+    /// <summary>
+    /// Specifies a IMinioClient factory function used by the Leader Election.
+    /// </summary>
+    public static ServiceBuilder WithMinioClientFactory(
+        this ServiceBuilder builder,
+        Func<S3Settings, IMinioClient> minioClientFactory
+    )
+    {
+        ArgumentNullException.ThrowIfNull(minioClientFactory);
+        return builder.WithSettings(options => options.MinioClientFactory = minioClientFactory);
+    }
+
+    /// <summary>
+    /// Specifies that the Leader Election should attempt to resolve an IMinioClient
+    /// from the DI container, first trying to resolve a keyed instance with the same
+    /// service key as the leader election registration, then falling back to an unkeyed
+    /// IMinioClient. This is the default behavior when no MinioClientFactory is configured.
+    /// </summary>
+    public static ServiceBuilder WithRegisteredMinioClient(this ServiceBuilder builder)
+    {
+        return builder.WithSettings(
+            static (opts, sp, serviceKey) =>
+                opts.MinioClientFactory = _ => GetMinioClient(serviceKey, sp)
+        );
+    }
+
+    private static IMinioClient GetMinioClient(string? serviceKey, IServiceProvider sp)
+    {
+        return sp.GetKeyedService<IMinioClient>(serviceKey)
+            ?? sp.GetRequiredService<IMinioClient>();
     }
 }

--- a/src/LeaderElection.S3/S3ServiceBuilderExtensions.cs
+++ b/src/LeaderElection.S3/S3ServiceBuilderExtensions.cs
@@ -41,7 +41,7 @@ public static class S3ServiceBuilderExtensions
     ) => AddS3LeaderElectionInternal(services, builder, serviceKey);
 
     /// <summary>
-    /// Adds S3-based leader election services to the specified specified
+    /// Adds S3-based leader election services to the specified
     /// <see cref="IServiceCollection"/>.
     /// </summary>
     /// <param name="services">The service collection to add the services to.</param>

--- a/src/LeaderElection.S3/S3ServiceBuilderExtensions.cs
+++ b/src/LeaderElection.S3/S3ServiceBuilderExtensions.cs
@@ -51,7 +51,7 @@ public static class S3ServiceBuilderExtensions
     /// application. If not provided, the services and settings will be registered
     /// without a key.</param>
     /// <returns>The updated service collection.</returns>
-    public static IServiceCollection AddS3LeaderElectionInternal(
+    private static IServiceCollection AddS3LeaderElectionInternal(
         IServiceCollection services,
         Action<ServiceBuilder> builder,
         string? serviceKey = null

--- a/src/LeaderElection.S3/S3ServiceBuilderExtensions.cs
+++ b/src/LeaderElection.S3/S3ServiceBuilderExtensions.cs
@@ -70,11 +70,27 @@ public static class S3ServiceBuilderExtensions
             serviceKey,
             static (sp, key) =>
             {
-                // get keyed settings
+                // get settings
                 var settings = sp.GetRequiredService<IOptionsSnapshot<S3Settings>>()
                     .Get(key as string);
 
-                return ActivatorUtilities.CreateInstance<S3LeaderElection>(sp, settings);
+                // Note: We must resolve the Minio client here. If we don't do it now
+                // and the factory resolves it from DI, then the Minio client (or its dependencies)
+                // may be disposed before the LeaderElection resulting in a crash.
+                var minioClient =
+                    (
+                        settings.MinioClientFactory
+                        ?? throw new InvalidOperationException(
+                            "MinioClientFactory must be specified in settings."
+                        )
+                    ).Invoke(settings)
+                    ?? throw new InvalidOperationException("MinioClientFactory returned null.");
+
+                return ActivatorUtilities.CreateInstance<S3LeaderElection>(
+                    sp,
+                    settings,
+                    minioClient
+                );
             }
         );
 
@@ -90,7 +106,7 @@ public static class S3ServiceBuilderExtensions
         // Ensure the MinioClientFactory is set. If not, configure
         // it using DI, first trying to resolve a keyed instance.
         optionsBuilder.PostConfigure<IServiceProvider>(
-            (opts, sp) => opts.MinioClientFactory ??= _ => GetMinioClient(serviceKey, sp)
+            (opts, sp) => opts.MinioClientFactory ??= _ => GetRegisteredMinioClient(sp, serviceKey)
         );
 
         return services;
@@ -228,11 +244,11 @@ public static class S3ServiceBuilderExtensions
     {
         return builder.WithSettings(
             static (opts, sp, serviceKey) =>
-                opts.MinioClientFactory = _ => GetMinioClient(serviceKey, sp)
+                opts.MinioClientFactory = _ => GetRegisteredMinioClient(sp, serviceKey)
         );
     }
 
-    private static IMinioClient GetMinioClient(string? serviceKey, IServiceProvider sp)
+    private static IMinioClient GetRegisteredMinioClient(IServiceProvider sp, string? serviceKey)
     {
         return sp.GetKeyedService<IMinioClient>(serviceKey)
             ?? sp.GetRequiredService<IMinioClient>();

--- a/src/LeaderElection.S3/S3ServiceBuilderExtensions.cs
+++ b/src/LeaderElection.S3/S3ServiceBuilderExtensions.cs
@@ -248,9 +248,7 @@ public static class S3ServiceBuilderExtensions
         );
     }
 
-    private static IMinioClient GetRegisteredMinioClient(IServiceProvider sp, string? serviceKey)
-    {
-        return sp.GetKeyedService<IMinioClient>(serviceKey)
-            ?? sp.GetRequiredService<IMinioClient>();
-    }
+    private static IMinioClient GetRegisteredMinioClient(IServiceProvider sp, object? serviceKey) =>
+        (serviceKey != null ? sp.GetKeyedService<IMinioClient>(serviceKey) : null)
+        ?? sp.GetRequiredService<IMinioClient>();
 }

--- a/src/LeaderElection.S3/S3Settings.cs
+++ b/src/LeaderElection.S3/S3Settings.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using Minio;
 
 namespace LeaderElection.S3;
 
@@ -33,4 +34,25 @@ public class S3Settings : LeaderElectionSettingsBase
         nameof(S3SettingsValidator.ValidateLeaseDuration)
     )]
     public TimeSpan LeaseDuration { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// The Minio client factory to create IMinioClient instances. If not provided, the
+    /// S3LeaderElection will use the MinioClient registered in the DI container
+    /// (assuming the S3LeaderElection is created via DI).
+    /// </summary>
+    public Func<S3Settings, IMinioClient>? MinioClientFactory { get; set; }
+
+    /// <summary>
+    /// Copies the S3 settings from the source to the destination.
+    /// </summary>
+    public static void Copy(S3Settings src, S3Settings dst)
+    {
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(dst);
+        LeaderElectionSettingsBase.Copy(src, dst);
+        dst.BucketName = src.BucketName;
+        dst.ObjectKey = src.ObjectKey;
+        dst.LeaseDuration = src.LeaseDuration;
+        dst.MinioClientFactory = src.MinioClientFactory;
+    }
 }

--- a/src/LeaderElection.S3/S3Settings.cs
+++ b/src/LeaderElection.S3/S3Settings.cs
@@ -3,12 +3,22 @@ using Minio;
 
 namespace LeaderElection.S3;
 
+/// <summary>
+/// Settings for S3-based leader election.
+/// </summary>
 public class S3Settings : LeaderElectionSettingsBase
 {
     /// <summary>
-    /// The name of the S3 bucket to use for leader election.
-    /// This bucket must exist and be accessible with the provided AWS credentials.
-    /// <para/>
+    /// An optional factory function used to obtain an <see cref="IMinioClient"/>.
+    /// </summary>
+    /// <remarks>
+    /// If not provided, it will attempt to obtain a <see cref="IMinioClient"/> from DI
+    /// (assuming the leader election is created via DI).
+    /// </remarks>
+    public Func<S3Settings, IMinioClient>? MinioClientFactory { get; set; }
+
+    /// <summary>
+    /// The name of the S3 bucket to use for leader election. This bucket must exist.
     /// Default value is "leader-election".
     /// </summary>
     [Required]
@@ -26,7 +36,6 @@ public class S3Settings : LeaderElectionSettingsBase
 
     /// <summary>
     /// The duration for which a leader holds the leadership before it needs to renew it.
-    /// <para/>
     /// Default value is 30 seconds.
     /// </summary>
     [CustomValidation(
@@ -36,13 +45,6 @@ public class S3Settings : LeaderElectionSettingsBase
     public TimeSpan LeaseDuration { get; set; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
-    /// The Minio client factory to create IMinioClient instances. If not provided, the
-    /// S3LeaderElection will use the MinioClient registered in the DI container
-    /// (assuming the S3LeaderElection is created via DI).
-    /// </summary>
-    public Func<S3Settings, IMinioClient>? MinioClientFactory { get; set; }
-
-    /// <summary>
     /// Copies the S3 settings from the source to the destination.
     /// </summary>
     public static void Copy(S3Settings src, S3Settings dst)
@@ -50,9 +52,9 @@ public class S3Settings : LeaderElectionSettingsBase
         ArgumentNullException.ThrowIfNull(src);
         ArgumentNullException.ThrowIfNull(dst);
         LeaderElectionSettingsBase.Copy(src, dst);
+        dst.MinioClientFactory = src.MinioClientFactory;
         dst.BucketName = src.BucketName;
         dst.ObjectKey = src.ObjectKey;
         dst.LeaseDuration = src.LeaseDuration;
-        dst.MinioClientFactory = src.MinioClientFactory;
     }
 }

--- a/src/LeaderElection/LeaderElection.csproj
+++ b/src/LeaderElection/LeaderElection.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <!-- Inherits settings from Directory.Build.props -->
 
   <ItemGroup>

--- a/src/LeaderElection/LeaderElection.csproj
+++ b/src/LeaderElection/LeaderElection.csproj
@@ -2,6 +2,7 @@
   <!-- Inherits settings from Directory.Build.props -->
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" />

--- a/src/LeaderElection/LeaderElectionBase.cs
+++ b/src/LeaderElection/LeaderElectionBase.cs
@@ -14,8 +14,10 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
 
     protected LeaderElectionBase(TSettings settings, ILogger logger)
     {
-        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(logger);
+        this._settings = settings;
+        this._logger = logger;
     }
 
     private readonly SemaphoreSlim _leadershipSemaphore = new(1, 1);
@@ -25,7 +27,6 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
     private int _disposedValue;
     private Task? _leadershipLoopTask;
     private DateTime _lastLeadershipRenewalTime = DateTime.MinValue;
-
     public event EventHandler<LeadershipChangedEventArgs>? LeadershipChanged;
     public event EventHandler<LeadershipExceptionEventArgs>? ErrorOccurred;
 
@@ -76,6 +77,7 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
                     }
                     else
                     {
+                        // Very common that leadership acquisition fails because another instance holds the leadership - log at debug level in that case and avoid log noise
                         LogFailedToAcquireLeadershipWillRetry();
                         retryCount++;
                     }
@@ -138,6 +140,11 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
 
     private async Task InternalStopAsync(CancellationToken cancellationToken = default)
     {
+        if (!_isLeader)
+        {
+            return;
+        }
+
         LogStoppingLeaderElectionForInstanceInstanceid(_settings.InstanceId);
 
         if (_leadershipLoopCancellationTokenSource != null)
@@ -211,7 +218,7 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
     }
 
     public async Task RunTaskIfLeaderAsync(
-        Func<Task>? task,
+        Func<Task> task,
         CancellationToken cancellationToken = default
     )
     {

--- a/src/LeaderElection/LeaderElectionBase.cs
+++ b/src/LeaderElection/LeaderElectionBase.cs
@@ -149,15 +149,10 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
 
     private async Task InternalStopAsync(CancellationToken cancellationToken = default)
     {
-        if (_leadershipLoopTask == null)
-        {
-            return;
-        }
-
-        LogStoppingLeaderElectionForInstanceInstanceid(_settings.InstanceId);
-
         if (_leadershipLoopCancellationTokenSource != null)
         {
+            LogStoppingLeaderElectionForInstanceInstanceid(_settings.InstanceId);
+
             await _leadershipLoopCancellationTokenSource.CancelAsync().ConfigureAwait(false);
         }
 

--- a/src/LeaderElection/LeaderElectionBase.cs
+++ b/src/LeaderElection/LeaderElectionBase.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace LeaderElection;
 
@@ -12,12 +13,19 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
     [SuppressMessage("Design", "CA1051", Justification = "Field readonly to derived types")]
     protected readonly ILogger _logger;
 
-    protected LeaderElectionBase(TSettings settings, ILogger logger)
+    [SuppressMessage("Design", "CA1051", Justification = "Field readonly to derived types")]
+    protected readonly TimeProvider _timeProvider;
+
+    protected LeaderElectionBase(
+        TSettings settings,
+        ILogger? logger = null,
+        TimeProvider? timeProvider = null
+    )
     {
         ArgumentNullException.ThrowIfNull(settings);
-        ArgumentNullException.ThrowIfNull(logger);
-        this._settings = settings;
-        this._logger = logger;
+        _settings = settings;
+        _logger = logger ?? NullLogger.Instance;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
     private readonly SemaphoreSlim _leadershipSemaphore = new(1, 1);
@@ -26,13 +34,13 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
     private volatile bool _isLeader;
     private int _disposedValue;
     private Task? _leadershipLoopTask;
-    private DateTime _lastLeadershipRenewalTime = DateTime.MinValue;
+    private DateTimeOffset _lastLeadershipRenewalTime = DateTimeOffset.MinValue;
     public event EventHandler<LeadershipChangedEventArgs>? LeadershipChanged;
     public event EventHandler<LeadershipExceptionEventArgs>? ErrorOccurred;
 
     private bool IsDisposed => Volatile.Read(ref _disposedValue) == 1;
     public bool IsLeader => _isLeader && !IsDisposed;
-    public DateTime LastLeadershipRenewal => _lastLeadershipRenewalTime;
+    public DateTime LastLeadershipRenewal => _lastLeadershipRenewalTime.UtcDateTime;
 
     public async Task StartAsync(CancellationToken cancellationToken = default)
     {
@@ -93,13 +101,13 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
                     else
                     {
                         LogLeadershipRenewedSuccessfully();
-                        _lastLeadershipRenewalTime = DateTime.UtcNow;
+                        _lastLeadershipRenewalTime = _timeProvider.GetUtcNow();
                         retryCount = 0;
                     }
                 }
 
                 var delay = GetNextDelay(retryCount);
-                await Task.Delay(delay, token).ConfigureAwait(false);
+                await _timeProvider.Delay(delay, token).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
@@ -113,7 +121,7 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
 
                 try
                 {
-                    await Task.Delay(_settings.RetryInterval, token).ConfigureAwait(false);
+                    await _timeProvider.Delay(_settings.RetryInterval, token).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {
@@ -193,7 +201,9 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
         if (_isLeader != isLeader)
         {
             _isLeader = isLeader;
-            _lastLeadershipRenewalTime = isLeader ? DateTime.UtcNow : DateTime.MinValue;
+            _lastLeadershipRenewalTime = isLeader
+                ? _timeProvider.GetUtcNow()
+                : DateTimeOffset.MinValue;
             LeadershipChanged?.Invoke(this, new(isLeader));
         }
     }

--- a/src/LeaderElection/LeaderElectionBase.cs
+++ b/src/LeaderElection/LeaderElectionBase.cs
@@ -38,7 +38,7 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
     public event EventHandler<LeadershipChangedEventArgs>? LeadershipChanged;
     public event EventHandler<LeadershipExceptionEventArgs>? ErrorOccurred;
 
-    public bool LeaderLoopRunning => Volatile.Read(ref _leadershipLoopTask) != null;
+    public bool LeaderLoopRunning => Volatile.Read(ref _leadershipLoopTask)?.IsCompleted is false;
 
     private bool IsDisposed => Volatile.Read(ref _disposedValue) == 1;
     public bool IsLeader => _isLeader && !IsDisposed;

--- a/src/LeaderElection/LeaderElectionBase.cs
+++ b/src/LeaderElection/LeaderElectionBase.cs
@@ -38,6 +38,8 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
     public event EventHandler<LeadershipChangedEventArgs>? LeadershipChanged;
     public event EventHandler<LeadershipExceptionEventArgs>? ErrorOccurred;
 
+    public bool LeaderLoopRunning => Volatile.Read(ref _leadershipLoopTask) != null;
+
     private bool IsDisposed => Volatile.Read(ref _disposedValue) == 1;
     public bool IsLeader => _isLeader && !IsDisposed;
     public DateTime LastLeadershipRenewal => _lastLeadershipRenewalTime.UtcDateTime;
@@ -147,7 +149,7 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
 
     private async Task InternalStopAsync(CancellationToken cancellationToken = default)
     {
-        if (!_isLeader)
+        if (_leadershipLoopTask == null)
         {
             return;
         }

--- a/src/LeaderElection/LeaderElectionBase.cs
+++ b/src/LeaderElection/LeaderElectionBase.cs
@@ -44,14 +44,8 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
 
     public async Task StartAsync(CancellationToken cancellationToken = default)
     {
-#if NET6_0_OR_GREATER
-        ObjectDisposedException.ThrowIf(IsDisposed, this);
-#else
-        if (IsDisposed)
-        {
-            throw new ObjectDisposedException(GetType().Name);
-        }
-#endif
+        ThrowIfDisposed();
+
         if (_leadershipLoopTask is { IsCompleted: false })
         {
             LogLeaderElectionIsAlreadyRunning();
@@ -70,6 +64,8 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
 
     private async Task RunLeaderLoopAsync(CancellationToken token)
     {
+        ThrowIfDisposed();
+
         var retryCount = 0;
 
         while (!token.IsCancellationRequested)
@@ -143,8 +139,11 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
         );
     }
 
-    public virtual Task StopAsync(CancellationToken cancellationToken = default) =>
-        IsDisposed ? Task.CompletedTask : InternalStopAsync(cancellationToken);
+    public virtual Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        return InternalStopAsync(cancellationToken);
+    }
 
     private async Task InternalStopAsync(CancellationToken cancellationToken = default)
     {
@@ -165,10 +164,6 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
             try
             {
                 await _leadershipLoopTask.WaitAsync(cancellationToken).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                LogLeaderLoopCancellationWasExpected();
             }
             finally
             {
@@ -210,8 +205,7 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
 
     public async Task<bool> TryAcquireLeadershipAsync(CancellationToken cancellationToken = default)
     {
-        if (IsDisposed)
-            return false;
+        ThrowIfDisposed();
 
         await _leadershipSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
@@ -232,6 +226,8 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
         CancellationToken cancellationToken = default
     )
     {
+        ThrowIfDisposed();
+
         if (!IsLeader)
         {
             LogNotTheLeaderSkippingTaskExecution();
@@ -285,6 +281,18 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
 
         _leadershipLoopCancellationTokenSource?.Dispose();
         _leadershipSemaphore.Dispose();
+    }
+
+    private void ThrowIfDisposed()
+    {
+#if NET6_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
+#else
+        if (IsDisposed)
+        {
+            throw new ObjectDisposedException(GetType().Name);
+        }
+#endif
     }
 
     [LoggerMessage(LogLevel.Warning, "Leader election is already running")]

--- a/src/LeaderElection/LeaderElectionBase.cs
+++ b/src/LeaderElection/LeaderElectionBase.cs
@@ -170,13 +170,17 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
             }
         }
 
-        if (_settings.EnableGracefulShutdown && _isLeader)
-        {
-            await ReleaseLeadershipAsync().ConfigureAwait(false);
-        }
-
         if (_isLeader)
         {
+            if (_settings.EnableGracefulShutdown)
+            {
+                await ReleaseLeadershipAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                await ResetLeadershipAsync().ConfigureAwait(false);
+            }
+
             SetLeadership(false);
         }
     }
@@ -187,6 +191,7 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
 
     protected abstract Task<bool> RenewLeadershipInternalAsync(CancellationToken cancellationToken);
     protected abstract Task ReleaseLeadershipAsync();
+    protected abstract ValueTask ResetLeadershipAsync();
 
     protected void SetLeadership(bool isLeader)
     {

--- a/src/LeaderElection/LeaderElectionSettingsBase.cs
+++ b/src/LeaderElection/LeaderElectionSettingsBase.cs
@@ -5,8 +5,8 @@ namespace LeaderElection;
 public class LeaderElectionSettingsBase
 {
     /// <summary>
-    /// A unique identifier for the group of instances participating in the
-    /// leader election.
+    /// A unique identifier for the instance participating in the
+    /// leader election. It must be unique across all contenders.
     /// <para/>
     /// Must be non-empty.
     /// Default is a new GUID.
@@ -53,4 +53,18 @@ public class LeaderElectionSettingsBase
     /// Default is true.
     /// </summary>
     public bool EnableGracefulShutdown { get; set; } = true;
+
+    /// <summary>
+    /// Copies the common settings from the source to the destination.
+    /// </summary>
+    protected static void Copy(LeaderElectionSettingsBase src, LeaderElectionSettingsBase dst)
+    {
+        ArgumentNullException.ThrowIfNull(src);
+        ArgumentNullException.ThrowIfNull(dst);
+        dst.InstanceId = src.InstanceId;
+        dst.RetryInterval = src.RetryInterval;
+        dst.RenewInterval = src.RenewInterval;
+        dst.EnableGracefulShutdown = src.EnableGracefulShutdown;
+        dst.MaxRetryAttempts = src.MaxRetryAttempts;
+    }
 }

--- a/src/Polyfill.cs
+++ b/src/Polyfill.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace LeaderElection;
 
@@ -6,7 +7,7 @@ namespace LeaderElection;
 /// Provides necessary polyfills for older versions of .NET.
 /// See https://github.com/SimonCropp/Polyfill for implementations.
 /// </summary>
-[System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+[ExcludeFromCodeCoverage]
 [System.Diagnostics.DebuggerNonUserCode]
 [SuppressMessage(
     "Reliability",
@@ -22,114 +23,168 @@ internal static class Polyfill
 {
     // csharpier-ignore-start -- contains copied code
 
-#if !NET8_0_OR_GREATER
-    // Copied from https://github.com/SimonCropp/Polyfill/blob/18243e7e051c347acf023978bd18abd181ea6695/src/Split/netstandard2.1/Polyfill_CancellationTokenSource.cs
-    /// <summary>Communicates a request for cancellation asynchronously.</summary>
-    public static Task CancelAsync(this CancellationTokenSource target)
+    extension(CancellationTokenSource target)
     {
-        if (target.IsCancellationRequested)
+#if !NET8_0_OR_GREATER
+        // Copied from https://github.com/SimonCropp/Polyfill/blob/18243e7e051c347acf023978bd18abd181ea6695/src/Split/netstandard2.1/Polyfill_CancellationTokenSource.cs
+        /// <summary>Communicates a request for cancellation asynchronously.</summary>
+        public Task CancelAsync()
         {
-            return Task.CompletedTask;
-        }
+            if (target.IsCancellationRequested)
+            {
+                return Task.CompletedTask;
+            }
 
-        var task = Task.Run(target.Cancel);
-        while (!target.IsCancellationRequested) ;
-        return task;
-    }
+            var task = Task.Run(target.Cancel);
+            while (!target.IsCancellationRequested) ;
+            return task;
+        }
 #endif
+    }
 
 #if !NET6_0_OR_GREATER
     // Copied from https://github.com/SimonCropp/Polyfill/blob/18243e7e051c347acf023978bd18abd181ea6695/src/Split/netstandard2.1/Polyfill_Task.cs
     const uint MAX_SUPPORTED_TIMEOUT = 0xfffffffe;
 
-    /// <summary>Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes or when the specified <see cref="CancellationToken"/> has cancellation requested.</summary>
-    public static Task WaitAsync(this Task target, CancellationToken cancellationToken) =>
-        target.WaitAsync(Timeout.InfiniteTimeSpan, cancellationToken);
-
-    /// <summary>Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes or when the specified timeout expires.</summary>
-    public static Task WaitAsync(
-        this Task target,
-        TimeSpan timeout) =>
-        target.WaitAsync(timeout, default);
-
-    /// <summary>Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes, when the specified timeout expires, or when the specified <see cref="CancellationToken"/> has cancellation requested.</summary>
-    public static async Task WaitAsync(
-        this Task target,
-        TimeSpan timeout,
-        CancellationToken cancellationToken)
+    extension(Task target)
     {
-        var milliseconds = (long)timeout.TotalMilliseconds;
-        if (milliseconds is < -1 or > MAX_SUPPORTED_TIMEOUT)
-        {
-            throw new ArgumentOutOfRangeException(nameof(timeout));
-        }
+        /// <summary>Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes or when the specified <see cref="CancellationToken"/> has cancellation requested.</summary>
+        public Task WaitAsync(CancellationToken cancellationToken) =>
+            target.WaitAsync(Timeout.InfiniteTimeSpan, cancellationToken);
 
-        if (target.IsCompleted ||
-            (!cancellationToken.CanBeCanceled && timeout == Timeout.InfiniteTimeSpan))
-        {
-            await target.ConfigureAwait(false);
-            return;
-        }
+        /// <summary>Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes or when the specified timeout expires.</summary>
+        public Task WaitAsync(TimeSpan timeout) =>
+            target.WaitAsync(timeout, default);
 
-        if (cancellationToken.IsCancellationRequested)
+        /// <summary>Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes, when the specified timeout expires, or when the specified <see cref="CancellationToken"/> has cancellation requested.</summary>
+        public async Task WaitAsync(
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
         {
-            await Task.FromCanceled(cancellationToken);
-        }
-
-        if (timeout == TimeSpan.Zero)
-        {
-            throw new TimeoutException();
-        }
-
-        using var cancelSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        cancelSource.CancelAfter(timeout);
-        var cancelTask = new TaskCompletionSource<bool>();
-        using (cancelSource.Token.Register(
-                   tcs => ((TaskCompletionSource<bool>)tcs!).TrySetResult(true), cancelTask))
-        {
-            await Task.WhenAny(target, cancelTask.Task).ConfigureAwait(false);
-            if (!target.IsCompleted)
+            var milliseconds = (long)timeout.TotalMilliseconds;
+            if (milliseconds is < -1 or > MAX_SUPPORTED_TIMEOUT)
             {
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    await Task.FromCanceled(cancellationToken);
-                }
+                throw new ArgumentOutOfRangeException(nameof(timeout));
+            }
 
+            if (target.IsCompleted ||
+                (!cancellationToken.CanBeCanceled && timeout == Timeout.InfiniteTimeSpan))
+            {
+                await target.ConfigureAwait(false);
+                return;
+            }
+
+            if (cancellationToken.IsCancellationRequested)
+            {
+                await Task.FromCanceled(cancellationToken);
+            }
+
+            if (timeout == TimeSpan.Zero)
+            {
                 throw new TimeoutException();
             }
 
-            await target.ConfigureAwait(false);
+            using var cancelSource =
+                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cancelSource.CancelAfter(timeout);
+            var cancelTask = new TaskCompletionSource<bool>();
+            using (cancelSource.Token.Register(
+                       tcs => ((TaskCompletionSource<bool>)tcs!).TrySetResult(true), cancelTask))
+            {
+                await Task.WhenAny(target, cancelTask.Task).ConfigureAwait(false);
+                if (!target.IsCompleted)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        await Task.FromCanceled(cancellationToken);
+                    }
+
+                    throw new TimeoutException();
+                }
+
+                await target.ConfigureAwait(false);
+            }
         }
     }
 
-    /// <summary>
-    /// Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes, or when the specified <see cref="CancellationToken"/> has cancellation requested.
-    /// </summary>
-    public static Task<TResult> WaitAsync<TResult>(
-        this Task<TResult> target,
-        CancellationToken cancellationToken) =>
-        target.WaitAsync<TResult>(Timeout.InfiniteTimeSpan, cancellationToken);
-
-    /// <summary>
-    /// Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes, or when the specified timeout expires.
-    /// </summary>
-    public static Task<TResult> WaitAsync<TResult>(
-        this Task<TResult> target,
-        TimeSpan timeout) =>
-        target.WaitAsync<TResult>(timeout, default);
-
-    /// <summary>
-    /// Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes, when the specified timeout expires, or when the specified <see cref="CancellationToken"/> has cancellation requested.
-    /// </summary>
-    public static async Task<TResult> WaitAsync<TResult>(
-        this Task<TResult> target,
-        TimeSpan timeout,
-        CancellationToken cancellationToken)
+    extension<TResult>(Task<TResult> target)
     {
-        await ((Task)target).WaitAsync(timeout, cancellationToken);
-        return target.Result;
+        /// <summary>
+        /// Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes, or when the specified <see cref="CancellationToken"/> has cancellation requested.
+        /// </summary>
+        public Task<TResult> WaitAsync(CancellationToken cancellationToken) =>
+            target.WaitAsync(Timeout.InfiniteTimeSpan, cancellationToken);
+
+        /// <summary>
+        /// Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes, or when the specified timeout expires.
+        /// </summary>
+        public Task<TResult> WaitAsync(TimeSpan timeout) =>
+            target.WaitAsync(timeout, default);
+
+        /// <summary>
+        /// Gets a <see cref="Task"/> that will complete when this <see cref="Task"/> completes, when the specified timeout expires, or when the specified <see cref="CancellationToken"/> has cancellation requested.
+        /// </summary>
+        public async Task<TResult> WaitAsync(
+            TimeSpan timeout,
+            CancellationToken cancellationToken)
+        {
+            await ((Task)target).WaitAsync(timeout, cancellationToken);
+            return target.Result;
+        }
     }
 #endif
+
+    extension(ArgumentNullException)
+    {
+#if !NET6_0_OR_GREATER
+        public static void ThrowIfNull([NotNull] object? argument,
+            [CallerArgumentExpression(nameof(argument))]
+            string? paramName = null)
+        {
+            if (argument is null)
+            {
+                throw new ArgumentNullException(paramName);
+            }
+        }
+#endif
+
+#if !NET7_0_OR_GREATER
+        public static void ThrowIfNullOrEmpty([NotNull] string? argument,
+            [CallerArgumentExpression(nameof(argument))]
+            string? paramName = null)
+        {
+            if (string.IsNullOrEmpty(argument))
+            {
+                throw argument is null
+                    ? new ArgumentNullException(paramName)
+                    : new ArgumentException("Value cannot be empty.", paramName);
+            }
+        }
+#endif
+    }
+
+    extension(ObjectDisposedException)
+    {
+#if !NET7_0_OR_GREATER
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.objectdisposedexception.throwif?view=net-11.0##system-objectdisposedexception-throwif(system-boolean-system-object)
+        public static void ThrowIf(bool condition, object instance)
+        {
+            if (condition)
+            {
+                throw new ObjectDisposedException(instance.GetType().FullName);
+            }
+        }
+
+        //Link: https://learn.microsoft.com/en-us/dotnet/api/system.objectdisposedexception.throwif?view=net-11.0##system-objectdisposedexception-throwif(system-boolean-system-type)
+        public static void ThrowIf(bool condition, Type type)
+        {
+            if (condition)
+            {
+                throw new ObjectDisposedException(type.FullName);
+            }
+        }
+#endif
+    }
 
     // csharpier-ignore-end
 }

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -6,7 +6,7 @@ dotnet_diagnostic.CA1852.severity = suggestion
 dotnet_diagnostic.CA1515.severity = suggestion
 
 # CA2007: Consider calling ConfigureAwait on the awaited task
-dotnet_diagnostic.CA2007.severity = suggestion
+dotnet_diagnostic.CA2007.severity = none
 
 # CA1305: Specify IFormatProvider
 dotnet_diagnostic.CA1305.severity = suggestion

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -7,3 +7,6 @@ dotnet_diagnostic.CA1515.severity = suggestion
 
 # CA2007: Consider calling ConfigureAwait on the awaited task
 dotnet_diagnostic.CA2007.severity = suggestion
+
+# CA1305: Specify IFormatProvider
+dotnet_diagnostic.CA1305.severity = suggestion

--- a/tests/LeaderElection.Tests/BlobStorageLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/BlobStorageLeaderElectionTests.cs
@@ -2,9 +2,6 @@ using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Specialized;
 using LeaderElection.BlobStorage;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 
 namespace LeaderElection.Tests;
 
@@ -95,7 +92,7 @@ public sealed class BlobStorageLeaderElectionTests(AzuriteContainerFixture azuri
         await WaitForLeadershipChange(leaderElection1, true, TimeSpan.FromSeconds(15));
 
         await leaderElection2.StartAsync(CancellationToken);
-        await Task.Delay(TimeSpan.FromSeconds(5), CancellationToken); // Give time for second instance to try
+        await TimeProvider.Delay(TimeSpan.FromSeconds(5), CancellationToken); // Give time for second instance to try
 
         // Assert
         leaderElection1.IsLeader.Should().BeTrue();

--- a/tests/LeaderElection.Tests/BlobStorageLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/BlobStorageLeaderElectionTests.cs
@@ -1,6 +1,7 @@
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Specialized;
 using LeaderElection.BlobStorage;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -41,12 +42,14 @@ public sealed class BlobStorageLeaderElectionTests(AzuriteContainerFixture azuri
             CreateContainerIfNotExists = createContainerIfNotExists,
         };
 
-    private BlobStorageLeaderElection CreateSut(BlobStorageSettings options) =>
-        new(
-            _blobServiceClient,
-            Options.Create(options),
-            NullLoggerFactory.Instance.CreateLogger<BlobStorageLeaderElection>()
-        );
+    private BlobStorageLeaderElection CreateSut(BlobStorageSettings settings) =>
+        new ServiceCollection()
+            .AddLogging()
+            .AddBlobStorageLeaderElection(builder =>
+                builder.WithSettings(settings).WithBlobServiceClient(_blobServiceClient)
+            )
+            .BuildServiceProvider()
+            .GetRequiredService<BlobStorageLeaderElection>();
 
     [Fact]
     public async Task ShouldAcquireLeadershipWhenNoOtherInstanceExists()
@@ -227,27 +230,6 @@ public sealed class BlobStorageLeaderElectionTests(AzuriteContainerFixture azuri
         var blobExists = await blobClient.ExistsAsync(CancellationToken);
         blobExists.Value.Should().BeTrue();
 
-        await leaderElection.StopAsync(CancellationToken);
-    }
-
-    [Fact]
-    public async Task ShouldWorkWithSecondConstructor()
-    {
-        var containerName = "test-second-constructor";
-        var options = CreateSettings(containerName);
-        var containerClient = _blobServiceClient.GetBlobContainerClient(containerName);
-        await containerClient.CreateIfNotExistsAsync(cancellationToken: CancellationToken);
-
-        await using var leaderElection = new BlobStorageLeaderElection(
-            containerClient,
-            options,
-            NullLoggerFactory.Instance.CreateLogger<BlobStorageLeaderElection>()
-        );
-
-        await leaderElection.StartAsync(CancellationToken);
-        await WaitForLeadershipChange(leaderElection, true, options.LeaseDuration);
-
-        leaderElection.IsLeader.Should().BeTrue();
         await leaderElection.StopAsync(CancellationToken);
     }
 

--- a/tests/LeaderElection.Tests/BlobStorageLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/BlobStorageLeaderElectionTests.cs
@@ -9,9 +9,18 @@ namespace LeaderElection.Tests;
 [Trait("Kind", "Integration")]
 [Trait("Category", "BlobStorage")]
 public sealed class BlobStorageLeaderElectionTests(AzuriteContainerFixture azuriteFixture)
-    : TestBase
+    : TestBase,
+        IAsyncDisposable
 {
     private readonly BlobServiceClient _blobServiceClient = azuriteFixture.BlobServiceClient;
+    private readonly List<ServiceProvider> _serviceProviders = [];
+
+    public async ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+        foreach (var sp in _serviceProviders ?? [])
+            await sp.DisposeAsync();
+    }
 
     private BlobStorageSettings CreateSettings(
         string containerName, // should be unique per test to avoid conflicts
@@ -39,14 +48,18 @@ public sealed class BlobStorageLeaderElectionTests(AzuriteContainerFixture azuri
             CreateContainerIfNotExists = createContainerIfNotExists,
         };
 
-    private BlobStorageLeaderElection CreateSut(BlobStorageSettings settings) =>
-        new ServiceCollection()
+    private BlobStorageLeaderElection CreateSut(BlobStorageSettings settings)
+    {
+        var serviceProvider = new ServiceCollection()
             .AddLogging()
             .AddBlobStorageLeaderElection(builder =>
                 builder.WithSettings(settings).WithBlobServiceClient(_blobServiceClient)
             )
-            .BuildServiceProvider()
-            .GetRequiredService<BlobStorageLeaderElection>();
+            .BuildServiceProvider();
+
+        _serviceProviders.Add(serviceProvider);
+        return serviceProvider.GetRequiredService<BlobStorageLeaderElection>();
+    }
 
     [Fact]
     public async Task ShouldAcquireLeadershipWhenNoOtherInstanceExists()

--- a/tests/LeaderElection.Tests/BlobStorageServiceBuilderExtensionsTests.cs
+++ b/tests/LeaderElection.Tests/BlobStorageServiceBuilderExtensionsTests.cs
@@ -1,0 +1,438 @@
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Blobs.Specialized;
+using LeaderElection.BlobStorage;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace LeaderElection.Tests;
+
+public sealed class BlobStorageServiceBuilderExtensionsTests
+{
+    // Settings with all properties set to non-default values.
+    private readonly BlobStorageSettings settings = new()
+    {
+        ConnectionString = "...",
+        ContainerName = "container",
+        BlobName = "blob",
+        LeaseDuration = TimeSpan.FromSeconds(20),
+        CreateContainerIfNotExists = false,
+        InstanceId = "foo",
+        RenewInterval = TimeSpan.FromSeconds(2),
+        RetryInterval = TimeSpan.FromSeconds(1),
+        MaxRetryAttempts = 300,
+        EnableGracefulShutdown = false,
+    };
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData(null)]
+    public async Task ShouldAddOptionsCorrectlyWhenUsingDirectSettings(string? serviceKey)
+    {
+        // Arrange
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddBlobStorageLeaderElection(b => b.WithSettings(settings), serviceKey)
+            .BuildServiceProvider();
+
+        // Assert
+        var actualSettings = sp.GetRequiredService<IOptionsMonitor<BlobStorageSettings>>()
+            .Get(serviceKey);
+        actualSettings.Should().BeEquivalentTo(settings);
+    }
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData(null)]
+    public async Task ShouldAddOptionsCorrectlyWhenUsingConfiguration(string? serviceKey)
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["LeaderElection:BlobStorage:ConnectionString"] = settings.ConnectionString,
+                    ["LeaderElection:BlobStorage:ContainerName"] = settings.ContainerName,
+                    ["LeaderElection:BlobStorage:BlobName"] = settings.BlobName,
+                    ["LeaderElection:BlobStorage:LeaseDuration"] =
+                        settings.LeaseDuration.ToString(),
+                    ["LeaderElection:BlobStorage:CreateContainerIfNotExists"] =
+                        settings.CreateContainerIfNotExists.ToString(),
+                    // ["LeaderElection:Base:InstanceId"] = settings.InstanceId,
+                    ["LeaderElection:Base:RenewInterval"] = settings.RenewInterval.ToString(),
+                    ["LeaderElection:Base:RetryInterval"] = settings.RetryInterval.ToString(),
+                    ["LeaderElection:Base:MaxRetryAttempts"] = settings.MaxRetryAttempts.ToString(),
+                    // ["LeaderElection:Base:EnableGracefulShutdown"] = settings.EnableGracefulShutdown.ToString(),
+                }
+            )
+            .Build();
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IConfiguration>(config)
+            .AddBlobStorageLeaderElection(
+                builder =>
+                    builder
+                        .WithConfiguration("LeaderElection:BlobStorage")
+                        .WithConfiguration(config.GetSection("LeaderElection:Base"))
+                        .WithInstanceId(settings.InstanceId)
+                        .WithSettings(s =>
+                            s.EnableGracefulShutdown = settings.EnableGracefulShutdown
+                        ),
+                serviceKey
+            )
+            .BuildServiceProvider();
+
+        // Assert
+        var actualSettings = sp.GetRequiredService<IOptionsSnapshot<BlobStorageSettings>>()
+            .Get(serviceKey);
+        actualSettings.Should().BeEquivalentTo(settings);
+    }
+
+    [Theory]
+    [InlineData("foo", true)]
+    [InlineData("foo", false)]
+    [InlineData(null, false)]
+    public async Task ShouldSetDefaultBlobClientFactoryWhenConnectionStringIsNull(
+        string? serviceKey,
+        bool useKeyedBSC
+    )
+    {
+        // Arrange
+        var settings = new BlobStorageSettings
+        {
+            ConnectionString = null, // use BSC from DI
+            CreateContainerIfNotExists = false,
+        };
+
+        var mockBC = Mock.Of<BlobClient>();
+        var mockBCC = Mock.Of<BlobContainerClient>(m =>
+            m.GetBlobClient(settings.BlobName) == mockBC
+        );
+        var mockBSC = Mock.Of<BlobServiceClient>(m =>
+            m.GetBlobContainerClient(settings.ContainerName) == mockBCC
+        );
+        var bsc = new BlobServiceClient("UseDevelopmentStorage=true");
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddKeyedSingleton(useKeyedBSC ? serviceKey : null, bsc)
+            .AddBlobStorageLeaderElection(builder => builder.WithSettings(settings), serviceKey)
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptionsMonitor<BlobStorageSettings>>().Get(serviceKey);
+        options.BlobClientFactory.Should().NotBeNull();
+        var actualBC = await options.BlobClientFactory(
+            settings,
+            TestContext.Current.CancellationToken
+        );
+        actualBC.Should().NotBeNull();
+        actualBC.Name.Should().Be(settings.BlobName);
+        actualBC.BlobContainerName.Should().Be(settings.ContainerName);
+        actualBC
+            .GetParentBlobContainerClient()
+            .GetParentBlobServiceClient()
+            .Uri.Should()
+            .Be(bsc.Uri);
+
+        var leaderElection = sp.GetRequiredKeyedService<BlobStorageLeaderElection>(serviceKey);
+        sp.GetRequiredKeyedService<ILeaderElection>(serviceKey).Should().BeSameAs(leaderElection);
+    }
+
+    [Theory]
+    [InlineData("foo", true)]
+    [InlineData("foo", false)]
+    [InlineData(null, false)]
+    public async Task ShouldUseRegisteredBlobClientFactoryWhenTold(
+        string? serviceKey,
+        bool useKeyedBSC
+    )
+    {
+        // Arrange
+        var settings = new BlobStorageSettings
+        {
+            ConnectionString = "invalid; will be ignored",
+            CreateContainerIfNotExists = false,
+        };
+
+        var bsc = new BlobServiceClient("UseDevelopmentStorage=true");
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddKeyedSingleton(useKeyedBSC ? serviceKey : null, bsc)
+            .AddBlobStorageLeaderElection(
+                builder => builder.WithSettings(settings).WithRegisteredBlobServiceClient(),
+                serviceKey
+            )
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptionsMonitor<BlobStorageSettings>>().Get(serviceKey);
+        options.BlobClientFactory.Should().NotBeNull();
+        var actualBC = await options.BlobClientFactory(
+            settings,
+            TestContext.Current.CancellationToken
+        );
+        actualBC.Should().NotBeNull();
+        actualBC.Name.Should().Be(settings.BlobName);
+        actualBC.BlobContainerName.Should().Be(settings.ContainerName);
+        actualBC
+            .GetParentBlobContainerClient()
+            .GetParentBlobServiceClient()
+            .Uri.Should()
+            .Be(bsc.Uri);
+    }
+
+    [Fact]
+    public async Task ShouldNotSetDefaultBlobClientFactoryWhenConnectionStringIsUsed()
+    {
+        // Arrange
+        var settings = new BlobStorageSettings()
+        {
+            ConnectionString = "UseDevelopmentStorage=true",
+            CreateContainerIfNotExists = false,
+        };
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddBlobStorageLeaderElection(b => b.WithSettings(settings))
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptions<BlobStorageSettings>>().Value;
+        options.BlobClientFactory.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData(null)]
+    public async Task ShouldAddServicesCorrectlyWhenUsingBCInstance(string? serviceKey)
+    {
+        // Arrange
+        var mockBC = Mock.Of<BlobClient>();
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddBlobStorageLeaderElection(b => b.WithBlobClient(mockBC), serviceKey)
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptionsMonitor<BlobStorageSettings>>().Get(serviceKey);
+        options.BlobClientFactory.Should().NotBeNull();
+        var actualBC = await options.BlobClientFactory(
+            settings,
+            TestContext.Current.CancellationToken
+        );
+        actualBC.Should().BeSameAs(mockBC);
+
+        var leaderElection = sp.GetRequiredKeyedService<BlobStorageLeaderElection>(serviceKey);
+        sp.GetRequiredKeyedService<ILeaderElection>(serviceKey).Should().BeSameAs(leaderElection);
+    }
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData(null)]
+    public async Task ShouldAddServicesCorrectlyWhenUsingBSCInstance(string? serviceKey)
+    {
+        // Arrange
+        var bsc = new BlobServiceClient("UseDevelopmentStorage=true");
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddBlobStorageLeaderElection(b => b.WithBlobServiceClient(bsc), serviceKey)
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptionsMonitor<BlobStorageSettings>>().Get(serviceKey);
+        options.BlobClientFactory.Should().NotBeNull();
+        var actualBC = await options.BlobClientFactory(
+            settings,
+            TestContext.Current.CancellationToken
+        );
+        actualBC
+            .GetParentBlobContainerClient()
+            .GetParentBlobServiceClient()
+            .Uri.Should()
+            .Be(bsc.Uri);
+
+        var leaderElection = sp.GetRequiredKeyedService<BlobStorageLeaderElection>(serviceKey);
+        sp.GetRequiredKeyedService<ILeaderElection>(serviceKey).Should().BeSameAs(leaderElection);
+    }
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData(null)]
+    public async Task ShouldAddServicesCorrectlyWhenUsingCustomBCFactory(string? serviceKey)
+    {
+        // Arrange
+        var mockBC = Mock.Of<BlobClient>();
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddBlobStorageLeaderElection(
+                b => b.WithBlobClientFactory((_, _, _) => Task.FromResult(mockBC)),
+                serviceKey
+            )
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptionsMonitor<BlobStorageSettings>>().Get(serviceKey);
+        options.BlobClientFactory.Should().NotBeNull();
+        var actualBC = await options.BlobClientFactory(
+            settings,
+            TestContext.Current.CancellationToken
+        );
+        actualBC.Should().BeSameAs(mockBC);
+
+        var leaderElection = sp.GetRequiredKeyedService<BlobStorageLeaderElection>(serviceKey);
+        sp.GetRequiredKeyedService<ILeaderElection>(serviceKey).Should().BeSameAs(leaderElection);
+    }
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData(null)]
+    public async Task ShouldAddServicesCorrectlyWhenUsingCustomBSC(string? serviceKey)
+    {
+        // Arrange
+        var bsc = new BlobServiceClient("UseDevelopmentStorage=true");
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddBlobStorageLeaderElection(
+                builder => builder.WithSettings(settings).WithBlobServiceClientFactory(_ => bsc),
+                serviceKey
+            )
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptionsMonitor<BlobStorageSettings>>().Get(serviceKey);
+        options.BlobClientFactory.Should().NotBeNull();
+        var actualBC = await options.BlobClientFactory(
+            settings,
+            TestContext.Current.CancellationToken
+        );
+        actualBC
+            .GetParentBlobContainerClient()
+            .GetParentBlobServiceClient()
+            .Uri.Should()
+            .Be(bsc.Uri);
+
+        var leaderElection = sp.GetRequiredKeyedService<BlobStorageLeaderElection>(serviceKey);
+        sp.GetRequiredKeyedService<ILeaderElection>(serviceKey).Should().BeSameAs(leaderElection);
+    }
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData(null)]
+    public async Task ShouldAddServicesCorrectlyWhenUsingBCC(string? serviceKey)
+    {
+        // Arrange
+        var bsc = new BlobServiceClient("UseDevelopmentStorage=true");
+        var bcc = bsc.GetBlobContainerClient(settings.ContainerName);
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddBlobStorageLeaderElection(
+                builder => builder.WithSettings(settings).WithContainerClient(bcc),
+                serviceKey
+            )
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptionsMonitor<BlobStorageSettings>>().Get(serviceKey);
+        options.BlobClientFactory.Should().NotBeNull();
+        var actualBC = await options.BlobClientFactory(
+            settings,
+            TestContext.Current.CancellationToken
+        );
+        actualBC.GetParentBlobContainerClient().Uri.Should().Be(bcc.Uri);
+
+        var leaderElection = sp.GetRequiredKeyedService<BlobStorageLeaderElection>(serviceKey);
+        sp.GetRequiredKeyedService<ILeaderElection>(serviceKey).Should().Be(leaderElection);
+    }
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData(null)]
+    public async Task ShouldAddServicesCorrectlyWhenUsingCustomBCC(string? serviceKey)
+    {
+        // Arrange
+        settings.CreateContainerIfNotExists = true; // for coverage
+
+        var mockBC = Mock.Of<BlobClient>();
+        var mockBCC = Mock.Of<BlobContainerClient>(m =>
+            m.GetBlobClient(settings.BlobName) == mockBC
+            && m.CreateIfNotExistsAsync(
+                publicAccessType: default,
+                metadata: default,
+                encryptionScopeOptions: default,
+                cancellationToken: It.IsAny<CancellationToken>()
+            )
+                == Task.FromResult(
+                    Azure.Response.FromValue(
+                        BlobsModelFactory.BlobContainerInfo(new("etag"), DateTimeOffset.UtcNow),
+                        Mock.Of<Azure.Response>(m => m.Status == 201)
+                    )
+                )
+        );
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddBlobStorageLeaderElection(
+                builder => builder.WithSettings(settings).WithContainerClient(mockBCC),
+                serviceKey
+            )
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptionsMonitor<BlobStorageSettings>>().Get(serviceKey);
+        options.BlobClientFactory.Should().NotBeNull();
+        var actualBC = await options.BlobClientFactory(
+            settings,
+            TestContext.Current.CancellationToken
+        );
+        actualBC.Should().BeSameAs(mockBC);
+
+        Mock.Get(mockBCC).VerifyAll();
+    }
+
+    [Fact]
+    public async Task ShouldAddServicesCorrectlyWhenUsingEndpointOverload()
+    {
+        // Arrange
+        var endpoint = "https://foo.fake"; // will not actually connect to Azure in this test
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddBlobStorageLeaderElection(endpoint: endpoint, settings)
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptions<BlobStorageSettings>>().Value;
+        options.BlobClientFactory.Should().NotBeNull();
+        var actualBC = await options.BlobClientFactory(
+            settings,
+            TestContext.Current.CancellationToken
+        );
+        actualBC.Should().NotBeNull();
+        actualBC
+            .Uri.ToString()
+            .Should()
+            .Be($"{endpoint}/{settings.ContainerName}/{settings.BlobName}");
+    }
+}

--- a/tests/LeaderElection.Tests/BlobStorageServiceBuilderExtensionsTests.cs
+++ b/tests/LeaderElection.Tests/BlobStorageServiceBuilderExtensionsTests.cs
@@ -88,7 +88,7 @@ public sealed class BlobStorageServiceBuilderExtensionsTests
             .BuildServiceProvider();
 
         // Assert
-        var actualSettings = sp.GetRequiredService<IOptionsSnapshot<BlobStorageSettings>>()
+        var actualSettings = sp.GetRequiredService<IOptionsMonitor<BlobStorageSettings>>()
             .Get(serviceKey);
         actualSettings.Should().BeEquivalentTo(settings);
     }

--- a/tests/LeaderElection.Tests/BlobStorageServiceBuilderExtensionsTests.cs
+++ b/tests/LeaderElection.Tests/BlobStorageServiceBuilderExtensionsTests.cs
@@ -109,13 +109,6 @@ public sealed class BlobStorageServiceBuilderExtensionsTests
             CreateContainerIfNotExists = false,
         };
 
-        var mockBC = Mock.Of<BlobClient>();
-        var mockBCC = Mock.Of<BlobContainerClient>(m =>
-            m.GetBlobClient(settings.BlobName) == mockBC
-        );
-        var mockBSC = Mock.Of<BlobServiceClient>(m =>
-            m.GetBlobContainerClient(settings.ContainerName) == mockBCC
-        );
         var bsc = new BlobServiceClient("UseDevelopmentStorage=true");
 
         // Act

--- a/tests/LeaderElection.Tests/FakeLeaderElection.cs
+++ b/tests/LeaderElection.Tests/FakeLeaderElection.cs
@@ -61,4 +61,6 @@ internal sealed class FakeLeaderElection : LeaderElectionBase<FakeLeaderElection
         _settings.ReleaseAction?.Invoke();
         return Task.CompletedTask;
     }
+
+    protected override ValueTask ResetLeadershipAsync() => ValueTask.CompletedTask;
 }

--- a/tests/LeaderElection.Tests/FakeLeaderElection.cs
+++ b/tests/LeaderElection.Tests/FakeLeaderElection.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.Time.Testing;
+
+namespace LeaderElection.Tests;
+
+internal sealed class FakeLeaderElectionSettings : LeaderElectionSettingsBase
+{
+    public Func<bool> AcquireResult { get; set; } = () => true;
+    public Func<bool> RenewResult { get; set; } = () => true;
+    public Action? ReleaseAction { get; set; }
+
+    public int TryAcquireCount { get; set; }
+    public int TryRenewCount { get; set; }
+    public int TryReleaseCount { get; set; }
+    public int LeadershipChangedCount { get; set; }
+    public int ErrorCount { get; set; }
+}
+
+internal sealed class FakeLeaderElection : LeaderElectionBase<FakeLeaderElectionSettings>
+{
+    public FakeLeaderElectionSettings Settings => _settings;
+
+    public FakeLeaderElection(FakeLeaderElectionSettings settings, FakeTimeProvider timeProvider)
+        : base(settings, timeProvider: timeProvider)
+    {
+        LeadershipChanged += (s, e) =>
+        {
+            s.Should().BeSameAs(this);
+            e.Should().NotBeNull();
+            _settings.LeadershipChangedCount++;
+        };
+
+        ErrorOccurred += (s, e) =>
+        {
+            s.Should().BeSameAs(this);
+            e.Should().NotBeNull();
+            e.LeadershipException.Should().NotBeNull();
+            _settings.ErrorCount++;
+        };
+    }
+
+    // Use a fixed retry for easier testing
+    protected override TimeSpan GetNextDelay(int retryCount) => _settings.RetryInterval;
+
+    protected override Task<bool> TryAcquireLeadershipInternalAsync(
+        CancellationToken cancellationToken
+    )
+    {
+        _settings.TryAcquireCount++;
+        return Task.FromResult(_settings.AcquireResult());
+    }
+
+    protected override Task<bool> RenewLeadershipInternalAsync(CancellationToken cancellationToken)
+    {
+        _settings.TryRenewCount++;
+        return Task.FromResult(_settings.RenewResult());
+    }
+
+    protected override Task ReleaseLeadershipAsync()
+    {
+        _settings.TryReleaseCount++;
+        _settings.ReleaseAction?.Invoke();
+        return Task.CompletedTask;
+    }
+}

--- a/tests/LeaderElection.Tests/LeaderElection.Tests.csproj
+++ b/tests/LeaderElection.Tests/LeaderElection.Tests.csproj
@@ -5,6 +5,7 @@
     <!-- for Codecov test results -->
     <PackageReference Include="JunitXml.TestLogger" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/LeaderElection.Tests/LeaderElection.Tests.csproj
+++ b/tests/LeaderElection.Tests/LeaderElection.Tests.csproj
@@ -4,6 +4,7 @@
     <PackageReference Include="AwesomeAssertions" />
     <!-- for Codecov test results -->
     <PackageReference Include="JunitXml.TestLogger" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit.v3" />

--- a/tests/LeaderElection.Tests/LeaderElectionBaseTests.cs
+++ b/tests/LeaderElection.Tests/LeaderElectionBaseTests.cs
@@ -6,8 +6,7 @@ namespace LeaderElection.Tests;
 public class LeaderElectionBaseTests
 {
     private sealed class MockLeaderElection(LeaderElectionSettingsBase settings, ILogger logger)
-        : LeaderElectionBase<LeaderElectionSettingsBase>(settings, logger),
-            IDisposable
+        : LeaderElectionBase<LeaderElectionSettingsBase>(settings, logger)
     {
         public int TryAcquireCalls { get; private set; }
         public int RenewCalls { get; private set; }
@@ -44,20 +43,6 @@ public class LeaderElectionBaseTests
         }
 
         protected override TimeSpan GetNextDelay(int retryCount) => TimeSpan.FromMilliseconds(50);
-
-        private static void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                // TODO release managed resources here
-            }
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
     }
 
     [Fact]
@@ -68,7 +53,7 @@ public class LeaderElectionBaseTests
             RenewInterval = TimeSpan.FromMilliseconds(50),
             RetryInterval = TimeSpan.FromMilliseconds(50),
         };
-        using var sut = new MockLeaderElection(settings, NullLogger.Instance);
+        await using var sut = new MockLeaderElection(settings, NullLogger.Instance);
         sut.TryAcquireResult = _ => Task.FromResult(true);
 
         await sut.StartAsync(TestContext.Current.CancellationToken);
@@ -90,7 +75,7 @@ public class LeaderElectionBaseTests
             RetryInterval = TimeSpan.FromMilliseconds(50),
             MaxRetryAttempts = 1,
         };
-        using var sut = new MockLeaderElection(settings, NullLogger.Instance);
+        await using var sut = new MockLeaderElection(settings, NullLogger.Instance);
         var calls = 0;
         sut.TryAcquireResult = _ => Task.FromResult(++calls > 1);
 
@@ -112,7 +97,7 @@ public class LeaderElectionBaseTests
             RenewInterval = TimeSpan.FromMilliseconds(20),
             RetryInterval = TimeSpan.FromMilliseconds(20),
         };
-        using var sut = new MockLeaderElection(settings, NullLogger.Instance);
+        await using var sut = new MockLeaderElection(settings, NullLogger.Instance);
 
         await sut.StartAsync(TestContext.Current.CancellationToken);
 
@@ -134,7 +119,7 @@ public class LeaderElectionBaseTests
             RetryInterval = TimeSpan.FromMilliseconds(50),
             MaxRetryAttempts = 1,
         };
-        using var sut = new MockLeaderElection(settings, NullLogger.Instance);
+        await using var sut = new MockLeaderElection(settings, NullLogger.Instance);
         var tcs = new TaskCompletionSource<bool>();
         sut.LeadershipChanged += (_, leaderShipChanged) =>
         {
@@ -160,7 +145,7 @@ public class LeaderElectionBaseTests
     public async Task RunTaskIfLeaderAsyncShouldOnlyRunWhenLeader()
     {
         var settings = new LeaderElectionSettingsBase();
-        using var sut = new MockLeaderElection(settings, NullLogger.Instance);
+        await using var sut = new MockLeaderElection(settings, NullLogger.Instance);
         var taskExecuted = false;
 
         await sut.RunTaskIfLeaderAsync(
@@ -181,7 +166,7 @@ public class LeaderElectionBaseTests
     public async Task StopAsyncShouldReleaseLeadershipWhenEnabled()
     {
         var settings = new LeaderElectionSettingsBase { EnableGracefulShutdown = true };
-        using var sut = new MockLeaderElection(settings, NullLogger.Instance);
+        await using var sut = new MockLeaderElection(settings, NullLogger.Instance);
 
         await sut.StartAsync(TestContext.Current.CancellationToken);
         await WaitUntilLeader(sut, true, TimeSpan.FromSeconds(5));
@@ -196,7 +181,7 @@ public class LeaderElectionBaseTests
     public async Task DisposeAsyncShouldStopCorrectly()
     {
         var settings = new LeaderElectionSettingsBase();
-        var sut = new MockLeaderElection(settings, NullLogger.Instance);
+        await using var sut = new MockLeaderElection(settings, NullLogger.Instance);
 
         await sut.StartAsync(TestContext.Current.CancellationToken);
         await WaitUntilLeader(sut, true, TimeSpan.FromSeconds(5));

--- a/tests/LeaderElection.Tests/LeaderElectionBaseTests.cs
+++ b/tests/LeaderElection.Tests/LeaderElectionBaseTests.cs
@@ -1,215 +1,363 @@
+using Microsoft.Extensions.Time.Testing;
+
 namespace LeaderElection.Tests;
 
 public class LeaderElectionBaseTests
 {
-    private sealed class MockLeaderElection(LeaderElectionSettingsBase settings)
-        : LeaderElectionBase<LeaderElectionSettingsBase>(settings)
+    readonly FakeTimeProvider _fakeTimeProvider = new();
+
+    FakeLeaderElection CreateSut(FakeLeaderElectionSettings? settings = null) =>
+        new(settings ?? new(), _fakeTimeProvider);
+
+    // Helper method to fast forward time and allow any released tasks to run
+    async Task FastForward(TimeSpan timeSpan)
     {
-        public int TryAcquireCalls { get; private set; }
-        public int RenewCalls { get; private set; }
-        public int ReleaseCalls { get; private set; }
-
-        public Func<CancellationToken, Task<bool>>? TryAcquireResult { get; set; } =
-            _ => Task.FromResult(true);
-
-        public Func<CancellationToken, Task<bool>>? RenewResult { get; set; } =
-            _ => Task.FromResult(true);
-
-        public Func<Task>? ReleaseAction { get; set; }
-
-        protected override async Task<bool> TryAcquireLeadershipInternalAsync(
-            CancellationToken cancellationToken
-        )
-        {
-            TryAcquireCalls++;
-            return await TryAcquireResult!(cancellationToken).ConfigureAwait(false);
-        }
-
-        protected override async Task<bool> RenewLeadershipInternalAsync(
-            CancellationToken cancellationToken
-        )
-        {
-            RenewCalls++;
-            return await RenewResult!(cancellationToken).ConfigureAwait(false);
-        }
-
-        protected override Task ReleaseLeadershipAsync()
-        {
-            ReleaseCalls++;
-            return ReleaseAction?.Invoke() ?? Task.CompletedTask;
-        }
-
-        protected override TimeSpan GetNextDelay(int retryCount) => TimeSpan.FromMilliseconds(50);
+        _fakeTimeProvider.Advance(timeSpan);
+        await Task.Yield(); // allow any released tasks to run
     }
 
     [Fact]
-    public async Task StartAsyncShouldAcquireLeadershipSuccessfully()
+    public async Task StartAsyncShouldAcquireLeadership()
     {
-        var settings = new LeaderElectionSettingsBase
-        {
-            RenewInterval = TimeSpan.FromMilliseconds(50),
-            RetryInterval = TimeSpan.FromMilliseconds(50),
-        };
-        await using var sut = new MockLeaderElection(settings);
-        sut.TryAcquireResult = _ => Task.FromResult(true);
+        // Arrange
+        await using var sut = CreateSut();
 
+        // Act
         await sut.StartAsync(TestContext.Current.CancellationToken);
+        await FastForward(TimeSpan.Zero);
 
-        var isLeader = await WaitUntilLeader(sut, true, TimeSpan.FromSeconds(5));
+        // Assert
+        sut.IsLeader.Should().BeTrue();
+        sut.LastLeadershipRenewal.Should().Be(_fakeTimeProvider.GetUtcNow().UtcDateTime);
+        sut.Settings.TryAcquireCount.Should().Be(1);
+        sut.Settings.LeadershipChangedCount.Should().Be(1);
+        sut.Settings.ErrorCount.Should().Be(0);
 
-        isLeader.Should().BeTrue();
-        sut.TryAcquireCalls.Should().BeGreaterThan(0);
-
-        await sut.StopAsync(TestContext.Current.CancellationToken);
+        // Call StartAsync again should be no-op
+        await sut.StartAsync(TestContext.Current.CancellationToken);
+        sut.IsLeader.Should().BeTrue();
+        sut.Settings.TryAcquireCount.Should().Be(1);
+        sut.Settings.LeadershipChangedCount.Should().Be(1);
+        sut.Settings.ErrorCount.Should().Be(0);
     }
 
     [Fact]
     public async Task StartAsyncShouldRetryAcquisitionWhenFails()
     {
-        var settings = new LeaderElectionSettingsBase
-        {
-            RenewInterval = TimeSpan.FromMilliseconds(50),
-            RetryInterval = TimeSpan.FromMilliseconds(50),
-            MaxRetryAttempts = 1,
-        };
-        await using var sut = new MockLeaderElection(settings);
-        var calls = 0;
-        sut.TryAcquireResult = _ => Task.FromResult(++calls > 1);
+        // Arrange
+        await using var sut = CreateSut();
 
+        sut.Settings.AcquireResult = () => false;
         await sut.StartAsync(TestContext.Current.CancellationToken);
+        await FastForward(TimeSpan.Zero);
+        sut.IsLeader.Should().BeFalse();
+        sut.Settings.TryAcquireCount.Should().Be(1);
+        sut.Settings.LeadershipChangedCount.Should().Be(0);
+        sut.Settings.ErrorCount.Should().Be(0);
 
-        var isLeader = await WaitUntilLeader(sut, true, TimeSpan.FromSeconds(5));
+        // Act
+        sut.Settings.AcquireResult = () => true;
+        await FastForward(sut.Settings.RetryInterval);
 
-        sut.TryAcquireCalls.Should().BeGreaterThan(1);
-        isLeader.Should().BeTrue();
+        // Assert
+        sut.IsLeader.Should().BeTrue();
+        sut.LastLeadershipRenewal.Should().Be(_fakeTimeProvider.GetUtcNow().UtcDateTime);
+        sut.Settings.TryAcquireCount.Should().Be(2);
+        sut.Settings.LeadershipChangedCount.Should().Be(1);
+        sut.Settings.ErrorCount.Should().Be(0);
+    }
 
-        await sut.StopAsync(TestContext.Current.CancellationToken);
+    [Fact]
+    public async Task LeaderLoopShouldRetryOnError()
+    {
+        // Arrange
+        await using var sut = CreateSut();
+
+        // Act
+        sut.Settings.AcquireResult = () => throw new InvalidOperationException("Test exception");
+        await sut.StartAsync(TestContext.Current.CancellationToken);
+        await FastForward(TimeSpan.Zero);
+
+        // Assert - Should have reported the error
+        sut.IsLeader.Should().BeFalse();
+        sut.Settings.TryAcquireCount.Should().Be(1);
+        sut.Settings.ErrorCount.Should().Be(1);
+
+        // Act - Clear error and retry
+        sut.Settings.AcquireResult = () => true;
+        await FastForward(sut.Settings.RetryInterval);
+
+        // Assert
+        sut.IsLeader.Should().BeTrue();
+        sut.LastLeadershipRenewal.Should().Be(_fakeTimeProvider.GetUtcNow().UtcDateTime);
+        sut.Settings.TryAcquireCount.Should().Be(2);
+        sut.Settings.LeadershipChangedCount.Should().Be(1);
+        sut.Settings.ErrorCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task LeaderLoopShouldCancelOnRequest()
+    {
+        // Arrange
+        await using var sut = CreateSut();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken
+        );
+
+        sut.Settings.AcquireResult = () =>
+        {
+            cts.Cancel();
+            cts.Token.ThrowIfCancellationRequested();
+            return true;
+        };
+
+        // Act
+        await sut.StartAsync(cts.Token);
+        await FastForward(TimeSpan.Zero);
+        sut.IsLeader.Should().BeFalse();
+        sut.Settings.TryAcquireCount.Should().Be(1);
+        sut.Settings.ErrorCount.Should().Be(0);
     }
 
     [Fact]
     public async Task RenewShouldBeCalledRepeatedlyWhenLeader()
     {
-        var settings = new LeaderElectionSettingsBase
-        {
-            RenewInterval = TimeSpan.FromMilliseconds(20),
-            RetryInterval = TimeSpan.FromMilliseconds(20),
-        };
-        await using var sut = new MockLeaderElection(settings);
+        // Arrange
+        await using var sut = CreateSut();
 
         await sut.StartAsync(TestContext.Current.CancellationToken);
-
-        // Wait for multiple renewals
-        await Task.Delay(500, TestContext.Current.CancellationToken);
-
+        await FastForward(TimeSpan.Zero);
         sut.IsLeader.Should().BeTrue();
-        sut.RenewCalls.Should().BeGreaterThan(1);
+        sut.Settings.LeadershipChangedCount.Should().Be(1);
 
-        await sut.StopAsync(TestContext.Current.CancellationToken);
+        // Act
+        // Wait for multiple renewals
+        for (var i = 0; i < 50; i++)
+        {
+            await FastForward(sut.Settings.RenewInterval);
+
+            // Assert
+            sut.IsLeader.Should().BeTrue();
+            sut.Settings.TryRenewCount.Should().Be(i + 1);
+        }
+
+        sut.Settings.LeadershipChangedCount.Should().Be(1);
     }
 
     [Fact]
     public async Task LeadershipShouldBeLostWhenRenewalFails()
     {
-        var settings = new LeaderElectionSettingsBase
-        {
-            RenewInterval = TimeSpan.FromMilliseconds(50),
-            RetryInterval = TimeSpan.FromMilliseconds(50),
-            MaxRetryAttempts = 1,
-        };
-        await using var sut = new MockLeaderElection(settings);
-        var tcs = new TaskCompletionSource<bool>();
-        sut.LeadershipChanged += (_, leaderShipChanged) =>
-        {
-            if (!leaderShipChanged.IsLeader)
-                tcs.TrySetResult(true);
-        };
+        // Arrange
+        await using var sut = CreateSut();
 
-        sut.RenewResult = _ => Task.FromResult(false);
-
+        // acquire leadership first
         await sut.StartAsync(TestContext.Current.CancellationToken);
+        await FastForward(TimeSpan.Zero);
+        sut.IsLeader.Should().BeTrue();
+        sut.Settings.TryRenewCount.Should().Be(0);
+        sut.Settings.LeadershipChangedCount.Should().Be(1);
 
-        var eventFired = await tcs.Task.WaitAsync(
-            TimeSpan.FromSeconds(5),
-            TestContext.Current.CancellationToken
-        );
-        eventFired.Should().BeTrue();
+        // Act - Renewal failure
+        sut.Settings.RenewResult = () => false;
+        await FastForward(sut.Settings.RenewInterval);
+
+        // Assert - Lost leadership
         sut.IsLeader.Should().BeFalse();
+        sut.Settings.TryRenewCount.Should().Be(1);
+        sut.Settings.LeadershipChangedCount.Should().Be(2);
+        sut.Settings.ErrorCount.Should().Be(0);
 
-        await sut.StopAsync(TestContext.Current.CancellationToken);
+        // Act - Clear error and retry
+        sut.Settings.RenewResult = () => true;
+        await FastForward(sut.Settings.RetryInterval);
+
+        // Assert - Leadership reacquired
+        sut.IsLeader.Should().BeTrue();
+        sut.Settings.TryAcquireCount.Should().Be(2);
+        sut.Settings.TryRenewCount.Should().Be(1);
+        sut.Settings.LeadershipChangedCount.Should().Be(3);
+        sut.Settings.ErrorCount.Should().Be(0);
     }
 
     [Fact]
-    public async Task RunTaskIfLeaderAsyncShouldOnlyRunWhenLeader()
+    public async Task RunTaskIfLeaderAsyncShouldNotRunWhenNotStarted()
     {
-        var settings = new LeaderElectionSettingsBase();
-        await using var sut = new MockLeaderElection(settings);
+        // Arrange
+        await using var sut = CreateSut();
+
+        // Act
         var taskExecuted = false;
-
         await sut.RunTaskIfLeaderAsync(
             () => taskExecuted = true,
             TestContext.Current.CancellationToken
         );
+
+        // Assert
         taskExecuted.Should().BeFalse();
+    }
 
-        await sut.TryAcquireLeadershipAsync(TestContext.Current.CancellationToken);
+    [Fact]
+    public async Task RunTaskIfLeaderAsyncShouldNotRunWhenNotLeader()
+    {
+        // Arrange
+        await using var sut = CreateSut();
+
+        // start without leadership
+        sut.Settings.AcquireResult = () => false;
+        await sut.StartAsync(TestContext.Current.CancellationToken);
+        await FastForward(TimeSpan.Zero);
+        sut.IsLeader.Should().BeFalse();
+
+        // Act
+        var taskExecuted = false;
         await sut.RunTaskIfLeaderAsync(
             () => taskExecuted = true,
             TestContext.Current.CancellationToken
         );
+
+        // Assert
+        taskExecuted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RunTaskIfLeaderAsyncShouldRunWhenLeader()
+    {
+        // Arrange
+        await using var sut = CreateSut();
+
+        // start with leadership
+        await sut.StartAsync(TestContext.Current.CancellationToken);
+        await FastForward(TimeSpan.Zero);
+        sut.IsLeader.Should().BeTrue();
+
+        // Act
+        var taskExecuted = false;
+        await sut.RunTaskIfLeaderAsync(
+            () => taskExecuted = true,
+            TestContext.Current.CancellationToken
+        );
+
+        // Assert
         taskExecuted.Should().BeTrue();
     }
 
     [Fact]
-    public async Task StopAsyncShouldReleaseLeadershipWhenEnabled()
+    public async Task RunTaskIfLeaderAsyncShouldReportErrorOnException()
     {
-        var settings = new LeaderElectionSettingsBase { EnableGracefulShutdown = true };
-        await using var sut = new MockLeaderElection(settings);
+        // Arrange
+        await using var sut = CreateSut();
+
+        // start with leadership
+        sut.Settings.AcquireResult = () => true;
+        await sut.StartAsync(TestContext.Current.CancellationToken);
+        await FastForward(TimeSpan.Zero);
+        sut.IsLeader.Should().BeTrue();
+        sut.Settings.ErrorCount.Should().Be(0);
+
+        // Act
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.RunTaskIfLeaderAsync(
+                () => throw new InvalidOperationException("Test exception"),
+                TestContext.Current.CancellationToken
+            )
+        );
+
+        // Assert
+        sut.Settings.ErrorCount.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task StopAsyncShouldReleaseLeadership(bool gracefulShutdown)
+    {
+        // Arrange
+        await using var sut = CreateSut();
+        sut.Settings.EnableGracefulShutdown = gracefulShutdown;
 
         await sut.StartAsync(TestContext.Current.CancellationToken);
-        await WaitUntilLeader(sut, true, TimeSpan.FromSeconds(5));
+        await FastForward(TimeSpan.Zero);
+        sut.IsLeader.Should().BeTrue();
 
+        // Act
         await sut.StopAsync(TestContext.Current.CancellationToken);
 
-        sut.ReleaseCalls.Should().Be(1);
-        sut.IsLeader.Should().BeFalse();
+        // Assert
+        sut.IsLeader.Should().BeFalse(); // because stopped
+        sut.Settings.TryReleaseCount.Should().Be(gracefulShutdown ? 1 : 0);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task DisposeAsyncShouldReleaseLeadership(bool gracefulShutdown)
+    {
+        // Arrange
+        await using var sut = CreateSut();
+        sut.Settings.EnableGracefulShutdown = gracefulShutdown;
+
+        await sut.StartAsync(TestContext.Current.CancellationToken);
+        await FastForward(TimeSpan.Zero);
+        sut.IsLeader.Should().BeTrue();
+
+        // Act
+        await sut.DisposeAsync();
+
+        // Assert
+        sut.IsLeader.Should().BeFalse(); // because disposed/stopped
+        sut.Settings.TryReleaseCount.Should().Be(gracefulShutdown ? 1 : 0);
     }
 
     [Fact]
-    public async Task DisposeAsyncShouldStopCorrectly()
+    public async Task UseAfterDisposeShouldThrowObjectDisposedException()
     {
-        var settings = new LeaderElectionSettingsBase();
-        await using var sut = new MockLeaderElection(settings);
-
-        await sut.StartAsync(TestContext.Current.CancellationToken);
-        await WaitUntilLeader(sut, true, TimeSpan.FromSeconds(5));
-
+        // Arrange
+        await using var sut = CreateSut();
         await sut.DisposeAsync();
 
+        // Act & Assert
+        await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+            sut.StartAsync(TestContext.Current.CancellationToken)
+        );
+        await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+            sut.StopAsync(TestContext.Current.CancellationToken)
+        );
+        await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+            sut.RunTaskIfLeaderAsync(
+                () => Task.CompletedTask,
+                TestContext.Current.CancellationToken
+            )
+        );
+        await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+            sut.RunTaskIfLeaderAsync(() => { }, TestContext.Current.CancellationToken)
+        );
+
+        // Properties are okay
         sut.IsLeader.Should().BeFalse();
+        sut.LastLeadershipRenewal.Should().Be(DateTime.MinValue);
+
+        // Calling DisposeAsync multiple times should be fine
+        await sut.DisposeAsync();
+        await sut.DisposeAsync();
     }
 
-    private static async Task<bool> WaitUntilLeader(
-        ILeaderElection leaderElection,
-        bool expected,
-        TimeSpan timeout
-    )
+    [Fact]
+    public async Task DisposeShouldSwallowReleaseException()
     {
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(
-            TestContext.Current.CancellationToken
-        );
-        cts.CancelAfter(timeout);
+        // Arrange
+        await using var sut = CreateSut();
+        sut.Settings.EnableGracefulShutdown = true;
+        sut.Settings.ReleaseAction = () => throw new InvalidOperationException("Release failed");
 
-        try
-        {
-            while (!cts.IsCancellationRequested)
-            {
-                if (leaderElection.IsLeader == expected)
-                    return expected;
-                await Task.Delay(20, cts.Token).ConfigureAwait(false);
-            }
-        }
-        catch (OperationCanceledException) { }
+        await sut.StartAsync(TestContext.Current.CancellationToken);
+        await FastForward(TimeSpan.Zero);
+        sut.IsLeader.Should().BeTrue();
 
-        return leaderElection.IsLeader;
+        // Act
+        await sut.DisposeAsync();
+
+        // Assert
+        sut.Settings.TryReleaseCount.Should().Be(1);
+        sut.Settings.ErrorCount.Should().Be(0);
     }
 }

--- a/tests/LeaderElection.Tests/LeaderElectionBaseTests.cs
+++ b/tests/LeaderElection.Tests/LeaderElectionBaseTests.cs
@@ -1,12 +1,9 @@
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-
 namespace LeaderElection.Tests;
 
 public class LeaderElectionBaseTests
 {
-    private sealed class MockLeaderElection(LeaderElectionSettingsBase settings, ILogger logger)
-        : LeaderElectionBase<LeaderElectionSettingsBase>(settings, logger)
+    private sealed class MockLeaderElection(LeaderElectionSettingsBase settings)
+        : LeaderElectionBase<LeaderElectionSettingsBase>(settings)
     {
         public int TryAcquireCalls { get; private set; }
         public int RenewCalls { get; private set; }
@@ -53,7 +50,7 @@ public class LeaderElectionBaseTests
             RenewInterval = TimeSpan.FromMilliseconds(50),
             RetryInterval = TimeSpan.FromMilliseconds(50),
         };
-        await using var sut = new MockLeaderElection(settings, NullLogger.Instance);
+        await using var sut = new MockLeaderElection(settings);
         sut.TryAcquireResult = _ => Task.FromResult(true);
 
         await sut.StartAsync(TestContext.Current.CancellationToken);
@@ -75,7 +72,7 @@ public class LeaderElectionBaseTests
             RetryInterval = TimeSpan.FromMilliseconds(50),
             MaxRetryAttempts = 1,
         };
-        await using var sut = new MockLeaderElection(settings, NullLogger.Instance);
+        await using var sut = new MockLeaderElection(settings);
         var calls = 0;
         sut.TryAcquireResult = _ => Task.FromResult(++calls > 1);
 
@@ -97,7 +94,7 @@ public class LeaderElectionBaseTests
             RenewInterval = TimeSpan.FromMilliseconds(20),
             RetryInterval = TimeSpan.FromMilliseconds(20),
         };
-        await using var sut = new MockLeaderElection(settings, NullLogger.Instance);
+        await using var sut = new MockLeaderElection(settings);
 
         await sut.StartAsync(TestContext.Current.CancellationToken);
 
@@ -119,7 +116,7 @@ public class LeaderElectionBaseTests
             RetryInterval = TimeSpan.FromMilliseconds(50),
             MaxRetryAttempts = 1,
         };
-        await using var sut = new MockLeaderElection(settings, NullLogger.Instance);
+        await using var sut = new MockLeaderElection(settings);
         var tcs = new TaskCompletionSource<bool>();
         sut.LeadershipChanged += (_, leaderShipChanged) =>
         {
@@ -145,7 +142,7 @@ public class LeaderElectionBaseTests
     public async Task RunTaskIfLeaderAsyncShouldOnlyRunWhenLeader()
     {
         var settings = new LeaderElectionSettingsBase();
-        await using var sut = new MockLeaderElection(settings, NullLogger.Instance);
+        await using var sut = new MockLeaderElection(settings);
         var taskExecuted = false;
 
         await sut.RunTaskIfLeaderAsync(
@@ -166,7 +163,7 @@ public class LeaderElectionBaseTests
     public async Task StopAsyncShouldReleaseLeadershipWhenEnabled()
     {
         var settings = new LeaderElectionSettingsBase { EnableGracefulShutdown = true };
-        await using var sut = new MockLeaderElection(settings, NullLogger.Instance);
+        await using var sut = new MockLeaderElection(settings);
 
         await sut.StartAsync(TestContext.Current.CancellationToken);
         await WaitUntilLeader(sut, true, TimeSpan.FromSeconds(5));
@@ -181,7 +178,7 @@ public class LeaderElectionBaseTests
     public async Task DisposeAsyncShouldStopCorrectly()
     {
         var settings = new LeaderElectionSettingsBase();
-        await using var sut = new MockLeaderElection(settings, NullLogger.Instance);
+        await using var sut = new MockLeaderElection(settings);
 
         await sut.StartAsync(TestContext.Current.CancellationToken);
         await WaitUntilLeader(sut, true, TimeSpan.FromSeconds(5));

--- a/tests/LeaderElection.Tests/LeaderElectionBaseTests.cs
+++ b/tests/LeaderElection.Tests/LeaderElectionBaseTests.cs
@@ -287,6 +287,24 @@ public class LeaderElectionBaseTests
         sut.Settings.TryReleaseCount.Should().Be(gracefulShutdown ? 1 : 0);
     }
 
+    [Fact]
+    public async Task StopAsyncShouldAlwaysStopLeaderLoop()
+    {
+        // Arrange
+        await using var sut = CreateSut();
+        sut.Settings.AcquireResult = () => false; // do NOT acquire leadership
+        await sut.StartAsync(TestContext.Current.CancellationToken);
+        await FastForward(TimeSpan.Zero);
+        sut.IsLeader.Should().BeFalse();
+        sut.LeaderLoopRunning.Should().BeTrue();
+
+        // Act
+        await sut.StopAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        sut.LeaderLoopRunning.Should().BeFalse();
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/tests/LeaderElection.Tests/PostgresLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/PostgresLeaderElectionTests.cs
@@ -1,7 +1,6 @@
 using LeaderElection.Postgres;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 
 namespace LeaderElection.Tests;
 
@@ -63,7 +62,7 @@ public sealed class PostgresLeaderElectionTests(PostgresContainerFixture postgre
         await WaitForLeadershipChange(leaderElection1, true, TimeSpan.FromSeconds(10));
 
         await leaderElection2.StartAsync(CancellationToken);
-        await Task.Delay(TimeSpan.FromSeconds(5), CancellationToken);
+        await TimeProvider.Delay(TimeSpan.FromSeconds(5), CancellationToken);
 
         leaderElection1.IsLeader.Should().BeTrue();
         leaderElection2.IsLeader.Should().BeFalse();

--- a/tests/LeaderElection.Tests/PostgresLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/PostgresLeaderElectionTests.cs
@@ -33,10 +33,7 @@ public sealed class PostgresLeaderElectionTests(PostgresContainerFixture postgre
         };
 
     private static PostgresLeaderElection CreateSut(PostgresSettings options) =>
-        new(
-            Options.Create(options),
-            NullLoggerFactory.Instance.CreateLogger<PostgresLeaderElection>()
-        );
+        new(options, NullLoggerFactory.Instance.CreateLogger<PostgresLeaderElection>());
 
     [Fact]
     public async Task ShouldAcquireLeadershipWhenNoOtherInstanceExists()

--- a/tests/LeaderElection.Tests/PostgresLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/PostgresLeaderElectionTests.cs
@@ -1,4 +1,5 @@
 using LeaderElection.Postgres;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -32,7 +33,11 @@ public sealed class PostgresLeaderElectionTests(PostgresContainerFixture postgre
         };
 
     private static PostgresLeaderElection CreateSut(PostgresSettings options) =>
-        new(options, NullLoggerFactory.Instance.CreateLogger<PostgresLeaderElection>());
+        new ServiceCollection()
+            .AddLogging()
+            .AddPostgresLeaderElection(builder => builder.WithSettings(options))
+            .BuildServiceProvider()
+            .GetRequiredService<PostgresLeaderElection>();
 
     [Fact]
     public async Task ShouldAcquireLeadershipWhenNoOtherInstanceExists()

--- a/tests/LeaderElection.Tests/PostgresLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/PostgresLeaderElectionTests.cs
@@ -7,11 +7,22 @@ namespace LeaderElection.Tests;
 [Collection("PostgreSQL Container")]
 [Trait("Kind", "Integration")]
 [Trait("Category", "PostgreSQL")]
-public sealed class PostgresLeaderElectionTests(PostgresContainerFixture postgresFixture) : TestBase
+public sealed class PostgresLeaderElectionTests(PostgresContainerFixture postgresFixture)
+    : TestBase,
+        IAsyncDisposable
 {
+    private readonly List<ServiceProvider> _serviceProviders = [];
+
     private static long _lockIdCounter = 1000;
 
     private static long GetNextLockId() => Interlocked.Increment(ref _lockIdCounter);
+
+    public async ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+        foreach (var sp in _serviceProviders ?? [])
+            await sp.DisposeAsync();
+    }
 
     private PostgresSettings CreateSettings(
         string? instanceId = null,
@@ -31,12 +42,16 @@ public sealed class PostgresLeaderElectionTests(PostgresContainerFixture postgre
             EnableGracefulShutdown = enableGracefulShutdown,
         };
 
-    private static PostgresLeaderElection CreateSut(PostgresSettings options) =>
-        new ServiceCollection()
+    private PostgresLeaderElection CreateSut(PostgresSettings options)
+    {
+        var serviceProvider = new ServiceCollection()
             .AddLogging()
             .AddPostgresLeaderElection(builder => builder.WithSettings(options))
-            .BuildServiceProvider()
-            .GetRequiredService<PostgresLeaderElection>();
+            .BuildServiceProvider();
+
+        _serviceProviders.Add(serviceProvider);
+        return serviceProvider.GetRequiredService<PostgresLeaderElection>();
+    }
 
     [Fact]
     public async Task ShouldAcquireLeadershipWhenNoOtherInstanceExists()

--- a/tests/LeaderElection.Tests/PostgresLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/PostgresLeaderElectionTests.cs
@@ -1,7 +1,6 @@
 using LeaderElection.Postgres;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
 
 namespace LeaderElection.Tests;
 
@@ -157,5 +156,33 @@ public sealed class PostgresLeaderElectionTests(PostgresContainerFixture postgre
 
         // Act & Assert
         await TestShouldRetainLeadershipAfterAtLeastOneRenewalCycle(leaderElection, options);
+    }
+
+    [Fact]
+    public async Task ShouldThrowWhenUsingMultiHostConnectionStringWithInvalidTargetSessionAttributes()
+    {
+        // Arrange
+        var options = CreateSettings();
+        options.ConnectionString = "host=host1,host2;TargetSessionAttributes=any;";
+
+        // Act & Assert - Should throw due to invalid connection string for leader election usage
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await using var leaderElection = CreateSut(options);
+        });
+    }
+
+    [Fact]
+    public async Task ShouldThrowWhenUsingConnectionStringWithMultiplexingEnabled()
+    {
+        // Arrange
+        var options = CreateSettings();
+        options.ConnectionString += ";Multiplexing=true;";
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await using var leaderElection = CreateSut(options);
+        });
     }
 }

--- a/tests/LeaderElection.Tests/PostgresServiceBuilderExtensionsTests.cs
+++ b/tests/LeaderElection.Tests/PostgresServiceBuilderExtensionsTests.cs
@@ -42,8 +42,8 @@ public class PostgresServiceBuilderExtensionsTests
 
         services.AddPostgresLeaderElection(options =>
         {
-            // Specifically leave ConnectionString empty
-            options.ConnectionString = string.Empty;
+            // Specifically leave InstanceId empty
+            options.InstanceId = string.Empty;
             options.LockId = 12345;
         });
 
@@ -58,7 +58,7 @@ public class PostgresServiceBuilderExtensionsTests
         act.Should()
             .Throw<OptionsValidationException>()
             .And.Failures.Should()
-            .Contain(f => f.Contains("ConnectionString"));
+            .Contain(f => f.Contains("InstanceId"));
     }
 
     [Fact]

--- a/tests/LeaderElection.Tests/PostgresServiceBuilderExtensionsTests.cs
+++ b/tests/LeaderElection.Tests/PostgresServiceBuilderExtensionsTests.cs
@@ -48,9 +48,7 @@ public class PostgresServiceBuilderExtensionsTests
         });
 
         var serviceProvider = services.BuildServiceProvider();
-        var optionsProvider = serviceProvider.GetRequiredService<
-            IOptionsSnapshot<PostgresSettings>
-        >();
+        var optionsProvider = serviceProvider.GetRequiredService<IOptions<PostgresSettings>>();
 
         // Accessing .Value should trigger validation via IValidateOptions
         var act = new Func<object>(() => _ = optionsProvider.Value);

--- a/tests/LeaderElection.Tests/PostgresServiceBuilderExtensionsTests.cs
+++ b/tests/LeaderElection.Tests/PostgresServiceBuilderExtensionsTests.cs
@@ -158,6 +158,26 @@ public class PostgresServiceBuilderExtensionsTests
         sp.GetRequiredKeyedService<ILeaderElection>(serviceKey).Should().BeSameAs(leaderElection);
     }
 
+    [Fact]
+    public async Task ShouldUseDefaultRegisteredDataSource()
+    {
+        // Arrange
+        var dummyDS = new NpgsqlDataSourceBuilder(settings.ConnectionString).Build();
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddKeyedSingleton<NpgsqlDataSource>(null, dummyDS)
+            .AddPostgresLeaderElection(builder => builder.WithRegisteredDataSource())
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptions<PostgresSettings>>().Value;
+        options.DataSourceFactory.Should().NotBeNull();
+        var actualDS = options.DataSourceFactory(new());
+        actualDS.Should().BeSameAs(dummyDS);
+    }
+
     [Theory]
     [InlineData("foo")]
     [InlineData(null)]

--- a/tests/LeaderElection.Tests/PostgresServiceBuilderExtensionsTests.cs
+++ b/tests/LeaderElection.Tests/PostgresServiceBuilderExtensionsTests.cs
@@ -1,83 +1,182 @@
 using LeaderElection.Postgres;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Npgsql;
 
 namespace LeaderElection.Tests;
 
 public class PostgresServiceBuilderExtensionsTests
 {
-    [Fact]
-    public void ShouldRegisterAllRequiredServices()
+    // Settings with all properties set to non-default values.
+    private readonly PostgresSettings settings = new()
     {
-        var services = new ServiceCollection();
-        services.AddLogging();
+        ConnectionString = "Host=localhost",
+        LockId = 12345,
+        InstanceId = "foo",
+        RenewInterval = TimeSpan.FromSeconds(2),
+        RetryInterval = TimeSpan.FromSeconds(1),
+        MaxRetryAttempts = 300,
+        EnableGracefulShutdown = false,
+    };
 
-        services.AddPostgresLeaderElection(options =>
-        {
-            options.ConnectionString = "Host=localhost";
-            options.LockId = 12345;
-        });
+    [Fact]
+    public async Task ShouldRegisterAllRequiredServices()
+    {
+        // Arrange & Act
+        await using var serviceProvider = new ServiceCollection()
+            .AddLogging()
+            .AddPostgresLeaderElection(settings)
+            .BuildServiceProvider();
 
-        var serviceProvider = services.BuildServiceProvider();
-
+        // Assert
         serviceProvider.GetService<ILeaderElection>().Should().NotBeNull();
-
         serviceProvider.GetService<PostgresLeaderElection>().Should().NotBeNull();
-
-        var options = serviceProvider.GetService<IOptions<PostgresSettings>>();
-        options.Should().NotBeNull();
-        options.Value.ConnectionString.Should().Be("Host=localhost");
-
-        var validators = serviceProvider.GetServices<IValidateOptions<PostgresSettings>>();
-        var validateOptionsEnumerable = validators.ToList();
+        serviceProvider.GetService<IOptions<PostgresSettings>>().Should().NotBeNull();
+        var validateOptionsEnumerable = serviceProvider
+            .GetServices<IValidateOptions<PostgresSettings>>()
+            .ToList();
         validateOptionsEnumerable.Should().NotBeEmpty();
         validateOptionsEnumerable.Should().ContainSingle(v => v is PostgresSettingsValidator);
     }
 
     [Fact]
-    public void ShouldFailValidationWhenSettingsAreInvalid()
+    public async Task ShouldFailValidationWhenSettingsAreInvalid()
     {
-        var services = new ServiceCollection();
-        services.AddLogging();
+        // Arrange
+        await using var serviceProvider = new ServiceCollection()
+            .AddPostgresLeaderElection(options =>
+            {
+                // Specifically leave InstanceId empty
+                options.InstanceId = string.Empty;
+                options.LockId = 12345;
+            })
+            .BuildServiceProvider();
 
-        services.AddPostgresLeaderElection(options =>
-        {
-            // Specifically leave InstanceId empty
-            options.InstanceId = string.Empty;
-            options.LockId = 12345;
-        });
-
-        var serviceProvider = services.BuildServiceProvider();
         var optionsProvider = serviceProvider.GetRequiredService<IOptions<PostgresSettings>>();
 
-        // Accessing .Value should trigger validation via IValidateOptions
-        var act = new Func<object>(() => _ = optionsProvider.Value);
-
-        act.Should()
-            .Throw<OptionsValidationException>()
-            .And.Failures.Should()
-            .Contain(f => f.Contains("InstanceId"));
+        // Act & Assert
+        var ex = Assert.Throws<OptionsValidationException>(() => optionsProvider.Value);
+        ex.Failures.Should().Contain(f => f.Contains("InstanceId"));
     }
 
-    [Fact]
-    public void ShouldRegisterWithPostgresSettingsInstance()
+    [Theory]
+    [InlineData("foo")]
+    [InlineData(null)]
+    public async Task ShouldAddOptionsCorrectlyWhenUsingDirectSettings(string? serviceKey)
     {
-        var services = new ServiceCollection();
-        services.AddLogging();
+        // Arrange
 
-        var settings = new PostgresSettings
-        {
-            ConnectionString = "Host=localhost",
-            LockId = 12345,
-            InstanceId = "custom-instance",
-        };
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddPostgresLeaderElection(b => b.WithSettings(settings), serviceKey: serviceKey)
+            .BuildServiceProvider();
 
-        services.AddPostgresLeaderElection(settings);
+        // Assert
+        var actualSettings = sp.GetRequiredService<IOptionsMonitor<PostgresSettings>>()
+            .Get(serviceKey);
+        actualSettings.DataSourceFactory.Should().NotBeNull();
+        actualSettings.DataSourceFactory = null; // ignore factory for equivalence check
+        actualSettings.Should().BeEquivalentTo(settings);
+    }
 
-        var serviceProvider = services.BuildServiceProvider();
-        var options = serviceProvider.GetRequiredService<IOptions<PostgresSettings>>().Value;
+    [Theory]
+    [InlineData("foo")]
+    [InlineData(null)]
+    public async Task ShouldAddOptionsCorrectlyWhenUsingConfiguration(string? serviceKey)
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["LeaderElection:Postgres:ConnectionString"] = settings.ConnectionString,
+                    ["LeaderElection:Postgres:LockId"] = settings.LockId.ToString(),
+                    // ["LeaderElection:Base:InstanceId"] = settings.InstanceId,
+                    ["LeaderElection:Base:RenewInterval"] = settings.RenewInterval.ToString(),
+                    ["LeaderElection:Base:RetryInterval"] = settings.RetryInterval.ToString(),
+                    ["LeaderElection:Base:MaxRetryAttempts"] = settings.MaxRetryAttempts.ToString(),
+                    // ["LeaderElection:Base:EnableGracefulShutdown"] = settings.EnableGracefulShutdown.ToString(),
+                }
+            )
+            .Build();
 
-        options.ConnectionString.Should().Be("Host=localhost");
-        options.InstanceId.Should().Be("custom-instance");
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IConfiguration>(config)
+            .AddPostgresLeaderElection(
+                builder =>
+                    builder
+                        .WithConfiguration("LeaderElection:Postgres")
+                        .WithConfiguration(config.GetSection("LeaderElection:Base"))
+                        .WithInstanceId(settings.InstanceId)
+                        .WithSettings(s =>
+                            s.EnableGracefulShutdown = settings.EnableGracefulShutdown
+                        ),
+                serviceKey
+            )
+            .BuildServiceProvider();
+
+        // Assert
+        var actualSettings = sp.GetRequiredService<IOptionsMonitor<PostgresSettings>>()
+            .Get(serviceKey);
+        actualSettings.ConnectionString.Should().Be(settings.ConnectionString);
+        actualSettings.LockId.Should().Be(settings.LockId);
+        actualSettings.InstanceId.Should().Be(settings.InstanceId);
+        actualSettings.RenewInterval.Should().Be(settings.RenewInterval);
+        actualSettings.RetryInterval.Should().Be(settings.RetryInterval);
+        actualSettings.MaxRetryAttempts.Should().Be(settings.MaxRetryAttempts);
+        actualSettings.EnableGracefulShutdown.Should().Be(settings.EnableGracefulShutdown);
+    }
+
+    [Theory]
+    [InlineData("foo", true)]
+    [InlineData("foo", false)]
+    [InlineData(null, false)]
+    public async Task ShouldSetRegisteredDataSourceFactory(string? serviceKey, bool useKeyedDS)
+    {
+        // Arrange
+        var defaultSettings = new PostgresSettings();
+
+        var dummyDS = new NpgsqlDataSourceBuilder(settings.ConnectionString).Build();
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddKeyedSingleton(useKeyedDS ? serviceKey : null, dummyDS)
+            .AddPostgresLeaderElection(builder => builder.WithSettings(defaultSettings), serviceKey)
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptionsMonitor<PostgresSettings>>().Get(serviceKey);
+        options.DataSourceFactory.Should().NotBeNull();
+        var actualDS = options.DataSourceFactory(defaultSettings);
+        actualDS.Should().BeSameAs(dummyDS);
+
+        var leaderElection = sp.GetRequiredKeyedService<PostgresLeaderElection>(serviceKey);
+        sp.GetRequiredKeyedService<ILeaderElection>(serviceKey).Should().BeSameAs(leaderElection);
+    }
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData(null)]
+    public async Task ShouldUseRegisteredDataSource(string? dsServiceKey)
+    {
+        // Arrange
+        var dummyDS = new NpgsqlDataSourceBuilder(settings.ConnectionString).Build();
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddKeyedSingleton(dsServiceKey, dummyDS)
+            .AddPostgresLeaderElection(builder => builder.WithRegisteredDataSource(dsServiceKey))
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptions<PostgresSettings>>().Value;
+        options.DataSourceFactory.Should().NotBeNull();
+        var actualDS = options.DataSourceFactory(new());
+        actualDS.Should().BeSameAs(dummyDS);
     }
 }

--- a/tests/LeaderElection.Tests/PostgresServiceBuilderExtensionsTests.cs
+++ b/tests/LeaderElection.Tests/PostgresServiceBuilderExtensionsTests.cs
@@ -139,7 +139,7 @@ public class PostgresServiceBuilderExtensionsTests
         // Arrange
         var defaultSettings = new PostgresSettings();
 
-        var dummyDS = new NpgsqlDataSourceBuilder(settings.ConnectionString).Build();
+        using var dummyDS = new NpgsqlDataSourceBuilder(settings.ConnectionString).Build();
 
         // Act
         await using var sp = new ServiceCollection()
@@ -162,7 +162,7 @@ public class PostgresServiceBuilderExtensionsTests
     public async Task ShouldUseDefaultRegisteredDataSource()
     {
         // Arrange
-        var dummyDS = new NpgsqlDataSourceBuilder(settings.ConnectionString).Build();
+        using var dummyDS = new NpgsqlDataSourceBuilder(settings.ConnectionString).Build();
 
         // Act
         await using var sp = new ServiceCollection()
@@ -184,7 +184,7 @@ public class PostgresServiceBuilderExtensionsTests
     public async Task ShouldUseRegisteredDataSource(string? dsServiceKey)
     {
         // Arrange
-        var dummyDS = new NpgsqlDataSourceBuilder(settings.ConnectionString).Build();
+        using var dummyDS = new NpgsqlDataSourceBuilder(settings.ConnectionString).Build();
 
         // Act
         await using var sp = new ServiceCollection()

--- a/tests/LeaderElection.Tests/PostgresSettingsValidatorTests.cs
+++ b/tests/LeaderElection.Tests/PostgresSettingsValidatorTests.cs
@@ -7,11 +7,22 @@ public class PostgresSettingsValidatorTests
     private readonly PostgresSettingsValidator _validator = new();
 
     [Fact]
+    public void ShouldSucceedWhenDefaultSettings()
+    {
+        var settings = new PostgresSettings();
+
+        var result = _validator.Validate(null, settings);
+
+        result.Succeeded.Should().BeTrue();
+    }
+
+    [Fact]
     public void ShouldSucceedWhenSettingsAreValid()
     {
         var settings = new PostgresSettings
         {
             ConnectionString = "Host=localhost;Database=test",
+            ConnectionFactory = null,
             InstanceId = "test-instance",
             LockId = 12345,
             RetryInterval = TimeSpan.FromSeconds(5),
@@ -26,19 +37,32 @@ public class PostgresSettingsValidatorTests
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
-    public void ShouldFailWhenConnectionStringIsInvalid(string? connectionString)
+    [InlineData("bogus")]
+    public void ShouldSucceedWhenConnectionStringIsAnything(string? connectionString)
     {
-        var settings = new PostgresSettings
-        {
-            ConnectionString = connectionString!,
-            InstanceId = "test-instance",
-            LockId = 12345,
-        };
+        // This succeeds because a) the ConnectionFactory is an alternative to
+        // ConnectionString, and b) we do not validate connection string syntax.
+        var settings = new PostgresSettings { ConnectionString = connectionString };
 
         var result = _validator.Validate(null, settings);
 
-        result.Failed.Should().BeTrue();
-        result.Failures.Should().Contain(f => f.Contains("ConnectionString"));
+        result.Failed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSucceedWhenConnectionFactoryIsNull()
+    {
+        var settings = new PostgresSettings { ConnectionFactory = null };
+        var result = _validator.Validate(null, settings);
+        result.Failed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSucceedWhenConnectionFactoryIsNonNull()
+    {
+        var settings = new PostgresSettings { ConnectionFactory = _ => null! };
+        var result = _validator.Validate(null, settings);
+        result.Failed.Should().BeFalse();
     }
 
     [Theory]
@@ -47,12 +71,7 @@ public class PostgresSettingsValidatorTests
     [InlineData(" ")]
     public void ShouldFailWhenInstanceIdIsInvalid(string? instanceId)
     {
-        var settings = new PostgresSettings
-        {
-            ConnectionString = "Host=localhost",
-            InstanceId = instanceId!,
-            LockId = 12345,
-        };
+        var settings = new PostgresSettings { InstanceId = instanceId! };
 
         var result = _validator.Validate(null, settings);
 
@@ -63,13 +82,7 @@ public class PostgresSettingsValidatorTests
     [Fact]
     public void ShouldFailWhenRetryIntervalIsNegative()
     {
-        var settings = new PostgresSettings
-        {
-            ConnectionString = "Host=localhost",
-            InstanceId = "test-instance",
-            LockId = 12345,
-            RetryInterval = TimeSpan.FromSeconds(-1),
-        };
+        var settings = new PostgresSettings { RetryInterval = TimeSpan.FromSeconds(-1) };
 
         var result = _validator.Validate(null, settings);
 

--- a/tests/LeaderElection.Tests/PostgresSettingsValidatorTests.cs
+++ b/tests/LeaderElection.Tests/PostgresSettingsValidatorTests.cs
@@ -22,7 +22,7 @@ public class PostgresSettingsValidatorTests
         var settings = new PostgresSettings
         {
             ConnectionString = "Host=localhost;Database=test",
-            ConnectionFactory = null,
+            DataSourceFactory = null,
             InstanceId = "test-instance",
             LockId = 12345,
             RetryInterval = TimeSpan.FromSeconds(5),
@@ -40,7 +40,7 @@ public class PostgresSettingsValidatorTests
     [InlineData("bogus")]
     public void ShouldSucceedWhenConnectionStringIsAnything(string? connectionString)
     {
-        // This succeeds because a) the ConnectionFactory is an alternative to
+        // This succeeds because a) the DataSourceFactory is an alternative to
         // ConnectionString, and b) we do not validate connection string syntax.
         var settings = new PostgresSettings { ConnectionString = connectionString };
 
@@ -50,17 +50,17 @@ public class PostgresSettingsValidatorTests
     }
 
     [Fact]
-    public void ShouldSucceedWhenConnectionFactoryIsNull()
+    public void ShouldSucceedWhenDataSourceFactoryIsNull()
     {
-        var settings = new PostgresSettings { ConnectionFactory = null };
+        var settings = new PostgresSettings { DataSourceFactory = null };
         var result = _validator.Validate(null, settings);
         result.Failed.Should().BeFalse();
     }
 
     [Fact]
-    public void ShouldSucceedWhenConnectionFactoryIsNonNull()
+    public void ShouldSucceedWhenDataSourceFactoryIsNonNull()
     {
-        var settings = new PostgresSettings { ConnectionFactory = _ => null! };
+        var settings = new PostgresSettings { DataSourceFactory = _ => null! };
         var result = _validator.Validate(null, settings);
         result.Failed.Should().BeFalse();
     }

--- a/tests/LeaderElection.Tests/RedisContainerFixture.cs
+++ b/tests/LeaderElection.Tests/RedisContainerFixture.cs
@@ -41,6 +41,17 @@ public sealed class RedisContainerFixture : IAsyncLifetime
             "ConnectionMultiplexer is not initialized. Ensure InitializeAsync has been called."
         );
 
+    /// <summary>
+    /// Gets the host and port for the Redis service.
+    /// </summary>
+    public (string host, int port) HostPort =>
+        _redisContainer == null
+            ? throw new InvalidOperationException(
+                "Redis container is not initialized. Ensure InitializeAsync has been called."
+            )
+            : ((string host, int port))
+                (_redisContainer.Hostname, _redisContainer.GetMappedPublicPort(6379));
+
     public async ValueTask InitializeAsync()
     {
         _redisContainer = new RedisBuilder(image: "redis:7-alpine").Build();

--- a/tests/LeaderElection.Tests/RedisLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/RedisLeaderElectionTests.cs
@@ -1,7 +1,5 @@
 using LeaderElection.Redis;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace LeaderElection.Tests;
 
@@ -21,6 +19,7 @@ public sealed class RedisLeaderElectionTests(RedisContainerFixture redisFixture)
     ) =>
         new()
         {
+            Host = "", // Host is not used when ConnectionMultiplexer is provided
             LockKey = lockKey,
             InstanceId = instanceId,
             LockExpiry = lockExpiry ?? TimeSpan.FromSeconds(10),
@@ -30,12 +29,16 @@ public sealed class RedisLeaderElectionTests(RedisContainerFixture redisFixture)
             EnableGracefulShutdown = enableGracefulShutdown,
         };
 
-    private RedisLeaderElection CreateSut(RedisSettings options) =>
-        new(
-            redisFixture.ConnectionMultiplexer,
-            Options.Create(options),
-            NullLoggerFactory.Instance.CreateLogger<RedisLeaderElection>()
-        );
+    private RedisLeaderElection CreateSut(RedisSettings settings) =>
+        new ServiceCollection()
+            .AddLogging()
+            .AddRedisLeaderElection(builder =>
+                builder
+                    .WithSettings(settings)
+                    .WithConnectionMultiplexer(redisFixture.ConnectionMultiplexer)
+            )
+            .BuildServiceProvider()
+            .GetRequiredService<RedisLeaderElection>();
 
     [Fact]
     public async Task ShouldAcquireLeadershipWhenNoOtherInstanceExists()

--- a/tests/LeaderElection.Tests/RedisLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/RedisLeaderElectionTests.cs
@@ -81,7 +81,7 @@ public sealed class RedisLeaderElectionTests(RedisContainerFixture redisFixture)
         await WaitForLeadershipChange(leaderElection1, true, TimeSpan.FromSeconds(10));
 
         await leaderElection2.StartAsync(CancellationToken);
-        await Task.Delay(TimeSpan.FromSeconds(5), CancellationToken); // Give time for second instance to try
+        await TimeProvider.Delay(TimeSpan.FromSeconds(5), CancellationToken); // Give time for second instance to try
 
         // Assert
         leaderElection1.IsLeader.Should().BeTrue();

--- a/tests/LeaderElection.Tests/RedisLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/RedisLeaderElectionTests.cs
@@ -19,7 +19,6 @@ public sealed class RedisLeaderElectionTests(RedisContainerFixture redisFixture)
     ) =>
         new()
         {
-            Host = "", // Host is not used when ConnectionMultiplexer is provided
             LockKey = lockKey,
             InstanceId = instanceId,
             LockExpiry = lockExpiry ?? TimeSpan.FromSeconds(10),

--- a/tests/LeaderElection.Tests/RedisLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/RedisLeaderElectionTests.cs
@@ -6,8 +6,19 @@ namespace LeaderElection.Tests;
 [Collection("Redis Container")]
 [Trait("Kind", "Integration")]
 [Trait("Category", "Redis")]
-public sealed class RedisLeaderElectionTests(RedisContainerFixture redisFixture) : TestBase
+public sealed class RedisLeaderElectionTests(RedisContainerFixture redisFixture)
+    : TestBase,
+        IAsyncDisposable
 {
+    private readonly List<ServiceProvider> _serviceProviders = [];
+
+    public async ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+        foreach (var sp in _serviceProviders ?? [])
+            await sp.DisposeAsync();
+    }
+
     private static RedisSettings CreateSettings(
         string lockKey, // should be unique per test to avoid conflicts
         string instanceId = "test-instance-1",
@@ -28,16 +39,20 @@ public sealed class RedisLeaderElectionTests(RedisContainerFixture redisFixture)
             EnableGracefulShutdown = enableGracefulShutdown,
         };
 
-    private RedisLeaderElection CreateSut(RedisSettings settings) =>
-        new ServiceCollection()
+    private RedisLeaderElection CreateSut(RedisSettings settings)
+    {
+        var serviceProvider = new ServiceCollection()
             .AddLogging()
             .AddRedisLeaderElection(builder =>
                 builder
                     .WithSettings(settings)
                     .WithConnectionMultiplexer(redisFixture.ConnectionMultiplexer)
             )
-            .BuildServiceProvider()
-            .GetRequiredService<RedisLeaderElection>();
+            .BuildServiceProvider();
+
+        _serviceProviders.Add(serviceProvider);
+        return serviceProvider.GetRequiredService<RedisLeaderElection>();
+    }
 
     [Fact]
     public async Task ShouldAcquireLeadershipWhenNoOtherInstanceExists()

--- a/tests/LeaderElection.Tests/RedisServiceBuilderExtensionsTests.cs
+++ b/tests/LeaderElection.Tests/RedisServiceBuilderExtensionsTests.cs
@@ -1,0 +1,245 @@
+using LeaderElection.Redis;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Moq;
+using StackExchange.Redis;
+
+namespace LeaderElection.Tests;
+
+public sealed class RedisServiceBuilderExtensionsTests
+{
+    // Settings with all properties set to non-default values.
+    private readonly RedisSettings settings = new()
+    {
+        Host = "foo.localhost",
+        Port = 101,
+        Password = "pass",
+        Database = 22,
+        LockKey = "test-lock",
+        LockExpiry = TimeSpan.FromSeconds(10),
+        InstanceId = "foo",
+        RenewInterval = TimeSpan.FromSeconds(2),
+        RetryInterval = TimeSpan.FromSeconds(1),
+        MaxRetryAttempts = 300,
+        EnableGracefulShutdown = false,
+    };
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData(null)]
+    public async Task ShouldAddOptionsCorrectlyWhenUsingDirectSettings(string? serviceKey)
+    {
+        // Arrange
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddRedisLeaderElection(b => b.WithSettings(settings), serviceKey: serviceKey)
+            .BuildServiceProvider();
+
+        // Assert
+        var actualSettings = sp.GetRequiredService<IOptionsMonitor<RedisSettings>>()
+            .Get(serviceKey);
+        actualSettings.Should().BeEquivalentTo(settings);
+    }
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData(null)]
+    public async Task ShouldAddOptionsCorrectlyWhenUsingConfiguration(string? serviceKey)
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["LeaderElection:Redis:Host"] = settings.Host,
+                    ["LeaderElection:Redis:Port"] = settings.Port.ToString(),
+                    ["LeaderElection:Redis:Password"] = settings.Password,
+                    ["LeaderElection:Redis:Database"] = settings.Database.ToString(),
+                    ["LeaderElection:Redis:LockExpiry"] = settings.LockExpiry.ToString(),
+                    ["LeaderElection:Redis:LockKey"] = settings.LockKey,
+                    // ["LeaderElection:Base:InstanceId"] = settings.InstanceId,
+                    ["LeaderElection:Base:RenewInterval"] = settings.RenewInterval.ToString(),
+                    ["LeaderElection:Base:RetryInterval"] = settings.RetryInterval.ToString(),
+                    ["LeaderElection:Base:MaxRetryAttempts"] = settings.MaxRetryAttempts.ToString(),
+                    // ["LeaderElection:Base:EnableGracefulShutdown"] = settings.EnableGracefulShutdown.ToString(),
+                }
+            )
+            .Build();
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IConfiguration>(config)
+            .AddRedisLeaderElection(
+                builder =>
+                    builder
+                        .WithConfiguration("LeaderElection:Redis")
+                        .WithConfiguration(config.GetSection("LeaderElection:Base"))
+                        .WithInstanceId(settings.InstanceId)
+                        .WithSettings(s =>
+                            s.EnableGracefulShutdown = settings.EnableGracefulShutdown
+                        ),
+                serviceKey
+            )
+            .BuildServiceProvider();
+
+        // Assert
+        var actualSettings = sp.GetRequiredService<IOptionsSnapshot<RedisSettings>>()
+            .Get(serviceKey);
+        actualSettings.Should().BeEquivalentTo(settings);
+    }
+
+    [Theory]
+    [InlineData("foo", true)]
+    [InlineData("foo", false)]
+    [InlineData(null, false)]
+    public async Task ShouldSetDefaultConnectionMultiplexerFactoryWhenHostIsEmpty(
+        string? serviceKey,
+        bool useKeyedCM
+    )
+    {
+        // Arrange
+        var noHostSettings = new RedisSettings
+        {
+            Host = null, // use CM from DI
+        };
+
+        var mockCM = Mock.Of<IConnectionMultiplexer>();
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddKeyedSingleton(useKeyedCM ? serviceKey : null, mockCM)
+            .AddRedisLeaderElection(builder => builder.WithSettings(noHostSettings), serviceKey)
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptionsMonitor<RedisSettings>>().Get(serviceKey);
+        options.ConnectionMultiplexerFactory.Should().NotBeNull();
+        var actualCM = await options.ConnectionMultiplexerFactory(
+            noHostSettings,
+            TestContext.Current.CancellationToken
+        );
+        actualCM.Should().BeSameAs(mockCM);
+
+        var leaderElection = sp.GetRequiredKeyedService<RedisLeaderElection>(serviceKey);
+        sp.GetRequiredKeyedService<ILeaderElection>(serviceKey).Should().BeSameAs(leaderElection);
+    }
+
+    [Theory]
+    [InlineData("foo", true)]
+    [InlineData("foo", false)]
+    [InlineData(null, false)]
+    public async Task ShouldUseRegisteredConnectionMultiplexerWhenTold(
+        string? serviceKey,
+        bool useKeyedCM
+    )
+    {
+        // Arrange
+        // ensure host is set to confirm that factory is used instead of host/port
+        settings.Host = "foo.localhost";
+
+        var mockCM = Mock.Of<IConnectionMultiplexer>();
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddKeyedSingleton(useKeyedCM ? serviceKey : null, mockCM)
+            .AddRedisLeaderElection(
+                builder => builder.WithSettings(settings).WithRegisteredCache(),
+                serviceKey
+            )
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptionsMonitor<RedisSettings>>().Get(serviceKey);
+        options.ConnectionMultiplexerFactory.Should().NotBeNull();
+        var actualCM = await options.ConnectionMultiplexerFactory(
+            settings,
+            TestContext.Current.CancellationToken
+        );
+        actualCM.Should().BeSameAs(mockCM);
+    }
+
+    [Fact]
+    public async Task ShouldNotSetDefaultConnectionMultiplexerFactoryWhenHostIsSpecified()
+    {
+        // Arrange
+        settings.Host.Should().NotBeNullOrWhiteSpace();
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddRedisLeaderElection(builder => builder.WithSettings(settings))
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptions<RedisSettings>>().Value;
+        options.ConnectionMultiplexerFactory.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData(null)]
+    public async Task ShouldAddServicesCorrectlyWhenUsingCMInstance(string? serviceKey)
+    {
+        // Arrange
+        var mockCM = Mock.Of<IConnectionMultiplexer>();
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddRedisLeaderElection(
+                builder => builder.WithConnectionMultiplexer(mockCM),
+                serviceKey
+            )
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptionsMonitor<RedisSettings>>().Get(serviceKey);
+        options.ConnectionMultiplexerFactory.Should().NotBeNull();
+        var actualCM = await options.ConnectionMultiplexerFactory(
+            settings,
+            TestContext.Current.CancellationToken
+        );
+        actualCM.Should().BeSameAs(mockCM);
+
+        var leaderElection = sp.GetRequiredKeyedService<RedisLeaderElection>(serviceKey);
+        sp.GetRequiredKeyedService<ILeaderElection>(serviceKey).Should().BeSameAs(leaderElection);
+    }
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData(null)]
+    public async Task ShouldAddServicesCorrectlyWhenUsingCustomCMFactory(string? serviceKey)
+    {
+        // Arrange
+        var mockCM = Mock.Of<IConnectionMultiplexer>();
+
+        // Act
+#pragma warning disable CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddRedisLeaderElection(
+                builder =>
+                    builder.WithConnectionMultiplexerFactory((_, _, _) => Task.FromResult(mockCM)),
+                serviceKey
+            )
+            .BuildServiceProvider();
+#pragma warning restore CA2025 // Do not pass 'IDisposable' instances into unawaited tasks
+
+        // Assert
+        var options = sp.GetRequiredService<IOptionsMonitor<RedisSettings>>().Get(serviceKey);
+        options.ConnectionMultiplexerFactory.Should().NotBeNull();
+        var actualCM = await options.ConnectionMultiplexerFactory(
+            settings,
+            TestContext.Current.CancellationToken
+        );
+        actualCM.Should().BeSameAs(mockCM);
+
+        var leaderElection = sp.GetRequiredKeyedService<RedisLeaderElection>(serviceKey);
+        sp.GetRequiredKeyedService<ILeaderElection>(serviceKey).Should().BeSameAs(leaderElection);
+    }
+}

--- a/tests/LeaderElection.Tests/RedisServiceBuilderExtensionsTests.cs
+++ b/tests/LeaderElection.Tests/RedisServiceBuilderExtensionsTests.cs
@@ -88,7 +88,7 @@ public sealed class RedisServiceBuilderExtensionsTests
             .BuildServiceProvider();
 
         // Assert
-        var actualSettings = sp.GetRequiredService<IOptionsSnapshot<RedisSettings>>()
+        var actualSettings = sp.GetRequiredService<IOptionsMonitor<RedisSettings>>()
             .Get(serviceKey);
         actualSettings.ConnectionMultiplexerFactory.Should().NotBeNull();
         actualSettings.ConnectionMultiplexerFactory = null;

--- a/tests/LeaderElection.Tests/RedisServiceBuilderExtensionsTests.cs
+++ b/tests/LeaderElection.Tests/RedisServiceBuilderExtensionsTests.cs
@@ -12,9 +12,6 @@ public sealed class RedisServiceBuilderExtensionsTests
     // Settings with all properties set to non-default values.
     private readonly RedisSettings settings = new()
     {
-        Host = "foo.localhost",
-        Port = 101,
-        Password = "pass",
         Database = 22,
         LockKey = "test-lock",
         LockExpiry = TimeSpan.FromSeconds(10),
@@ -55,9 +52,6 @@ public sealed class RedisServiceBuilderExtensionsTests
             .AddInMemoryCollection(
                 new Dictionary<string, string?>
                 {
-                    ["LeaderElection:Redis:Host"] = settings.Host,
-                    ["LeaderElection:Redis:Port"] = settings.Port.ToString(),
-                    ["LeaderElection:Redis:Password"] = settings.Password,
                     ["LeaderElection:Redis:Database"] = settings.Database.ToString(),
                     ["LeaderElection:Redis:LockExpiry"] = settings.LockExpiry.ToString(),
                     ["LeaderElection:Redis:LockKey"] = settings.LockKey,
@@ -99,16 +93,13 @@ public sealed class RedisServiceBuilderExtensionsTests
     [InlineData("foo", true)]
     [InlineData("foo", false)]
     [InlineData(null, false)]
-    public async Task ShouldSetDefaultConnectionMultiplexerFactoryWhenHostIsEmpty(
+    public async Task ShouldSetRegisteredConnectionMultiplexerFactory(
         string? serviceKey,
         bool useKeyedCM
     )
     {
         // Arrange
-        var noHostSettings = new RedisSettings
-        {
-            Host = null, // use CM from DI
-        };
+        var defaultSettings = new RedisSettings();
 
         var mockCM = Mock.Of<IConnectionMultiplexer>();
 
@@ -116,66 +107,17 @@ public sealed class RedisServiceBuilderExtensionsTests
         await using var sp = new ServiceCollection()
             .AddLogging()
             .AddKeyedSingleton(useKeyedCM ? serviceKey : null, mockCM)
-            .AddRedisLeaderElection(builder => builder.WithSettings(noHostSettings), serviceKey)
+            .AddRedisLeaderElection(builder => builder.WithSettings(defaultSettings), serviceKey)
             .BuildServiceProvider();
 
         // Assert
         var options = sp.GetRequiredService<IOptionsMonitor<RedisSettings>>().Get(serviceKey);
         options.ConnectionMultiplexerFactory.Should().NotBeNull();
-        var actualCM = options.ConnectionMultiplexerFactory(noHostSettings);
+        var actualCM = options.ConnectionMultiplexerFactory(defaultSettings);
         actualCM.Should().BeSameAs(mockCM);
 
         var leaderElection = sp.GetRequiredKeyedService<RedisLeaderElection>(serviceKey);
         sp.GetRequiredKeyedService<ILeaderElection>(serviceKey).Should().BeSameAs(leaderElection);
-    }
-
-    [Theory]
-    [InlineData("foo", true)]
-    [InlineData("foo", false)]
-    [InlineData(null, false)]
-    public async Task ShouldUseRegisteredConnectionMultiplexerWhenTold(
-        string? serviceKey,
-        bool useKeyedCM
-    )
-    {
-        // Arrange
-        // ensure host is set to confirm that factory is used instead of host/port
-        settings.Host = "foo.localhost";
-
-        var mockCM = Mock.Of<IConnectionMultiplexer>();
-
-        // Act
-        await using var sp = new ServiceCollection()
-            .AddLogging()
-            .AddKeyedSingleton(useKeyedCM ? serviceKey : null, mockCM)
-            .AddRedisLeaderElection(
-                builder => builder.WithSettings(settings).WithRegisteredCache(),
-                serviceKey
-            )
-            .BuildServiceProvider();
-
-        // Assert
-        var options = sp.GetRequiredService<IOptionsMonitor<RedisSettings>>().Get(serviceKey);
-        options.ConnectionMultiplexerFactory.Should().NotBeNull();
-        var actualCM = options.ConnectionMultiplexerFactory(settings);
-        actualCM.Should().BeSameAs(mockCM);
-    }
-
-    [Fact]
-    public async Task ShouldSetDefaultConnectionMultiplexerFactoryWhenHostIsSpecified()
-    {
-        // Arrange
-        settings.Host.Should().NotBeNullOrWhiteSpace();
-
-        // Act
-        await using var sp = new ServiceCollection()
-            .AddLogging()
-            .AddRedisLeaderElection(builder => builder.WithSettings(settings))
-            .BuildServiceProvider();
-
-        // Assert
-        var options = sp.GetRequiredService<IOptions<RedisSettings>>().Value;
-        options.ConnectionMultiplexerFactory.Should().NotBeNull();
     }
 
     [Theory]

--- a/tests/LeaderElection.Tests/RedisServiceBuilderExtensionsTests.cs
+++ b/tests/LeaderElection.Tests/RedisServiceBuilderExtensionsTests.cs
@@ -40,6 +40,8 @@ public sealed class RedisServiceBuilderExtensionsTests
         // Assert
         var actualSettings = sp.GetRequiredService<IOptionsMonitor<RedisSettings>>()
             .Get(serviceKey);
+        actualSettings.ConnectionMultiplexerFactory.Should().NotBeNull();
+        actualSettings.ConnectionMultiplexerFactory = null;
         actualSettings.Should().BeEquivalentTo(settings);
     }
 
@@ -88,6 +90,8 @@ public sealed class RedisServiceBuilderExtensionsTests
         // Assert
         var actualSettings = sp.GetRequiredService<IOptionsSnapshot<RedisSettings>>()
             .Get(serviceKey);
+        actualSettings.ConnectionMultiplexerFactory.Should().NotBeNull();
+        actualSettings.ConnectionMultiplexerFactory = null;
         actualSettings.Should().BeEquivalentTo(settings);
     }
 
@@ -118,10 +122,7 @@ public sealed class RedisServiceBuilderExtensionsTests
         // Assert
         var options = sp.GetRequiredService<IOptionsMonitor<RedisSettings>>().Get(serviceKey);
         options.ConnectionMultiplexerFactory.Should().NotBeNull();
-        var actualCM = await options.ConnectionMultiplexerFactory(
-            noHostSettings,
-            TestContext.Current.CancellationToken
-        );
+        var actualCM = options.ConnectionMultiplexerFactory(noHostSettings);
         actualCM.Should().BeSameAs(mockCM);
 
         var leaderElection = sp.GetRequiredKeyedService<RedisLeaderElection>(serviceKey);
@@ -156,15 +157,12 @@ public sealed class RedisServiceBuilderExtensionsTests
         // Assert
         var options = sp.GetRequiredService<IOptionsMonitor<RedisSettings>>().Get(serviceKey);
         options.ConnectionMultiplexerFactory.Should().NotBeNull();
-        var actualCM = await options.ConnectionMultiplexerFactory(
-            settings,
-            TestContext.Current.CancellationToken
-        );
+        var actualCM = options.ConnectionMultiplexerFactory(settings);
         actualCM.Should().BeSameAs(mockCM);
     }
 
     [Fact]
-    public async Task ShouldNotSetDefaultConnectionMultiplexerFactoryWhenHostIsSpecified()
+    public async Task ShouldSetDefaultConnectionMultiplexerFactoryWhenHostIsSpecified()
     {
         // Arrange
         settings.Host.Should().NotBeNullOrWhiteSpace();
@@ -177,7 +175,7 @@ public sealed class RedisServiceBuilderExtensionsTests
 
         // Assert
         var options = sp.GetRequiredService<IOptions<RedisSettings>>().Value;
-        options.ConnectionMultiplexerFactory.Should().BeNull();
+        options.ConnectionMultiplexerFactory.Should().NotBeNull();
     }
 
     [Theory]
@@ -200,10 +198,7 @@ public sealed class RedisServiceBuilderExtensionsTests
         // Assert
         var options = sp.GetRequiredService<IOptionsMonitor<RedisSettings>>().Get(serviceKey);
         options.ConnectionMultiplexerFactory.Should().NotBeNull();
-        var actualCM = await options.ConnectionMultiplexerFactory(
-            settings,
-            TestContext.Current.CancellationToken
-        );
+        var actualCM = options.ConnectionMultiplexerFactory(settings);
         actualCM.Should().BeSameAs(mockCM);
 
         var leaderElection = sp.GetRequiredKeyedService<RedisLeaderElection>(serviceKey);
@@ -223,8 +218,7 @@ public sealed class RedisServiceBuilderExtensionsTests
         await using var sp = new ServiceCollection()
             .AddLogging()
             .AddRedisLeaderElection(
-                builder =>
-                    builder.WithConnectionMultiplexerFactory((_, _, _) => Task.FromResult(mockCM)),
+                builder => builder.WithConnectionMultiplexerFactory((_, _) => mockCM),
                 serviceKey
             )
             .BuildServiceProvider();
@@ -233,10 +227,7 @@ public sealed class RedisServiceBuilderExtensionsTests
         // Assert
         var options = sp.GetRequiredService<IOptionsMonitor<RedisSettings>>().Get(serviceKey);
         options.ConnectionMultiplexerFactory.Should().NotBeNull();
-        var actualCM = await options.ConnectionMultiplexerFactory(
-            settings,
-            TestContext.Current.CancellationToken
-        );
+        var actualCM = options.ConnectionMultiplexerFactory(settings);
         actualCM.Should().BeSameAs(mockCM);
 
         var leaderElection = sp.GetRequiredKeyedService<RedisLeaderElection>(serviceKey);

--- a/tests/LeaderElection.Tests/S3LeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/S3LeaderElectionTests.cs
@@ -1,9 +1,5 @@
-using System.Text.Json;
 using LeaderElection.S3;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using Minio.DataModel.Args;
 
 namespace LeaderElection.Tests;
@@ -101,7 +97,7 @@ public sealed class S3LeaderElectionTests(MinioContainerFixture minioFixture) : 
         await WaitForLeadershipChange(leaderElection1, true, TimeSpan.FromSeconds(15));
 
         await leaderElection2.StartAsync(CancellationToken);
-        await Task.Delay(TimeSpan.FromSeconds(5), CancellationToken);
+        await TimeProvider.Delay(TimeSpan.FromSeconds(5), CancellationToken);
 
         // Assert
         leaderElection1.IsLeader.Should().BeTrue();

--- a/tests/LeaderElection.Tests/S3LeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/S3LeaderElectionTests.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using LeaderElection.S3;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -13,9 +15,9 @@ public sealed class S3LeaderElectionTests(MinioContainerFixture minioFixture) : 
 {
     private const string BUCKET_NAME = "leader-election";
 
-    private static S3Settings CreateSettings(
+    private S3Settings CreateSettings(
         string objectKey,
-        string instanceId = "test-instance-1",
+        string? instanceId = null,
         TimeSpan? leaseDuration = null,
         TimeSpan? renewInterval = null,
         TimeSpan? retryInterval = null
@@ -24,20 +26,19 @@ public sealed class S3LeaderElectionTests(MinioContainerFixture minioFixture) : 
         {
             BucketName = BUCKET_NAME,
             ObjectKey = objectKey,
-            InstanceId = instanceId,
+            MinioClientFactory = _ => minioFixture.CreateClient(),
+            InstanceId = instanceId ?? "test-instance-1",
             LeaseDuration = leaseDuration ?? TimeSpan.FromSeconds(10),
             RenewInterval = renewInterval ?? TimeSpan.FromSeconds(2),
             RetryInterval = retryInterval ?? TimeSpan.FromSeconds(1),
         };
 
-    private S3LeaderElection CreateSut(S3Settings options) =>
-        new(
-#pragma warning disable CA2000 // dispose object
-            minioFixture.CreateClient(),
-#pragma warning restore CA2000
-            Options.Create(options),
-            NullLoggerFactory.Instance.CreateLogger<S3LeaderElection>()
-        );
+    private static S3LeaderElection CreateSut(S3Settings options) =>
+        new ServiceCollection()
+            .AddLogging()
+            .AddS3LeaderElection(options)
+            .BuildServiceProvider()
+            .GetRequiredService<S3LeaderElection>();
 
     private async Task EnsureBucketExistsAsync()
     {
@@ -81,7 +82,11 @@ public sealed class S3LeaderElectionTests(MinioContainerFixture minioFixture) : 
         // Arrange
         await EnsureBucketExistsAsync();
         var key = "test-leader-election-conflict";
-        var options1 = CreateSettings(key, leaseDuration: TimeSpan.FromSeconds(30));
+        var options1 = CreateSettings(
+            key,
+            "test-instance-1",
+            leaseDuration: TimeSpan.FromSeconds(30)
+        );
         var options2 = CreateSettings(
             key,
             "test-instance-2",
@@ -114,6 +119,7 @@ public sealed class S3LeaderElectionTests(MinioContainerFixture minioFixture) : 
         var key = "test-leader-election-transfer";
         var options1 = CreateSettings(
             key,
+            "test-instance-1",
             leaseDuration: TimeSpan.FromSeconds(5),
             renewInterval: TimeSpan.FromSeconds(1)
         );

--- a/tests/LeaderElection.Tests/S3LeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/S3LeaderElectionTests.cs
@@ -41,15 +41,9 @@ public sealed class S3LeaderElectionTests(MinioContainerFixture minioFixture) : 
 #pragma warning disable CA2000 // dispose object
         var client = minioFixture.CreateClient();
 #pragma warning restore CA2000
-        if (
-            !await client
-                .BucketExistsAsync(new BucketExistsArgs().WithBucket(BUCKET_NAME))
-                .ConfigureAwait(false)
-        )
+        if (!await client.BucketExistsAsync(new BucketExistsArgs().WithBucket(BUCKET_NAME)))
         {
-            await client
-                .MakeBucketAsync(new MakeBucketArgs().WithBucket(BUCKET_NAME))
-                .ConfigureAwait(false);
+            await client.MakeBucketAsync(new MakeBucketArgs().WithBucket(BUCKET_NAME));
         }
     }
 

--- a/tests/LeaderElection.Tests/S3LeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/S3LeaderElectionTests.cs
@@ -7,9 +7,20 @@ namespace LeaderElection.Tests;
 [Collection("Minio Container")]
 [Trait("Kind", "Integration")]
 [Trait("Category", "S3")]
-public sealed class S3LeaderElectionTests(MinioContainerFixture minioFixture) : TestBase
+public sealed class S3LeaderElectionTests(MinioContainerFixture minioFixture)
+    : TestBase,
+        IAsyncDisposable
 {
+    private readonly List<ServiceProvider> _serviceProviders = [];
+
     private const string BUCKET_NAME = "leader-election";
+
+    public async ValueTask DisposeAsync()
+    {
+        GC.SuppressFinalize(this);
+        foreach (var sp in _serviceProviders ?? [])
+            await sp.DisposeAsync();
+    }
 
     private S3Settings CreateSettings(
         string objectKey,
@@ -29,12 +40,16 @@ public sealed class S3LeaderElectionTests(MinioContainerFixture minioFixture) : 
             RetryInterval = retryInterval ?? TimeSpan.FromSeconds(1),
         };
 
-    private static S3LeaderElection CreateSut(S3Settings options) =>
-        new ServiceCollection()
+    private S3LeaderElection CreateSut(S3Settings options)
+    {
+        var serviceProvider = new ServiceCollection()
             .AddLogging()
             .AddS3LeaderElection(options)
-            .BuildServiceProvider()
-            .GetRequiredService<S3LeaderElection>();
+            .BuildServiceProvider();
+
+        _serviceProviders.Add(serviceProvider);
+        return serviceProvider.GetRequiredService<S3LeaderElection>();
+    }
 
     private async Task EnsureBucketExistsAsync()
     {

--- a/tests/LeaderElection.Tests/S3ServiceBuilderExtensionsTests.cs
+++ b/tests/LeaderElection.Tests/S3ServiceBuilderExtensionsTests.cs
@@ -85,7 +85,7 @@ public sealed class S3ServiceBuilderExtensionsTests
             .BuildServiceProvider();
 
         // Assert
-        var actualSettings = sp.GetRequiredService<IOptionsSnapshot<S3Settings>>().Get(serviceKey);
+        var actualSettings = sp.GetRequiredService<IOptionsMonitor<S3Settings>>().Get(serviceKey);
         actualSettings.Should().BeEquivalentTo(settings);
     }
 

--- a/tests/LeaderElection.Tests/S3ServiceBuilderExtensionsTests.cs
+++ b/tests/LeaderElection.Tests/S3ServiceBuilderExtensionsTests.cs
@@ -1,0 +1,152 @@
+using LeaderElection.S3;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Minio;
+using Moq;
+
+namespace LeaderElection.Tests;
+
+public sealed class S3ServiceBuilderExtensionsTests
+{
+    // Settings with all properties set to non-default values.
+    private readonly S3Settings settings;
+    private readonly IMinioClient mockMinioClient;
+
+    public S3ServiceBuilderExtensionsTests()
+    {
+        mockMinioClient = Mock.Of<IMinioClient>();
+        settings = new()
+        {
+            BucketName = "test-bucket",
+            ObjectKey = "test-object",
+            MinioClientFactory = _ => mockMinioClient,
+            InstanceId = "foo",
+            RenewInterval = TimeSpan.FromSeconds(2),
+            RetryInterval = TimeSpan.FromSeconds(1),
+            MaxRetryAttempts = 300,
+            EnableGracefulShutdown = false,
+        };
+    }
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData(null)]
+    public async Task ShouldAddOptionsCorrectlyWhenUsingDirectSettings(string? serviceKey)
+    {
+        // Arrange
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddS3LeaderElection(builder: b => b.WithSettings(settings), serviceKey: serviceKey)
+            .BuildServiceProvider();
+
+        // Assert
+        var actualSettings = sp.GetRequiredService<IOptionsMonitor<S3Settings>>().Get(serviceKey);
+        actualSettings.Should().BeEquivalentTo(settings);
+    }
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData(null)]
+    public async Task ShouldAddOptionsCorrectlyWhenUsingConfiguration(string? serviceKey)
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["LeaderElection:S3:BucketName"] = settings.BucketName,
+                    ["LeaderElection:S3:ObjectKey"] = settings.ObjectKey,
+                    // ["LeaderElection:Base:InstanceId"] = settings.InstanceId,
+                    ["LeaderElection:Base:RenewInterval"] = settings.RenewInterval.ToString(),
+                    ["LeaderElection:Base:RetryInterval"] = settings.RetryInterval.ToString(),
+                    ["LeaderElection:Base:MaxRetryAttempts"] = settings.MaxRetryAttempts.ToString(),
+                    // ["LeaderElection:Base:EnableGracefulShutdown"] = settings.EnableGracefulShutdown.ToString(),
+                }
+            )
+            .Build();
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddSingleton<IConfiguration>(config)
+            .AddS3LeaderElection(
+                builder: b =>
+                    b.WithMinioClientFactory(settings.MinioClientFactory!)
+                        .WithConfiguration("LeaderElection:S3")
+                        .WithConfiguration(config.GetSection("LeaderElection:Base"))
+                        .WithInstanceId(settings.InstanceId)
+                        .WithSettings(s =>
+                            s.EnableGracefulShutdown = settings.EnableGracefulShutdown
+                        ),
+                serviceKey: serviceKey
+            )
+            .BuildServiceProvider();
+
+        // Assert
+        var actualSettings = sp.GetRequiredService<IOptionsSnapshot<S3Settings>>().Get(serviceKey);
+        actualSettings.Should().BeEquivalentTo(settings);
+    }
+
+    [Theory]
+    [InlineData("foo", true)]
+    [InlineData("foo", false)]
+    [InlineData(null, false)]
+    public async Task ShouldAddServicesCorrectlyWhenUsingDefaultClient(
+        string? serviceKey,
+        bool useKeyedMC
+    )
+    {
+        // Arrange
+        var customMC = Mock.Of<IMinioClient>();
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddKeyedSingleton(useKeyedMC ? serviceKey : null, customMC)
+            .AddS3LeaderElection(
+                builder => builder.WithSettings(settings).WithRegisteredMinioClient(),
+                serviceKey: serviceKey
+            )
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptionsMonitor<S3Settings>>();
+        var mcFactory = options.Get(serviceKey).MinioClientFactory;
+        mcFactory.Should().NotBeNull();
+        var actualMC = mcFactory.Invoke(settings);
+        actualMC.Should().BeSameAs(customMC);
+
+        var leaderElection = sp.GetRequiredKeyedService<S3LeaderElection>(serviceKey);
+        sp.GetRequiredKeyedService<ILeaderElection>(serviceKey).Should().BeSameAs(leaderElection);
+    }
+
+    [Theory]
+    [InlineData("foo")]
+    [InlineData(null)]
+    public async Task ShouldAddServicesCorrectlyWhenUsingMCInstance(string? serviceKey)
+    {
+        // Arrange
+        var customMC = Mock.Of<IMinioClient>();
+
+        // Act
+        await using var sp = new ServiceCollection()
+            .AddLogging()
+            .AddS3LeaderElection(
+                builder => builder.WithSettings(settings).WithMinioClient(customMC),
+                serviceKey: serviceKey
+            )
+            .BuildServiceProvider();
+
+        // Assert
+        var options = sp.GetRequiredService<IOptionsMonitor<S3Settings>>();
+        var mcFactory = options.Get(serviceKey).MinioClientFactory;
+        mcFactory.Should().NotBeNull();
+        var actualMC = mcFactory.Invoke(settings);
+        actualMC.Should().BeSameAs(customMC);
+
+        var leaderElection = sp.GetRequiredKeyedService<S3LeaderElection>(serviceKey);
+        sp.GetRequiredKeyedService<ILeaderElection>(serviceKey).Should().BeSameAs(leaderElection);
+    }
+}

--- a/tests/LeaderElection.Tests/SettingsValidatorTests.cs
+++ b/tests/LeaderElection.Tests/SettingsValidatorTests.cs
@@ -131,12 +131,12 @@ public partial class SettingsValidatorTests
     public void PostgresSettingsValidatorShouldValidateCorrectly()
     {
         var validator = new PostgresSettingsValidator();
-        var settings = new PostgresSettings { ConnectionString = string.Empty, LockId = 0 };
+        var settings = new PostgresSettings { InstanceId = "", LockId = 0 };
 
         var result = validator.Validate(null, settings);
 
         result.Failed.Should().BeTrue();
-        result.Failures.Should().Contain(f => f.Contains("ConnectionString"));
+        result.Failures.Should().Contain(f => f.Contains("InstanceId"));
         result.Failures.Should().NotContain(f => f.Contains("LockId"));
     }
 }

--- a/tests/LeaderElection.Tests/SettingsValidatorTests.cs
+++ b/tests/LeaderElection.Tests/SettingsValidatorTests.cs
@@ -60,7 +60,6 @@ public partial class SettingsValidatorTests
         var settings = new RedisSettings
         {
             LockKey = string.Empty,
-            Host = null, // okay
             Database = -1,
             LockExpiry = TimeSpan.Zero,
         };

--- a/tests/LeaderElection.Tests/SettingsValidatorTests.cs
+++ b/tests/LeaderElection.Tests/SettingsValidatorTests.cs
@@ -60,7 +60,7 @@ public partial class SettingsValidatorTests
         var settings = new RedisSettings
         {
             LockKey = string.Empty,
-            Host = string.Empty,
+            Host = null, // okay
             Database = -1,
             LockExpiry = TimeSpan.Zero,
         };
@@ -69,7 +69,7 @@ public partial class SettingsValidatorTests
 
         result.Failed.Should().BeTrue();
         result.Failures.Should().Contain(f => f.Contains("LockKey"));
-        result.Failures.Should().Contain(f => f.Contains("Host"));
+        result.Failures.Should().NotContain(f => f.Contains("Host"));
         result.Failures.Should().Contain(f => f.Contains("Database"));
         result.Failures.Should().Contain(f => f.Contains("LockExpiry"));
     }

--- a/tests/LeaderElection.Tests/TestBase.cs
+++ b/tests/LeaderElection.Tests/TestBase.cs
@@ -10,6 +10,14 @@ public abstract class TestBase
     /// </summary>
     protected static CancellationToken CancellationToken => TestContext.Current.CancellationToken;
 
+    /// <summary>
+    /// The <see cref="TimeProvider"/> used to control time in tests.
+    /// Tests can use <see cref="FakeTimeProvider"/> to simulate time passage and test
+    /// time-dependent behavior without real delays.
+    /// Defaults to <see cref="TimeProvider.System"/> (real time) if not provided.
+    /// </summary>
+    protected TimeProvider TimeProvider { get; init; } = TimeProvider.System;
+
     protected static async Task WaitForLeadershipChange(
         ILeaderElection leaderElection,
         bool expectedLeadership,
@@ -104,7 +112,7 @@ public abstract class TestBase
     /// <param name="timeout">The maximum time to wait for a renewal.</param>
     /// <param name="pollInterval">The interval at which to check for leadership renewal.</param>
     /// <returns>True if a renewal was observed within the timeout period; otherwise, false.</returns>
-    protected static async Task<bool> WaitForLeadershipRenewal(
+    protected async Task<bool> WaitForLeadershipRenewal(
         ILeaderElection leaderElection,
         TimeSpan? timeout = null,
         TimeSpan? pollInterval = null
@@ -117,10 +125,10 @@ public abstract class TestBase
         leaderElection.IsLeader.Should().BeTrue("Expected to be leader before waiting for renewal");
         var lastKnownRenewal = leaderElection.LastLeadershipRenewal;
 
-        var stopTime = DateTime.UtcNow + timeout.Value;
-        while (DateTime.UtcNow < stopTime)
+        var stopTime = TimeProvider.GetUtcNow() + timeout.Value;
+        while (TimeProvider.GetUtcNow() < stopTime)
         {
-            await Task.Delay(pollInterval.Value, CancellationToken).ConfigureAwait(false);
+            await TimeProvider.Delay(pollInterval.Value, CancellationToken).ConfigureAwait(false);
 
             if (!leaderElection.IsLeader)
             {
@@ -136,7 +144,7 @@ public abstract class TestBase
         return false; // Timeout reached without observing renewal
     }
 
-    protected static async Task TestShouldRetainLeadershipAfterAtLeastOneRenewalCycle(
+    protected async Task TestShouldRetainLeadershipAfterAtLeastOneRenewalCycle(
         ILeaderElection leaderElection,
         LeaderElectionSettingsBase settings
     )

--- a/tests/LeaderElection.Tests/TestBase.cs
+++ b/tests/LeaderElection.Tests/TestBase.cs
@@ -54,7 +54,7 @@ public abstract class TestBase
             );
             linkedCts.Token.Register(() => tcs.TrySetCanceled());
 
-            await tcs.Task.ConfigureAwait(false);
+            await tcs.Task;
         }
         finally
         {
@@ -87,7 +87,7 @@ public abstract class TestBase
             );
             linkedCts.Token.Register(() => tcs.TrySetCanceled());
 
-            await tcs.Task.ConfigureAwait(false);
+            await tcs.Task;
         }
         finally
         {
@@ -128,7 +128,7 @@ public abstract class TestBase
         var stopTime = TimeProvider.GetUtcNow() + timeout.Value;
         while (TimeProvider.GetUtcNow() < stopTime)
         {
-            await TimeProvider.Delay(pollInterval.Value, CancellationToken).ConfigureAwait(false);
+            await TimeProvider.Delay(pollInterval.Value, CancellationToken);
 
             if (!leaderElection.IsLeader)
             {
@@ -151,19 +151,18 @@ public abstract class TestBase
     {
         // Act
         Debug.Assert(leaderElection != null, nameof(leaderElection) + " != null");
-        await leaderElection.StartAsync(CancellationToken).ConfigureAwait(false);
-        await WaitForLeadershipChange(leaderElection, true).ConfigureAwait(false);
+        await leaderElection.StartAsync(CancellationToken);
+        await WaitForLeadershipChange(leaderElection, true);
 
         Debug.Assert(settings != null, nameof(settings) + " != null");
         var renewalObserved = await WaitForLeadershipRenewal(
-                leaderElection,
-                settings.RenewInterval + TimeSpan.FromSeconds(0.5) // Add a buffer to avoid timing issues
-            )
-            .ConfigureAwait(false);
+            leaderElection,
+            settings.RenewInterval + TimeSpan.FromSeconds(0.5) // Add a buffer to avoid timing issues
+        );
 
         // Assert
         renewalObserved.Should().BeTrue();
 
-        await leaderElection.StopAsync(CancellationToken).ConfigureAwait(false);
+        await leaderElection.StopAsync(CancellationToken);
     }
 }


### PR DESCRIPTION
## Description

This PR updates the LeaderElection libraries to better support .NET Generic Host scenarios by adding keyed/named registrations and more flexible dependency injection options for underlying clients/connections, while also refactoring internals and expanding test coverage (notably around LeaderElectionBase and the ServiceBuilder extensions).

**Change Summary:**

- Add keyed service registrations + ServiceBuilder-style configuration for multiple leader election instances and more flexible client/connection resolution (Redis/S3/Postgres/BlobStorage/FusionCache/DistributedCache).
- Refactor leader election implementations to separate algorithm concerns from lock/client concerns, and introduce `TimeProvider` for testable time behavior.
- Add/expand unit tests for `LeaderElectionBase` and new ServiceBuilder extension behaviors; update example app DI usage and package references.
 
 
**LeaderElection improvements:**

* Refactored all LeaderElection classes to make a strong distinction between the LeaderElection _algorithm_ and the low-level, implementation specific _locking_ functionality.
* Modified all derived LeaderElection classes to have _similar_ error handling and logging behaviors.
* The **S3** Lock implementation was modified quite a bit to make use of the returned ETag and thereby avoid extra (non-atomic) read operations. 
* The **FusionCache** and **DistributedCache** were modified quite a bit in order to (attempt to) workaround the lack of distributed locking capabilities (using double checks and timing-based decisions). The current implementation works, but its robustness is an open question.

**Test improvements:**

* Near total unit test coverage of the `BaseLeaderElection` class/algorithm.
* Add unit tests for all ServiceBuilder Extension methods.
* Use `System.TimeProvider` for all time related operations to improve testability.
* Made internals visible to the test project for improved testability and compatibility.

**Project and code maintenance:**

* Update leader election tester example app to use dependency injection for Azure Blob Storage, PostgreSQL, and Redis services (the same way most users would consume these libraries).
* Removed the unused `Settings.cs` file from the leader election tester example and updated logging configuration to only include Npgsql warnings and errors.
* Added more polyfill types.

---

## Checklist

- [x] My code follows the project's coding style
- [x] I have self-reviewed my changes
- [x] I have added tests (or explain why not needed)
- [ ] I have updated the documentation
- [x] I have linked relevant issue(s)
- [x] I have included meaningful commit messages

---

## Related Issues

Closes #61 and #62

---

## Additional Notes

Lots of changes in this one (sorry). Many of the changes are straight-up refactorings with no effect on existing functionality (e.g., the ServiceBuilder Extensions). As far as I know, none of these changes alter existing behavior in a significant way (logging doesn't count in my book). The LeaderElection constructors were modified, which is technically an API breaking change.