### PR TITLE
Improve thread safety of LeaderElection algorithm

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,18 +8,18 @@
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />
     <PackageVersion Include="coverlet.msbuild" Version="10.0.0" />
     <PackageVersion Include="JunitXml.TestLogger" Version="7.1.0" />
-    <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.13.1" />
+    <PackageVersion Include="Microsoft.Bcl.TimeProvider" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Azure" Version="1.14.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.5.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Minio" Version="7.0.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ builder.Services.AddRedisLeaderElection(settings =>
     settings.LockExpiry = TimeSpan.FromSeconds(30);
     settings.RenewInterval = TimeSpan.FromSeconds(10);
     settings.RetryInterval = TimeSpan.FromSeconds(5);
-    settings.MaxRetryAttempts = 3;
     settings.EnableGracefulShutdown = true;
 });
 ```

--- a/examples/LeaderElectionTester/Program.cs
+++ b/examples/LeaderElectionTester/Program.cs
@@ -133,9 +133,14 @@ if (leaderElectionType is "Postgres")
     // Register a NpgsqlDataSource specifically for Leader Election use...
     const string postgresLeaderElectionDataSource = "PostgresLeaderElectionDataSource";
     builder.Services.AddNpgsqlDataSource(
-        // Use short CommandTimeout to avoid long waits if the database becomes unresponsive.
-        "Host=localhost;Database=mydb;Username=myuser;Password=mypassword;Timeout=5;CommandTimeout=3;",
-        serviceKey: postgresLeaderElectionDataSource
+        serviceKey: postgresLeaderElectionDataSource,
+        connectionString: "Host=localhost;Database=mydb;Username=myuser;Password=mypassword",
+        dataSourceBuilderAction: builder =>
+        {
+            // Use short timeouts to avoid long waits if the database becomes unresponsive.
+            builder.ConnectionStringBuilder.Timeout = 5; // connection timeout
+            builder.ConnectionStringBuilder.CommandTimeout = 3;
+        }
     );
 
     builder.Services.AddPostgresLeaderElection(builder =>
@@ -148,6 +153,8 @@ if (leaderElectionType is "Postgres")
                 // Use a short RenewInterval to quickly detect and recover from failed leaders.
                 // Note that the actual detection time will be at least the sum of the CommandTimeout
                 // and RenewInterval, so keep CommandTimeout low as well.
+                // Alternatively, you can specify a KeepAlive interval in the connection string
+                // (e.g., "KeepAlive=5") to have the Npgsql driver detect a broken connection.
                 options.RenewInterval = TimeSpan.FromSeconds(5); // aggressive renew
             })
     );

--- a/examples/LeaderElectionTester/Program.cs
+++ b/examples/LeaderElectionTester/Program.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Minio;
-using Npgsql;
 using StackExchange.Redis;
 using ZiggyCreatures.Caching.Fusion;
 
@@ -37,12 +36,11 @@ var leaderElectionType = (
 };
 
 // Get a unique ID for each running instance (e.g. in different terminals or machines).
-var instanceId = builder.Configuration.GetValue(
-    "InstanceId",
-    $"{AppDomain.CurrentDomain.FriendlyName}:{Environment.MachineName}:{Environment.ProcessId}"
-);
+var instanceId =
+    builder.Configuration["InstanceId"]
+    ?? $"{AppDomain.CurrentDomain.FriendlyName}:{Environment.MachineName}:{Environment.ProcessId}";
 
-var redisConfiguration = "localhost:6379";
+var redisConfiguration = builder.Configuration.GetConnectionString("redis") ?? "localhost:6379";
 
 if (leaderElectionType is "Redis")
 {
@@ -56,8 +54,7 @@ if (leaderElectionType is "Redis")
             })
     );
 }
-
-if (leaderElectionType is "DistributedCache")
+else if (leaderElectionType is "DistributedCache")
 {
     builder.Services.AddRedisServices(redisConfiguration);
     builder.Services.AddDistributedCache();
@@ -70,8 +67,7 @@ if (leaderElectionType is "DistributedCache")
             })
     );
 }
-
-if (leaderElectionType is "FusionCache")
+else if (leaderElectionType is "FusionCache")
 {
     builder.Services.AddRedisServices(redisConfiguration);
     builder.Services.AddDistributedCache();
@@ -88,13 +84,14 @@ if (leaderElectionType is "FusionCache")
             })
     );
 }
-
-if (leaderElectionType is "BlobStorage")
+else if (leaderElectionType is "BlobStorage")
 {
     builder.Services.AddAzureClients(configure =>
     {
         // blob test using Azurite or Storage Emulator
-        configure.AddBlobServiceClient("UseDevelopmentStorage=true;");
+        configure.AddBlobServiceClient(
+            builder.Configuration["BLOBS_CONNECTIONSTRING"] ?? "UseDevelopmentStorage=true;"
+        );
     });
     builder.Services.AddBlobStorageLeaderElection(builder =>
         builder
@@ -106,13 +103,18 @@ if (leaderElectionType is "BlobStorage")
             })
     );
 }
-
-if (leaderElectionType is "S3")
+else if (leaderElectionType is "S3")
 {
+    var minioUri = new Uri(builder.Configuration["Minio:Endpoint"] ?? "http://localhost:9000");
+    var minioEndpoint = $"{minioUri.Host}:{minioUri.Port}";
+    var minioAccessKey = builder.Configuration["Minio:AccessKey"] ?? "accessKey";
+    var minioSecretKey = builder.Configuration["Minio:SecretKey"] ?? "secretKey";
+    var minioBucketName = builder.Configuration["Minio:BucketName"] ?? "my-app-locks";
+
     builder.Services.AddMinio(client =>
         client
-            .WithEndpoint("localhost:9000")
-            .WithCredentials("accessKey", "secretKey")
+            .WithEndpoint(minioEndpoint)
+            .WithCredentials(minioAccessKey, minioSecretKey)
             .WithSSL(false)
             .Build()
     );
@@ -122,25 +124,23 @@ if (leaderElectionType is "S3")
             .WithInstanceId(instanceId)
             .WithSettings(options =>
             {
-                options.BucketName = "my-app-locks";
+                options.BucketName = minioBucketName;
                 options.ObjectKey = "leader-lock.json";
             })
     );
 }
-
-if (leaderElectionType is "Postgres")
+else if (leaderElectionType is "Postgres")
 {
+    var connectionString =
+        builder.Configuration.GetConnectionString("mydb")
+        ?? "Host=localhost;Database=mydb;Username=myuser;Password=mypassword;";
+
     // Register a NpgsqlDataSource specifically for Leader Election use...
     const string postgresLeaderElectionDataSource = "PostgresLeaderElectionDataSource";
     builder.Services.AddNpgsqlDataSource(
-        serviceKey: postgresLeaderElectionDataSource,
-        connectionString: "Host=localhost;Database=mydb;Username=myuser;Password=mypassword",
-        dataSourceBuilderAction: builder =>
-        {
-            // Use short timeouts to avoid long waits if the database becomes unresponsive.
-            builder.ConnectionStringBuilder.Timeout = 5; // connection timeout
-            builder.ConnectionStringBuilder.CommandTimeout = 3;
-        }
+        // Use short CommandTimeout to avoid long waits if the database becomes unresponsive.
+        connectionString + ";Timeout=5;CommandTimeout=3;",
+        serviceKey: postgresLeaderElectionDataSource
     );
 
     builder.Services.AddPostgresLeaderElection(builder =>
@@ -182,9 +182,12 @@ internal static class ProgramExtensions
         services.AddStackExchangeRedisCache(_ => { });
         services
             .AddOptions<RedisCacheOptions>()
-            .Configure<IConnectionMultiplexer>(
-                (options, connection) =>
-                    options.ConnectionMultiplexerFactory = () => Task.FromResult(connection)
+            .Configure<IServiceProvider>(
+                (options, serviceProvider) =>
+                    options.ConnectionMultiplexerFactory = () =>
+                        Task.FromResult(
+                            serviceProvider.GetRequiredService<IConnectionMultiplexer>()
+                        )
             );
         return services;
     }

--- a/src/LeaderElection.BlobStorage/README.md
+++ b/src/LeaderElection.BlobStorage/README.md
@@ -39,7 +39,6 @@ collection.AddBlobStorageLeaderElection(settings =>
     settings.LeaseDuration = TimeSpan.FromSeconds(30);
     settings.RenewInterval = TimeSpan.FromSeconds(10);
     settings.RetryInterval = TimeSpan.FromSeconds(5);
-    settings.MaxRetryAttempts = 3;
     settings.EnableGracefulShutdown = true;
 });
 ```

--- a/src/LeaderElection.DistributedCache/README.md
+++ b/src/LeaderElection.DistributedCache/README.md
@@ -43,7 +43,6 @@ builder.Services.AddRedisLeaderElection(settings =>
     settings.LockExpiry = TimeSpan.FromSeconds(30);
     settings.RenewInterval = TimeSpan.FromSeconds(10);
     settings.RetryInterval = TimeSpan.FromSeconds(5);
-    settings.MaxRetryAttempts = 3;
     settings.EnableGracefulShutdown = true;
 });
 ```

--- a/src/LeaderElection.FusionCache/README.md
+++ b/src/LeaderElection.FusionCache/README.md
@@ -43,7 +43,6 @@ builder.Services.AddRedisLeaderElection(settings =>
     settings.LockExpiry = TimeSpan.FromSeconds(30);
     settings.RenewInterval = TimeSpan.FromSeconds(10);
     settings.RetryInterval = TimeSpan.FromSeconds(5);
-    settings.MaxRetryAttempts = 3;
     settings.EnableGracefulShutdown = true;
 });
 ```

--- a/src/LeaderElection.Postgres/PostgresLeaderElection.cs
+++ b/src/LeaderElection.Postgres/PostgresLeaderElection.cs
@@ -234,12 +234,6 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         }
     }
 
-    protected override async ValueTask DisposeAsyncCore()
-    {
-        await ResetLeadershipAsync().ConfigureAwait(false);
-        await base.DisposeAsyncCore().ConfigureAwait(false);
-    }
-
     private static NpgsqlCommand CreateCommand(
         NpgsqlConnection connection,
         /* language=sql */string query,

--- a/src/LeaderElection.Postgres/PostgresLeaderElection.cs
+++ b/src/LeaderElection.Postgres/PostgresLeaderElection.cs
@@ -9,6 +9,9 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
     private readonly NpgsqlDataSource _dataSource;
     private NpgsqlConnection? _connection;
 
+    // for testing purposes, expose the process ID of the connection holding the lock (if any)
+    internal int? ConnectionProcessId => _connection?.ProcessID;
+
     public PostgresLeaderElection(
         PostgresSettings options,
         NpgsqlDataSource dataSource,
@@ -96,6 +99,21 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
             {
                 _connection = connection;
                 connection = null; // ownership transferred, don't dispose in finally
+
+                // monitor the connection for unexpected closures
+                _connection.StateChange += async (sender, e) =>
+                {
+                    if (
+                        e.OriginalState.HasFlag(ConnectionState.Open)
+                        && ((NpgsqlConnection)sender).FullState.HasFlag(ConnectionState.Broken)
+                    )
+                    {
+                        // connection was broken unexpectedly, assume we lost the lock
+                        LogConnectionBrokenUnexpectedly(_settings.LockId);
+                        await OnLeadershipLostAsync().ConfigureAwait(false);
+                    }
+                };
+
                 LogAcquiredLock(_settings.LockId);
             }
             else
@@ -301,4 +319,7 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         "CommandTimeout of {commandTimeout} seconds may be too high for reliable leader election. Consider setting 'CommandTimeout' to 3-5 seconds."
     )]
     partial void LogUseRecommendedCommandTimeout(int commandTimeout);
+
+    [LoggerMessage(LogLevel.Warning, "Connection broken unexpectedly for lock {lockId}.")]
+    partial void LogConnectionBrokenUnexpectedly(long lockId);
 }

--- a/src/LeaderElection.Postgres/README.md
+++ b/src/LeaderElection.Postgres/README.md
@@ -51,6 +51,8 @@ builder.Services.AddPostgresLeaderElection(builder =>
             // Use a short RenewInterval to quickly detect and recover from failed leaders.
             // Note that the actual detection time will be at least the sum of the CommandTimeout
             // and RenewInterval, so keep CommandTimeout low as well.
+            // Alternatively, you can specify a KeepAlive interval in the connection string
+            // (e.g., "KeepAlive=5") to have the Npgsql driver detect a broken connection.
             options.RenewInterval = TimeSpan.FromSeconds(5); // aggressive renew
         })
 );
@@ -92,15 +94,18 @@ public class Worker : BackgroundService
 
 ## Configuration (PostgresSettings)
 
-| Property                 | Default          | Description                                                                                                                     |
-| :----------------------- | :--------------- | :------------------------------------------------------------------------------------------------------------------------------ |
-| `DataSourceFactory`      | `null`           | A factory function used to create an `NpgsqlDataSource`. If not specified, the `ConnectionString` will be tried.                |
-| `ConnectionString`       | `null`           | The connection string for the PostgreSQL database. If not specified, the `NpgsqlDataSource` from the DI container will be used. |
-| `LockId`                 | `0`              | The unique 64-bit advisory lock id to use for leader election.                                                                  |
-| `InstanceId`             | `Guid.NewGuid()` | Unique ID for this node.                                                                                                        |
-| `RetryInterval`          | `5s`             | The interval to wait before retrying a failed leadership acquisition.                                                           |
-| `RenewInterval`          | `10s`            | The interval at which the leader will attempt to renew its leadership.                                                          |
-| `EnableGracefulShutdown` | `true`           | If true, explicitly unlocks via `pg_advisory_unlock` on stop. It is highly recommended to leave this enabled.                   |
+| Property                 | Default          | Description                                                                                                                              |
+| :----------------------- | :--------------- | :--------------------------------------------------------------------------------------------------------------------------------------- |
+| `DataSourceFactory`      | `null`           | A factory function used to create an `NpgsqlDataSource`. If not specified, the `ConnectionString` will be tried.                         |
+| `ConnectionString`       | `null`           | The connection string for the PostgreSQL database. If not specified, the `NpgsqlDataSource` from the DI container will be used.          |
+| `LockId`                 | `0`              | The unique 64-bit advisory lock id to use for leader election.                                                                           |
+| `InstanceId`             | `Guid.NewGuid()` | Unique ID for this node.                                                                                                                 |
+| `RenewInterval`          | `10s`            | The interval at which the leader will attempt to renew its leadership.                                                                   |
+| `RetryInterval`          | `5s`             | The interval at which non-leader instances will attempt to acquire leadership.                                                           |
+| `RetryBackoffFactor`     | `2.0`            | The exponential backoff factor applied to the `RetryInterval`.                                                                           |
+| `RetryJitter`            | `0.10`           | The jitter percentage to apply to the retry interval to avoid thundering herd when multiple contenders are trying to acquire leadership. |
+| `MaxRetryInterval`       | `40s`            | The maximum retry interval (after applying the backoff factor and jitter) when acquiring leadership.                                     |
+| `EnableGracefulShutdown` | `true`           | If true, explicitly unlocks via `pg_advisory_unlock` on stop. It is highly recommended to leave this enabled.                            |
 
 ## PostgreSQL Specifics
 

--- a/src/LeaderElection.Postgres/README.md
+++ b/src/LeaderElection.Postgres/README.md
@@ -96,7 +96,7 @@ public class Worker : BackgroundService
 | :----------------------- | :--------------- | :------------------------------------------------------------------------------------------------------------------------------ |
 | `DataSourceFactory`      | `null`           | A factory function used to create an `NpgsqlDataSource`. If not specified, the `ConnectionString` will be tried.                |
 | `ConnectionString`       | `null`           | The connection string for the PostgreSQL database. If not specified, the `NpgsqlDataSource` from the DI container will be used. |
-| `LockId`                 | (required)       | The unique 64-bit advisory lock id to use for leader election.                                                                  |
+| `LockId`                 | `0`              | The unique 64-bit advisory lock id to use for leader election.                                                                  |
 | `InstanceId`             | `Guid.NewGuid()` | Unique ID for this node.                                                                                                        |
 | `RetryInterval`          | `5s`             | The interval to wait before retrying a failed leadership acquisition.                                                           |
 | `RenewInterval`          | `10s`            | The interval at which the leader will attempt to renew its leadership.                                                          |

--- a/src/LeaderElection.Redis/README.md
+++ b/src/LeaderElection.Redis/README.md
@@ -43,7 +43,6 @@ builder.Services.AddRedisLeaderElection(settings =>
     settings.LockExpiry = TimeSpan.FromSeconds(30);
     settings.RenewInterval = TimeSpan.FromSeconds(10);
     settings.RetryInterval = TimeSpan.FromSeconds(5);
-    settings.MaxRetryAttempts = 3;
     settings.EnableGracefulShutdown = true;
 });
 ```

--- a/src/LeaderElection/BaseSettingsValidator.cs
+++ b/src/LeaderElection/BaseSettingsValidator.cs
@@ -17,4 +17,18 @@ public static class BaseSettingsValidator
             : new ValidationResult(
                 $"{nameof(LeaderElectionSettingsBase.RetryInterval)} must be positive."
             );
+
+    public static ValidationResult? ValidateMaxRetryInterval(
+        TimeSpan maxRetryInterval,
+        ValidationContext context
+    )
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        var settings = (LeaderElectionSettingsBase)context.ObjectInstance;
+        return maxRetryInterval >= settings.RetryInterval
+            ? ValidationResult.Success
+            : new ValidationResult(
+                $"{nameof(LeaderElectionSettingsBase.MaxRetryInterval)} must be greater than or equal to {nameof(LeaderElectionSettingsBase.RetryInterval)}."
+            );
+    }
 }

--- a/src/LeaderElection/ILeaderElection.cs
+++ b/src/LeaderElection/ILeaderElection.cs
@@ -6,10 +6,22 @@ namespace LeaderElection;
 public interface ILeaderElection : IAsyncDisposable
 {
     /// <summary>
+    /// Gets whether the leader loop is currently running, indicating that the
+    /// instance is actively participating in the leader election process.
+    /// </summary>
+    bool LeaderLoopRunning { get; }
+
+    /// <summary>
     /// Gets whether this instance is currently the leader
     /// </summary>
     bool IsLeader { get; }
 
+    /// <summary>
+    /// Gets the timestamp of the last successful leadership acquisition or renewal.
+    /// </summary>
+    /// <remarks>
+    /// Returns <see cref="DateTime.MinValue"/> when <see cref="IsLeader"/> is false.
+    /// </remarks>
     DateTime LastLeadershipRenewal { get; }
 
     /// <summary>
@@ -23,39 +35,56 @@ public interface ILeaderElection : IAsyncDisposable
     event EventHandler<LeadershipExceptionEventArgs>? ErrorOccurred;
 
     /// <summary>
-    /// Starts the leader election process
+    /// Starts the leader election process.
     /// </summary>
+    /// <remarks>
+    /// Calling this method when the leader loop is already running has no effect.
+    /// </remarks>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Task representing the async operation</returns>
+    /// <exception cref="ObjectDisposedException">Thrown if the leader election instance has been disposed.</exception>
     Task StartAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Stops the leader election process
+    /// Stops the leader election process.
     /// </summary>
+    /// <remarks>
+    /// Calling this method when the leader loop is not running has no effect.
+    /// </remarks>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Task representing the async operation</returns>
+    /// <exception cref="ObjectDisposedException">Thrown if the leader election instance has been disposed.</exception>
     Task StopAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Attempts to acquire leadership manually
+    /// Attempts to acquire leadership manually.
     /// </summary>
+    /// <remarks>
+    /// Must be called while the leader loop is running.
+    /// </remarks>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>True if leadership was acquired, false otherwise</returns>
+    /// <exception cref="InvalidOperationException">Thrown if the leader loop is not running.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown if the leader election instance has been disposed.</exception>
     Task<bool> TryAcquireLeadershipAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Executes a task only if this instance is the leader
+    /// Executes a task only if this instance is the leader.
     /// </summary>
     /// <param name="task">The task to execute</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Task representing the async operation</returns>
+    /// <exception cref="ArgumentNullException">Thrown if the task is null.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown if the leader election instance has been disposed.</exception>
     Task RunTaskIfLeaderAsync(Func<Task> task, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Executes a synchronous task only if this instance is the leader
+    /// Executes a synchronous task only if this instance is the leader.
     /// </summary>
     /// <param name="task">The task to execute</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Task representing the async operation</returns>
+    /// <exception cref="ArgumentNullException">Thrown if the task is null.</exception>
+    /// <exception cref="ObjectDisposedException">Thrown if the leader election instance has been disposed.</exception>
     Task RunTaskIfLeaderAsync(Action task, CancellationToken cancellationToken = default);
 }

--- a/src/LeaderElection/LeaderElectionBase.cs
+++ b/src/LeaderElection/LeaderElectionBase.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -7,6 +8,13 @@ namespace LeaderElection;
 public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
     where TSettings : LeaderElectionSettingsBase
 {
+    private readonly SemaphoreSlim _leaderLoopSemaphore = new(1, 1);
+    private volatile Task? _leaderLoopTask;
+    private CancellationTokenSource? _leaderLoopTaskCTS;
+    private DateTimeOffset _lastLeadershipRenewal;
+    private volatile bool _isLeader;
+    private volatile int _disposedValue;
+
     [SuppressMessage("Design", "CA1051", Justification = "Field readonly to derived types")]
     protected readonly TSettings _settings;
 
@@ -28,243 +36,418 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
-    private readonly SemaphoreSlim _leadershipSemaphore = new(1, 1);
-    private CancellationTokenSource? _leadershipLoopCancellationTokenSource = new();
-
-    private volatile bool _isLeader;
-    private int _disposedValue;
-    private Task? _leadershipLoopTask;
-    private DateTimeOffset _lastLeadershipRenewalTime = DateTimeOffset.MinValue;
+    /// <inheritdoc />
     public event EventHandler<LeadershipChangedEventArgs>? LeadershipChanged;
+
+    /// <inheritdoc />
     public event EventHandler<LeadershipExceptionEventArgs>? ErrorOccurred;
 
+    /// <inheritdoc />
     public bool LeaderLoopRunning => Volatile.Read(ref _leadershipLoopTask)?.IsCompleted is false;
 
-    private bool IsDisposed => Volatile.Read(ref _disposedValue) == 1;
-    public bool IsLeader => _isLeader && !IsDisposed;
-    public DateTime LastLeadershipRenewal => _lastLeadershipRenewalTime.UtcDateTime;
+    /// <inheritdoc />
+    public bool IsLeader => _isLeader;
 
+    /// <inheritdoc />
+    public DateTime LastLeadershipRenewal =>
+        _isLeader ? _lastLeadershipRenewal.UtcDateTime : DateTime.MinValue;
+
+    /// <inheritdoc />
     public async Task StartAsync(CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
 
-        if (_leadershipLoopTask is { IsCompleted: false })
+        if (LeaderLoopRunning)
         {
-            LogLeaderElectionIsAlreadyRunning();
+            LogLeaderElectionIsAlreadyRunning(_settings.InstanceId);
             return;
         }
 
-        LogStartingLeaderElectionForInstanceInstanceid(_settings.InstanceId);
-
-        _leadershipLoopCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(
-            cancellationToken
-        );
-        _leadershipLoopTask = RunLeaderLoopAsync(_leadershipLoopCancellationTokenSource.Token);
-
-        await Task.CompletedTask.ConfigureAwait(false);
-    }
-
-    private async Task RunLeaderLoopAsync(CancellationToken token)
-    {
-        ThrowIfDisposed();
-
-        var retryCount = 0;
-
-        while (!token.IsCancellationRequested)
+        CancellationTokenSource? cts = null;
+        await _leaderLoopSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
         {
-            try
+            if (LeaderLoopRunning)
             {
-                if (!_isLeader)
-                {
-                    if (await TryAcquireLeadershipAsync(token).ConfigureAwait(false))
-                    {
-                        LogLeadershipAcquiredForInstanceInstanceid(_settings.InstanceId);
-                        retryCount = 0;
-                    }
-                    else
-                    {
-                        // Very common that leadership acquisition fails because another instance holds the leadership - log at debug level in that case and avoid log noise
-                        LogFailedToAcquireLeadershipWillRetry();
-                        retryCount++;
-                    }
-                }
-                else
-                {
-                    if (!await RenewLeadershipInternalAsync(token).ConfigureAwait(false))
-                    {
-                        LogLostLeadershipDuringRenewalForInstanceInstanceid(_settings.InstanceId);
-                        SetLeadership(false);
-                        retryCount++;
-                    }
-                    else
-                    {
-                        LogLeadershipRenewedSuccessfully();
-                        _lastLeadershipRenewalTime = _timeProvider.GetUtcNow();
-                        retryCount = 0;
-                    }
-                }
+                LogLeaderElectionIsAlreadyRunning(_settings.InstanceId);
+                return;
+            }
 
-                var delay = GetNextDelay(retryCount);
-                await _timeProvider.Delay(delay, token).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                break;
-            }
-            catch (Exception ex)
-            {
-                LogUnexpectedErrorInLeaderLoop(ex);
-                ErrorOccurred?.Invoke(this, new(ex));
-                retryCount++;
+            LogStartingLeaderElection(_settings.InstanceId);
 
-                try
-                {
-                    await _timeProvider.Delay(_settings.RetryInterval, token).ConfigureAwait(false);
-                }
-                catch (OperationCanceledException)
-                {
-                    break;
-                }
-            }
+            // Important: DO NOT link the Leader Loop Task to the provided cancellation
+            // token since we need to control the lifetime of this task independently of
+            // external cancellation requests. There is also no reason to think that the
+            // provided cancellation token is long-lived -- it could be tied to a short-
+            // lived API call, for example.
+            // The user must call StopAsync() (or DisposeAsync()) to stop the leader loop.
+            cts = new CancellationTokenSource();
+            var task = RunLeaderLoopAsync(cts.Token);
+
+            // success
+            _leaderLoopTask = task;
+            _leaderLoopTaskCTS = cts;
+            cts = null; // ownership transferred
+        }
+        finally
+        {
+            _leaderLoopSemaphore.Release();
+            cts?.Dispose();
         }
     }
 
-    protected virtual TimeSpan GetNextDelay(int retryCount)
-    {
-        if (retryCount == 0)
-        {
-            return _settings.RenewInterval;
-        }
-
-        return TimeSpan.FromSeconds(
-            Math.Min(Math.Pow(2, Math.Min(retryCount, _settings.MaxRetryAttempts)), 60)
-        );
-    }
-
+    /// <inheritdoc />
     public virtual Task StopAsync(CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
-        return InternalStopAsync(cancellationToken);
+        return InternalStopAsync(true, cancellationToken);
     }
 
-    private async Task InternalStopAsync(CancellationToken cancellationToken = default)
-    {
-        if (_leadershipLoopCancellationTokenSource != null)
-        {
-            LogStoppingLeaderElectionForInstanceInstanceid(_settings.InstanceId);
-
-            await _leadershipLoopCancellationTokenSource.CancelAsync().ConfigureAwait(false);
-        }
-
-        if (_leadershipLoopTask != null)
-        {
-            try
-            {
-                await _leadershipLoopTask.WaitAsync(cancellationToken).ConfigureAwait(false);
-            }
-            finally
-            {
-                _leadershipLoopTask = null;
-                _leadershipLoopCancellationTokenSource?.Dispose();
-                _leadershipLoopCancellationTokenSource = null;
-            }
-        }
-
-        if (_isLeader)
-        {
-            if (_settings.EnableGracefulShutdown)
-            {
-                await ReleaseLeadershipAsync().ConfigureAwait(false);
-            }
-            else
-            {
-                await ResetLeadershipAsync().ConfigureAwait(false);
-            }
-
-            SetLeadership(false);
-        }
-    }
-
-    protected abstract Task<bool> TryAcquireLeadershipInternalAsync(
-        CancellationToken cancellationToken
-    );
-
-    protected abstract Task<bool> RenewLeadershipInternalAsync(CancellationToken cancellationToken);
-    protected abstract Task ReleaseLeadershipAsync();
-    protected abstract ValueTask ResetLeadershipAsync();
-
-    protected void SetLeadership(bool isLeader)
-    {
-        if (_isLeader != isLeader)
-        {
-            _isLeader = isLeader;
-            _lastLeadershipRenewalTime = isLeader
-                ? _timeProvider.GetUtcNow()
-                : DateTimeOffset.MinValue;
-            LeadershipChanged?.Invoke(this, new(isLeader));
-        }
-    }
-
+    /// <inheritdoc />
     public async Task<bool> TryAcquireLeadershipAsync(CancellationToken cancellationToken = default)
     {
         ThrowIfDisposed();
 
-        await _leadershipSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        // Fast checks before acquiring the semaphore to avoid unnecessary waits
+        if (!LeaderLoopRunning)
+        {
+            throw new InvalidOperationException(
+                "Leader loop must be running to acquire leadership"
+            );
+        }
+
+        if (IsLeader)
+        {
+            return true; // Already the leader
+        }
+
+        Exception? exceptionInfo = null;
+        var isLeader = false;
+        await _leaderLoopSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            var acquired = await TryAcquireLeadershipInternalAsync(cancellationToken)
-                .ConfigureAwait(false);
-            SetLeadership(acquired);
-            return acquired;
+            if (!LeaderLoopRunning)
+            {
+                throw new InvalidOperationException(
+                    "Leader loop must be running to acquire leadership"
+                );
+            }
+
+            if (IsLeader)
+            {
+                return true; // Already the leader
+            }
+
+            if (!await TryAcquireLeadershipInternalAsync(cancellationToken).ConfigureAwait(false))
+            {
+                LogFailedToAcquireLeadership(_settings.InstanceId);
+                return false;
+            }
+
+            // Successfully acquired leadership
+            _isLeader = true;
+            _lastLeadershipRenewal = _timeProvider.GetUtcNow();
+            LogLeadershipAcquired(_settings.InstanceId);
+        }
+        catch (Exception ex)
+        {
+            // don't throw since this is a "try" method
+            LogErrorAcquiringLeadership(ex, _settings.InstanceId);
+            exceptionInfo = ex; // capture for event raising after releasing semaphore
         }
         finally
         {
-            _leadershipSemaphore.Release();
+            isLeader = _isLeader;
+            _leaderLoopSemaphore.Release();
         }
+
+        // Fire events outside of the lock to avoid potential deadlocks
+        // if event handlers interact with the leader election instance
+        NotifyLeadershipStatus(false, isLeader, exceptionInfo);
+        return isLeader;
     }
 
+    /// <inheritdoc />
     public async Task RunTaskIfLeaderAsync(
         Func<Task> task,
         CancellationToken cancellationToken = default
     )
     {
+        ArgumentNullException.ThrowIfNull(task);
         ThrowIfDisposed();
 
-        if (!IsLeader)
+        if (IsLeader)
         {
-            LogNotTheLeaderSkippingTaskExecution();
-            return;
-        }
-
-        try
-        {
-            LogExecutingTaskAsLeader();
-            if (task != null)
-            {
-                await task().ConfigureAwait(false);
-            }
-        }
-        catch (Exception ex)
-        {
-            LogErrorExecutingLeaderTask(ex);
-            ErrorOccurred?.Invoke(this, new(ex));
-            throw;
+            await task().WaitAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 
-    public async Task RunTaskIfLeaderAsync(
-        Action task,
+    /// <inheritdoc />
+    public Task RunTaskIfLeaderAsync(Action task, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+        return RunTaskIfLeaderAsync(
+            () =>
+            {
+                task();
+                return Task.CompletedTask;
+            },
+            cancellationToken
+        );
+    }
+
+    /// <summary>
+    /// Tries to acquire leadership. Implementations should return true if leadership was
+    /// successfully acquired, or false if leadership could not be acquired (e.g. another
+    /// instance holds the leadership).
+    /// <para/>
+    /// If an unexpected error occurs, implementations should abandon leadership in their
+    /// internal state and throw an exception. The leader loop will catch the exception,
+    /// log it, and attempt to reacquire leadership on the next iteration. This is a safety
+    /// measure to avoid a situation where an instance thinks it is the leader when it is not.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>true if leadership was successfully acquired; otherwise, false.</returns>
+    protected abstract Task<bool> TryAcquireLeadershipInternalAsync(
+        CancellationToken cancellationToken
+    );
+
+    /// <summary>
+    /// Tries to renew leadership. Implementations should return true if leadership was
+    /// successfully renewed, or false if leadership was lost (e.g. due to a connectivity
+    /// issue with the underlying store). If leadership is lost, the leader loop will attempt
+    /// to reacquire leadership on the next iteration.
+    /// <para/>
+    /// If an unexpected error occurs, implementations should abandon leadership in their
+    /// internal state and throw an exception. The leader loop will catch the exception,
+    /// log it, and attempt to reacquire leadership on the next iteration. This is a safety
+    /// measure to avoid a situation where an instance thinks it is the leader when it is not.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>true if leadership was successfully renewed; otherwise, false.</returns>
+    protected abstract Task<bool> RenewLeadershipInternalAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Releases leadership. This will be called when StopAsync() is called while the instance
+    /// is the leader. Implementations should perform any necessary cleanup to release
+    /// leadership (e.g. delete leader key from the store).
+    /// <para/>
+    /// If an unexpected error occurs, implementations should abandon leadership in their
+    /// internal state and throw an exception. The leader loop will catch the exception and
+    /// log it. This is a safety measure to avoid a situation where an instance thinks it is
+    /// the leader when it is not.
+    /// </summary>
+    protected abstract Task ReleaseLeadershipAsync();
+
+    /// <summary>
+    /// This function is called when leadership is abandoned due to ungraceful shutdown.
+    /// Implementations should perform any necessary cleanup to abandon leadership and reset
+    /// internal state.
+    /// <para/>
+    /// This will be called instead of <see cref="ReleaseLeadershipAsync"/> when StopAsync()
+    /// is called with <see cref="LeaderElectionSettingsBase.EnableGracefulShutdown"/> set to false.
+    /// <para/>
+    /// If an unexpected error occurs, implementations should log it but swallow the exception
+    /// to avoid throwing from a shutdown path.
+    /// </summary>
+    protected abstract ValueTask ResetLeadershipAsync();
+
+    private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposedValue != 0, this);
+
+    private async Task RunLeaderLoopAsync(CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            var wasLeader = false;
+            var isLeader = false;
+            Exception? exceptionInfo = null;
+
+            // Grab the semaphore to ensure that we don't get interrupted by
+            // TryAcquireLeadershipAsync() or StopAsync().
+            await _leaderLoopSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                wasLeader = _isLeader;
+                if (!wasLeader)
+                {
+                    _isLeader = await TryAcquireLeadershipInternalAsync(cancellationToken)
+                        .ConfigureAwait(false);
+                    if (_isLeader)
+                    {
+                        LogLeadershipAcquired(_settings.InstanceId);
+                    }
+                    else
+                    {
+                        // very common that leadership acquisition fails, typically because
+                        // another instance holds the leadership
+                        LogFailedToAcquireLeadershipWillRetry(_settings.InstanceId);
+                    }
+                }
+                else
+                {
+                    _isLeader = await RenewLeadershipInternalAsync(cancellationToken)
+                        .ConfigureAwait(false);
+                    if (_isLeader)
+                    {
+                        // very common that leadership renewal succeeds, but we log it anyway
+                        // to provide visibility into the leader loop's operations
+                        LogLeadershipRenewedSuccessfully(_settings.InstanceId);
+                    }
+                    else
+                    {
+                        // unexpected
+                        LogLostLeadershipDuringRenewal(_settings.InstanceId);
+                    }
+                }
+            }
+            catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+            {
+                LogUnexpectedErrorInLeaderElection(ex, _settings.InstanceId);
+                exceptionInfo = ex;
+
+                // On any unexpected error, we assume we are no longer the leader.
+                // This is a safety measure to avoid a situation where an instance thinks
+                // it is the leader when it is not.
+                _isLeader = false;
+            }
+            finally
+            {
+                isLeader = _isLeader;
+                if (isLeader)
+                {
+                    _lastLeadershipRenewal = _timeProvider.GetUtcNow();
+                }
+
+                _leaderLoopSemaphore.Release();
+            }
+
+            // Fire events outside of the lock to avoid potential deadlocks
+            // if event handlers interact with the leader election instance
+            NotifyLeadershipStatus(wasLeader, isLeader, exceptionInfo);
+
+            // Wait before checking again...
+            var delay = GetNextDelay(isLeader ? 0 : 1);
+            await _timeProvider.Delay(delay, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    protected virtual TimeSpan GetNextDelay(int retryCount) =>
+        retryCount == 0 ? _settings.RenewInterval : _settings.RetryInterval;
+
+    private async Task InternalStopAsync(
+        bool releaseLeadership,
         CancellationToken cancellationToken = default
     )
     {
-        await RunTaskIfLeaderAsync(() => Task.Run(task, cancellationToken), cancellationToken)
-            .ConfigureAwait(false);
+        var wasLeader = false;
+        var isLeader = false;
+        Exception? exceptionInfo = null;
+
+        await _leaderLoopSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (LeaderLoopRunning)
+            {
+                Debug.Assert(_leaderLoopTask != null);
+                Debug.Assert(_leaderLoopTaskCTS != null);
+
+                // First stop the leader loop to prevent any further leadership
+                // changes while we are trying to stop
+
+                // Important: We are purposefully ignoring the provided cancellation token
+                // since we want to ensure that the leader loop is stopped and that we
+                // don't end up in a situation where the leader loop is still running but
+                // we consider ourselves not the leader because of a cancellation request.
+                await StopLeaderLoopAsync().ConfigureAwait(false);
+            }
+
+            // we must not consider ourselves leader since we've abandoned the
+            // leader election process
+            wasLeader = _isLeader;
+            _isLeader = false;
+
+            if (wasLeader)
+            {
+                if (releaseLeadership)
+                {
+                    try
+                    {
+                        await ReleaseLeadershipAsync().ConfigureAwait(false);
+                        LogLeadershipReleased(_settings.InstanceId);
+                    }
+                    catch (Exception ex)
+                    {
+                        LogErrorReleasingLeadership(ex, _settings.InstanceId);
+                        exceptionInfo = ex; // capture for event raising after releasing semaphore
+                    }
+                }
+                else
+                {
+                    await ResetLeadershipAsync().ConfigureAwait(false);
+                    LogLeadershipAbandoned(_settings.InstanceId);
+                }
+            }
+        }
+        finally
+        {
+            isLeader = _isLeader;
+            _leaderLoopSemaphore.Release();
+        }
+
+        NotifyLeadershipStatus(wasLeader, isLeader, exceptionInfo);
+
+        async Task StopLeaderLoopAsync()
+        {
+            LogStoppingLeaderElection(_settings.InstanceId);
+
+            // Cancel the leader loop task, wait for it to complete, and cleanup resources...
+            try
+            {
+                await _leaderLoopTaskCTS.CancelAsync().ConfigureAwait(false);
+                await _leaderLoopTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected, just proceed with stopping
+            }
+            catch (Exception ex)
+            {
+                // Task exited with an unexpected exception. Log it, but proceed
+                // with stopping to avoid leaving the system in an inconsistent state.
+                LogUnexpectedErrorInLeaderElection(ex, _settings.InstanceId);
+            }
+            finally
+            {
+                _leaderLoopTask = null;
+                _leaderLoopTaskCTS.Dispose();
+                _leaderLoopTaskCTS = null;
+            }
+        }
+    }
+
+    private void NotifyLeadershipStatus(bool wasLeader, bool isLeader, Exception? exceptionInfo)
+    {
+        Debug.Assert(
+            _leaderLoopSemaphore.CurrentCount == 1,
+            "Must be called outside of the leader loop lock"
+        );
+
+        if (exceptionInfo != null)
+        {
+            ErrorOccurred?.Invoke(this, new(exceptionInfo));
+        }
+        if (wasLeader != isLeader)
+        {
+            LeadershipChanged?.Invoke(this, new(isLeader));
+        }
     }
 
     public async ValueTask DisposeAsync()
     {
         if (Interlocked.Exchange(ref _disposedValue, 1) == 1)
-            return;
+        {
+            return; // Already disposed/disposing
+        }
 
         await DisposeAsyncCore().ConfigureAwait(false);
         GC.SuppressFinalize(this);
@@ -274,65 +457,88 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
     {
         try
         {
-            await InternalStopAsync().ConfigureAwait(false);
+            await InternalStopAsync(_settings.EnableGracefulShutdown).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             LogErrorDuringAsyncDisposal(ex);
         }
 
-        _leadershipLoopCancellationTokenSource?.Dispose();
-        _leadershipSemaphore.Dispose();
+        _leaderLoopTaskCTS?.Dispose();
+        _leaderLoopSemaphore.Dispose();
+        _isLeader = false;
     }
 
-    private void ThrowIfDisposed()
-    {
-#if NET6_0_OR_GREATER
-        ObjectDisposedException.ThrowIf(IsDisposed, this);
-#else
-        if (IsDisposed)
-        {
-            throw new ObjectDisposedException(GetType().Name);
-        }
-#endif
-    }
+    [LoggerMessage(
+        LogLevel.Information,
+        "Leader election is already running for instance {InstanceId}."
+    )]
+    partial void LogLeaderElectionIsAlreadyRunning(string instanceId);
 
-    [LoggerMessage(LogLevel.Warning, "Leader election is already running")]
-    partial void LogLeaderElectionIsAlreadyRunning();
+    [LoggerMessage(LogLevel.Information, "Starting leader election for instance {InstanceId}.")]
+    partial void LogStartingLeaderElection(string instanceId);
 
-    [LoggerMessage(LogLevel.Information, "Starting leader election for instance {instanceId}")]
-    partial void LogStartingLeaderElectionForInstanceInstanceid(string instanceId);
+    [LoggerMessage(LogLevel.Information, "Stopping leader election for instance {InstanceId}.")]
+    partial void LogStoppingLeaderElection(string instanceId);
 
-    [LoggerMessage(LogLevel.Information, "Leadership acquired for instance {instanceId}")]
-    partial void LogLeadershipAcquiredForInstanceInstanceid(string instanceId);
+    // An exception occurred in the leader election process. Log at Error level since this
+    // likely indicates an issue with the underlying store or infrastructure.
+    [LoggerMessage(
+        LogLevel.Error,
+        "Unexpected error in leader election for instance {InstanceId}."
+    )]
+    partial void LogUnexpectedErrorInLeaderElection(Exception errorMessage, string instanceId);
 
-    [LoggerMessage(LogLevel.Debug, "Failed to acquire leadership, will retry")]
-    partial void LogFailedToAcquireLeadershipWillRetry();
+    // TryAcquireLeadershipInternalAsync threw an exception. This is unexpected since
+    // implementations should handle expected exceptions. Log at Error level since this
+    // likely indicates an issue with the underlying store or infrastructure.
+    [LoggerMessage(
+        LogLevel.Error,
+        "Error while trying to acquire leadership for instance {InstanceId}."
+    )]
+    partial void LogErrorAcquiringLeadership(Exception errorMessage, string instanceId);
 
-    [LoggerMessage(LogLevel.Warning, "Lost leadership during renewal for instance {instanceId}")]
-    partial void LogLostLeadershipDuringRenewalForInstanceInstanceid(string instanceId);
+    [LoggerMessage(LogLevel.Information, "Failed to acquire leadership for instance {InstanceId}.")]
+    partial void LogFailedToAcquireLeadership(string instanceId);
 
-    [LoggerMessage(LogLevel.Debug, "Leadership renewed successfully")]
-    partial void LogLeadershipRenewedSuccessfully();
+    [LoggerMessage(LogLevel.Information, "Leadership acquired for instance {InstanceId}.")]
+    partial void LogLeadershipAcquired(string instanceId);
 
-    [LoggerMessage(LogLevel.Error, "Unexpected error in leader loop")]
-    partial void LogUnexpectedErrorInLeaderLoop(Exception errorMessage);
+    // It is very common that leadership acquisition fails because another instance
+    // holds the leadership. Log at debug level.
+    [LoggerMessage(
+        LogLevel.Debug,
+        "Failed to acquire leadership for instance {InstanceId}, will retry."
+    )]
+    partial void LogFailedToAcquireLeadershipWillRetry(string instanceId);
 
-    [LoggerMessage(LogLevel.Information, "Stopping leader election for instance {instanceId}")]
-    partial void LogStoppingLeaderElectionForInstanceInstanceid(string instanceId);
+    // It is very common that leadership renewal succeeds, so log at debug level.
+    [LoggerMessage(LogLevel.Debug, "Successfully renewed leadership for instance {InstanceId}.")]
+    partial void LogLeadershipRenewedSuccessfully(string instanceId);
 
-    [LoggerMessage(LogLevel.Debug, "Leader loop cancellation was expected")]
-    partial void LogLeaderLoopCancellationWasExpected();
+    // Losing leadership during renewal is not normal and could indicate a potential
+    // issue (e.g. connectivity problems with the underlying store), so we log at
+    // Warning level to highlight this. The leader loop will attempt to reacquire
+    // leadership on the next iteration, but it is important to log this event since
+    // it could indicate a potential problem that needs attention.
+    [LoggerMessage(LogLevel.Warning, "Lost leadership for instance {InstanceId} during renewal.")]
+    partial void LogLostLeadershipDuringRenewal(string instanceId);
 
-    [LoggerMessage(LogLevel.Debug, "Not the leader. Skipping task execution")]
-    partial void LogNotTheLeaderSkippingTaskExecution();
+    [LoggerMessage(LogLevel.Information, "Released leadership for instance {InstanceId}.")]
+    partial void LogLeadershipReleased(string instanceId);
 
-    [LoggerMessage(LogLevel.Debug, "Executing task as leader")]
-    partial void LogExecutingTaskAsLeader();
+    [LoggerMessage(LogLevel.Information, "Abandoned leadership for instance {InstanceId}.")]
+    partial void LogLeadershipAbandoned(string instanceId);
 
-    [LoggerMessage(LogLevel.Error, "Error executing leader task")]
-    partial void LogErrorExecutingLeaderTask(Exception errorMessage);
+    // ReleaseLeadershipAsync threw an exception. This is unexpected since implementations
+    // should handle expected exceptions. Log at Error level since this likely indicates an
+    // issue with the underlying store or infrastructure.
+    [LoggerMessage(LogLevel.Error, "Error releasing leadership for instance {InstanceId}.")]
+    partial void LogErrorReleasingLeadership(Exception ex, string instanceId);
 
-    [LoggerMessage(LogLevel.Error, "Error during async disposal")]
+    // InternalStopAsync threw an exception during disposal. Log at Error level since
+    // we want to avoid throwing from DisposeAsync, but we still want to log this since
+    // it could indicate a potential issue that needs attention.
+    [LoggerMessage(LogLevel.Error, "Error during async disposal.")]
     partial void LogErrorDuringAsyncDisposal(Exception errorMessage);
 }

--- a/src/LeaderElection/LeaderElectionBase.cs
+++ b/src/LeaderElection/LeaderElectionBase.cs
@@ -417,7 +417,11 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
         }
         else
         {
-            var backoffFactor = Math.Pow(_settings.RetryBackoffFactor, Math.Min(errorCount, 30));
+            const int maxExponent = 30; // to prevent overflow
+            var backoffFactor = Math.Pow(
+                _settings.RetryBackoffFactor,
+                Math.Min(errorCount, maxExponent)
+            );
             var jitter = _settings.RetryJitter - (_getRandomDouble() * _settings.RetryJitter * 2);
             return TimeSpan.FromTicks(
                 Math.Min(

--- a/src/LeaderElection/LeaderElectionBase.cs
+++ b/src/LeaderElection/LeaderElectionBase.cs
@@ -5,16 +5,31 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace LeaderElection;
 
+/// <summary>
+/// A thread-safe abstract implementation of the <see cref="ILeaderElection"/> interface that
+/// manages the leader loop, leadership status, and event notifications.
+/// <para/>
+/// Derived classes are responsible for implementing the specific logic to acquire, renew,
+/// and release leadership by implementing the abstract methods
+/// <see cref="TryAcquireLeadershipInternalAsync"/>, <see cref="RenewLeadershipInternalAsync"/>,
+/// and <see cref="ReleaseLeadershipAsync"/>.
+/// </summary>
+/// <typeparam name="TSettings">The settings used by the derived implementation.</typeparam>
 public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
     where TSettings : LeaderElectionSettingsBase
 {
-    private readonly SemaphoreSlim _leaderLoopSemaphore = new(1, 1);
-    private volatile Task? _leaderLoopTask;
-    private CancellationTokenSource? _leaderLoopTaskCTS;
-    private DateTimeOffset _lastLeadershipRenewal;
-    private volatile bool _isLeader;
-    private volatile int _disposedValue;
+    // We use an int for the disposed flag since Interlocked doesn't support bool.
+    // 0 = not disposed, 1 = disposed.
+    private int _disposedValue;
 
+    // Semaphore to protect access to the leader loop and related state.
+    private readonly SemaphoreSlim _leaderLoopSemaphore = new(1, 1);
+    private Task? _leaderLoopTask;
+    private CancellationTokenSource? _leaderLoopTaskCTS;
+    private bool _isLeader;
+    private long _lastLeadershipRenewalTicks;
+
+    // These readonly fields are visible for derived types.
     [SuppressMessage("Design", "CA1051", Justification = "Field readonly to derived types")]
     protected readonly TSettings _settings;
 
@@ -43,14 +58,16 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
     public event EventHandler<LeadershipExceptionEventArgs>? ErrorOccurred;
 
     /// <inheritdoc />
-    public bool LeaderLoopRunning => Volatile.Read(ref _leadershipLoopTask)?.IsCompleted is false;
+    public bool LeaderLoopRunning => Volatile.Read(ref _leaderLoopTask)?.IsCompleted is false;
 
     /// <inheritdoc />
-    public bool IsLeader => _isLeader;
+    public bool IsLeader => Volatile.Read(ref _isLeader);
 
     /// <inheritdoc />
     public DateTime LastLeadershipRenewal =>
-        _isLeader ? _lastLeadershipRenewal.UtcDateTime : DateTime.MinValue;
+        IsLeader
+            ? new DateTime(Interlocked.Read(ref _lastLeadershipRenewalTicks), DateTimeKind.Utc)
+            : DateTime.MinValue;
 
     /// <inheritdoc />
     public async Task StartAsync(CancellationToken cancellationToken = default)
@@ -64,7 +81,7 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
         }
 
         CancellationTokenSource? cts = null;
-        await _leaderLoopSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        await AcquireLeaderLoopSemaphoreAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             if (LeaderLoopRunning)
@@ -85,13 +102,13 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
             var task = RunLeaderLoopAsync(cts.Token);
 
             // success
-            _leaderLoopTask = task;
             _leaderLoopTaskCTS = cts;
+            Volatile.Write(ref _leaderLoopTask, task);
             cts = null; // ownership transferred
         }
         finally
         {
-            _leaderLoopSemaphore.Release();
+            ReleaseLeaderLoopSemaphore();
             cts?.Dispose();
         }
     }
@@ -121,9 +138,10 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
             return true; // Already the leader
         }
 
+        var isLeader = await AcquireLeaderLoopSemaphoreAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var acquiredLeadership = false;
         Exception? exceptionInfo = null;
-        var isLeader = false;
-        await _leaderLoopSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
             if (!LeaderLoopRunning)
@@ -133,7 +151,7 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
                 );
             }
 
-            if (IsLeader)
+            if (isLeader)
             {
                 return true; // Already the leader
             }
@@ -145,8 +163,8 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
             }
 
             // Successfully acquired leadership
-            _isLeader = true;
-            _lastLeadershipRenewal = _timeProvider.GetUtcNow();
+            isLeader = true;
+            acquiredLeadership = true;
             LogLeadershipAcquired(_settings.InstanceId);
         }
         catch (Exception ex)
@@ -157,8 +175,8 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
         }
         finally
         {
-            isLeader = _isLeader;
-            _leaderLoopSemaphore.Release();
+            SetLeaderStatus(isLeader, acquiredLeadership);
+            ReleaseLeaderLoopSemaphore();
         }
 
         // Fire events outside of the lock to avoid potential deadlocks
@@ -252,28 +270,64 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
     /// </summary>
     protected abstract ValueTask ResetLeadershipAsync();
 
-    private void ThrowIfDisposed() => ObjectDisposedException.ThrowIf(_disposedValue != 0, this);
+    private void ThrowIfDisposed() =>
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposedValue) != 0, this);
+
+    // Helper method to acquire the leader loop semaphore and check if we are the leader.
+    // Primarily used to throw ObjectDisposedException when another thread disposes this
+    // instance while waiting on the semaphore.
+    private async Task<bool> AcquireLeaderLoopSemaphoreAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _leaderLoopSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+            // in critical section now, so we can read the leader status
+            // safely without worrying about race conditions
+            return _isLeader;
+        }
+        catch (ObjectDisposedException)
+        {
+            // semaphore was disposed by another thread.
+            ThrowIfDisposed();
+            throw; // should be unreachable
+        }
+    }
+
+    // Helper method to release the leader loop semaphore.
+    // Primarily used to throw ObjectDisposedException when another thread disposes this
+    // instance while waiting on the semaphore.
+    private void ReleaseLeaderLoopSemaphore()
+    {
+        try
+        {
+            _leaderLoopSemaphore.Release();
+        }
+        catch (ObjectDisposedException)
+        {
+            // semaphore was disposed by another thread.
+            ThrowIfDisposed();
+            throw; // should be unreachable
+        }
+    }
 
     private async Task RunLeaderLoopAsync(CancellationToken cancellationToken)
     {
         while (true)
         {
-            var wasLeader = false;
-            var isLeader = false;
+            var isLeader = await AcquireLeaderLoopSemaphoreAsync(cancellationToken)
+                .ConfigureAwait(false);
+            var wasLeader = isLeader;
+            var acquiredLeadership = false;
             Exception? exceptionInfo = null;
-
-            // Grab the semaphore to ensure that we don't get interrupted by
-            // TryAcquireLeadershipAsync() or StopAsync().
-            await _leaderLoopSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
-                wasLeader = _isLeader;
-                if (!wasLeader)
+                if (!isLeader)
                 {
-                    _isLeader = await TryAcquireLeadershipInternalAsync(cancellationToken)
+                    isLeader = await TryAcquireLeadershipInternalAsync(cancellationToken)
                         .ConfigureAwait(false);
-                    if (_isLeader)
+                    if (isLeader)
                     {
+                        acquiredLeadership = true;
                         LogLeadershipAcquired(_settings.InstanceId);
                     }
                     else
@@ -285,10 +339,11 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
                 }
                 else
                 {
-                    _isLeader = await RenewLeadershipInternalAsync(cancellationToken)
+                    isLeader = await RenewLeadershipInternalAsync(cancellationToken)
                         .ConfigureAwait(false);
-                    if (_isLeader)
+                    if (isLeader)
                     {
+                        acquiredLeadership = true;
                         // very common that leadership renewal succeeds, but we log it anyway
                         // to provide visibility into the leader loop's operations
                         LogLeadershipRenewedSuccessfully(_settings.InstanceId);
@@ -308,17 +363,12 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
                 // On any unexpected error, we assume we are no longer the leader.
                 // This is a safety measure to avoid a situation where an instance thinks
                 // it is the leader when it is not.
-                _isLeader = false;
+                isLeader = false;
             }
             finally
             {
-                isLeader = _isLeader;
-                if (isLeader)
-                {
-                    _lastLeadershipRenewal = _timeProvider.GetUtcNow();
-                }
-
-                _leaderLoopSemaphore.Release();
+                SetLeaderStatus(isLeader, acquiredLeadership);
+                ReleaseLeaderLoopSemaphore();
             }
 
             // Fire events outside of the lock to avoid potential deadlocks
@@ -339,32 +389,28 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
         CancellationToken cancellationToken = default
     )
     {
-        var wasLeader = false;
-        var isLeader = false;
-        Exception? exceptionInfo = null;
+        // Fast checks before acquiring the semaphore to avoid unnecessary waits
+        if (!LeaderLoopRunning && !IsLeader)
+        {
+            return; // already stopped
+        }
 
-        await _leaderLoopSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        var isLeader = await AcquireLeaderLoopSemaphoreAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var wasLeader = isLeader;
+        Exception? exceptionInfo = null;
         try
         {
+            // First stop the leader loop to prevent any further leadership
+            // changes while we are trying to stop
             if (LeaderLoopRunning)
             {
-                Debug.Assert(_leaderLoopTask != null);
-                Debug.Assert(_leaderLoopTaskCTS != null);
-
-                // First stop the leader loop to prevent any further leadership
-                // changes while we are trying to stop
-
-                // Important: We are purposefully ignoring the provided cancellation token
-                // since we want to ensure that the leader loop is stopped and that we
-                // don't end up in a situation where the leader loop is still running but
-                // we consider ourselves not the leader because of a cancellation request.
                 await StopLeaderLoopAsync().ConfigureAwait(false);
             }
 
             // we must not consider ourselves leader since we've abandoned the
             // leader election process
-            wasLeader = _isLeader;
-            _isLeader = false;
+            isLeader = false;
 
             if (wasLeader)
             {
@@ -390,14 +436,17 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
         }
         finally
         {
-            isLeader = _isLeader;
-            _leaderLoopSemaphore.Release();
+            SetLeaderStatus(isLeader);
+            ReleaseLeaderLoopSemaphore();
         }
 
         NotifyLeadershipStatus(wasLeader, isLeader, exceptionInfo);
 
         async Task StopLeaderLoopAsync()
         {
+            Debug.Assert(_leaderLoopTask != null);
+            Debug.Assert(_leaderLoopTaskCTS != null);
+
             LogStoppingLeaderElection(_settings.InstanceId);
 
             // Cancel the leader loop task, wait for it to complete, and cleanup resources...
@@ -418,20 +467,37 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
             }
             finally
             {
-                _leaderLoopTask = null;
+                // Clear the task and dispose the CTS.
+                Volatile.Write(ref _leaderLoopTask, null);
                 _leaderLoopTaskCTS.Dispose();
                 _leaderLoopTaskCTS = null;
             }
         }
     }
 
+    // Set the leader status and update the last renewal time if we acquired leadership.
+    private void SetLeaderStatus(bool isLeader, bool acquiredLeadership = false)
+    {
+        if (isLeader && acquiredLeadership)
+        {
+            // Use Interlocked to ensure that LastLeadershipRenewal
+            // does not read a torn value
+            Interlocked.Exchange(ref _lastLeadershipRenewalTicks, _timeProvider.GetUtcNow().Ticks);
+        }
+
+        // Use Volatile.Write to ensure this happens last since LastLeadershipRenewal
+        // depends on IsLeader being true to return a valid value.
+        Volatile.Write(ref _isLeader, isLeader);
+    }
+
+    // Helper method to fire the LeadershipChanged and ErrorOccurred events based on the
+    // provided parameters. This consolidates the logic for firing these events in one place
+    // and ensures that they are always fired in the correct order (ErrorOccurred first, then
+    // LeadershipChanged).
+    // This *must* be called outside of the lock to avoid potential deadlocks if event handlers
+    // interact with the leader election instance.
     private void NotifyLeadershipStatus(bool wasLeader, bool isLeader, Exception? exceptionInfo)
     {
-        Debug.Assert(
-            _leaderLoopSemaphore.CurrentCount == 1,
-            "Must be called outside of the leader loop lock"
-        );
-
         if (exceptionInfo != null)
         {
             ErrorOccurred?.Invoke(this, new(exceptionInfo));
@@ -466,7 +532,7 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
 
         _leaderLoopTaskCTS?.Dispose();
         _leaderLoopSemaphore.Dispose();
-        _isLeader = false;
+        SetLeaderStatus(false);
     }
 
     [LoggerMessage(

--- a/src/LeaderElection/LeaderElectionBase.cs
+++ b/src/LeaderElection/LeaderElectionBase.cs
@@ -22,6 +22,10 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
     // 0 = not disposed, 1 = disposed.
     private int _disposedValue;
 
+    // A random number generator used for applying jitter to retry intervals.
+    // Must return a value in the range [0.0, 1.0).
+    private readonly Func<double> _getRandomDouble;
+
     // Semaphore to protect access to the leader loop and related state.
     private readonly SemaphoreSlim _leaderLoopSemaphore = new(1, 1);
     private Task? _leaderLoopTask;
@@ -42,13 +46,33 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
     protected LeaderElectionBase(
         TSettings settings,
         ILogger? logger = null,
-        TimeProvider? timeProvider = null
+        TimeProvider? timeProvider = null,
+        Func<double>? getRandomDouble = null
     )
     {
         ArgumentNullException.ThrowIfNull(settings);
         _settings = settings;
         _logger = logger ?? NullLogger.Instance;
         _timeProvider = timeProvider ?? TimeProvider.System;
+
+#pragma warning disable CA5394 // We do not need a cryptographically secure RNG
+#if NET6_0_OR_GREATER
+        _getRandomDouble = getRandomDouble ?? Random.Shared.NextDouble;
+#else
+        if (getRandomDouble == null)
+        {
+            var random = new Random(Guid.NewGuid().GetHashCode());
+            getRandomDouble = () =>
+            {
+                lock (random)
+                {
+                    return random.NextDouble();
+                }
+            };
+        }
+        _getRandomDouble = getRandomDouble;
+#endif
+#pragma warning restore CA5394 // Do not use insecure randomness
     }
 
     /// <inheritdoc />
@@ -312,6 +336,7 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
 
     private async Task RunLeaderLoopAsync(CancellationToken cancellationToken)
     {
+        var errorCount = 0;
         while (true)
         {
             var isLeader = await AcquireLeaderLoopSemaphoreAsync(cancellationToken)
@@ -354,11 +379,14 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
                         LogLostLeadershipDuringRenewal(_settings.InstanceId);
                     }
                 }
+
+                errorCount = 0;
             }
             catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
             {
                 LogUnexpectedErrorInLeaderElection(ex, _settings.InstanceId);
                 exceptionInfo = ex;
+                errorCount++;
 
                 // On any unexpected error, we assume we are no longer the leader.
                 // This is a safety measure to avoid a situation where an instance thinks
@@ -376,13 +404,29 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
             NotifyLeadershipStatus(wasLeader, isLeader, exceptionInfo);
 
             // Wait before checking again...
-            var delay = GetNextDelay(isLeader ? 0 : 1);
+            var delay = GetNextDelay(isLeader, errorCount);
             await _timeProvider.Delay(delay, cancellationToken).ConfigureAwait(false);
         }
     }
 
-    protected virtual TimeSpan GetNextDelay(int retryCount) =>
-        retryCount == 0 ? _settings.RenewInterval : _settings.RetryInterval;
+    private TimeSpan GetNextDelay(bool isLeader, int errorCount)
+    {
+        if (isLeader)
+        {
+            return _settings.RenewInterval;
+        }
+        else
+        {
+            var backoffFactor = Math.Pow(_settings.RetryBackoffFactor, Math.Min(errorCount, 30));
+            var jitter = _settings.RetryJitter - (_getRandomDouble() * _settings.RetryJitter * 2);
+            return TimeSpan.FromTicks(
+                Math.Min(
+                    (long)(_settings.RetryInterval.Ticks * backoffFactor * (1.0 - jitter)),
+                    _settings.MaxRetryInterval.Ticks
+                )
+            );
+        }
+    }
 
     private async Task InternalStopAsync(
         bool releaseLeadership,

--- a/src/LeaderElection/LeaderElectionBase.cs
+++ b/src/LeaderElection/LeaderElectionBase.cs
@@ -294,6 +294,49 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
     /// </summary>
     protected abstract ValueTask ResetLeadershipAsync();
 
+    /// <summary>
+    /// Thread-safe function to allow implementations to trigger a leadership loss from within
+    /// their internal logic. This will abandon leadership internally by calling <see cref="ResetLeadershipAsync"/>.
+    /// It will also fire the <see cref="LeadershipChanged"/> event if appropriate.
+    /// <para/>
+    /// Implementations should call this function when they detect that leadership has been
+    /// lost unexpectedly (e.g. connectivity issue with the underlying store).
+    /// </summary>
+    protected async Task OnLeadershipLostAsync()
+    {
+        // just return if we're already disposed
+        if (Volatile.Read(ref _disposedValue) != 0)
+        {
+            return;
+        }
+
+        var isLeader = await AcquireLeaderLoopSemaphoreAsync(CancellationToken.None)
+            .ConfigureAwait(false);
+        var wasLeader = isLeader;
+        try
+        {
+            if (isLeader)
+            {
+                isLeader = false;
+                LogLeadershipLost(_settings.InstanceId);
+            }
+
+            await ResetLeadershipAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Log any exceptions but swallow them to avoid throwing from an unexpected leadership loss
+            LogUnexpectedErrorInLeaderElection(ex, _settings.InstanceId);
+        }
+        finally
+        {
+            SetLeaderStatus(isLeader);
+            ReleaseLeaderLoopSemaphore();
+        }
+
+        NotifyLeadershipStatus(wasLeader, isLeader, null);
+    }
+
     private void ThrowIfDisposed() =>
         ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposedValue) != 0, this);
 
@@ -544,15 +587,34 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
     // LeadershipChanged).
     // This *must* be called outside of the lock to avoid potential deadlocks if event handlers
     // interact with the leader election instance.
+    // Does not throw.
     private void NotifyLeadershipStatus(bool wasLeader, bool isLeader, Exception? exceptionInfo)
     {
         if (exceptionInfo != null)
         {
-            ErrorOccurred?.Invoke(this, new(exceptionInfo));
+            SafeInvokeEventHandlers(ErrorOccurred, new LeadershipExceptionEventArgs(exceptionInfo));
         }
         if (wasLeader != isLeader)
         {
-            LeadershipChanged?.Invoke(this, new(isLeader));
+            SafeInvokeEventHandlers(LeadershipChanged, new LeadershipChangedEventArgs(isLeader));
+        }
+    }
+
+    // Helper method to safely invoke event handlers. This ensures that all handlers are invoked
+    // even if one throws an exception, and that exceptions from handlers are logged but do not
+    // affect the leader election process.
+    private void SafeInvokeEventHandlers<T>(MulticastDelegate? handler, T args)
+    {
+        foreach (var subscriber in handler?.GetInvocationList().Cast<EventHandler<T>>() ?? [])
+        {
+            try
+            {
+                subscriber(this, args);
+            }
+            catch (Exception ex)
+            {
+                LogEventHandlerException(ex);
+            }
         }
     }
 
@@ -644,6 +706,9 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
     [LoggerMessage(LogLevel.Information, "Abandoned leadership for instance {InstanceId}.")]
     partial void LogLeadershipAbandoned(string instanceId);
 
+    [LoggerMessage(LogLevel.Warning, "Lost leadership for instance {InstanceId}.")]
+    partial void LogLeadershipLost(string instanceId);
+
     // ReleaseLeadershipAsync threw an exception. This is unexpected since implementations
     // should handle expected exceptions. Log at Error level since this likely indicates an
     // issue with the underlying store or infrastructure.
@@ -655,4 +720,9 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
     // it could indicate a potential issue that needs attention.
     [LoggerMessage(LogLevel.Error, "Error during async disposal.")]
     partial void LogErrorDuringAsyncDisposal(Exception errorMessage);
+
+    // An exception occurred in the leader election process. Log at Error level since this
+    // likely indicates an issue with the underlying store or infrastructure.
+    [LoggerMessage(LogLevel.Warning, "Event handler threw an exception.")]
+    partial void LogEventHandlerException(Exception errorMessage);
 }

--- a/src/LeaderElection/LeaderElectionBase.cs
+++ b/src/LeaderElection/LeaderElectionBase.cs
@@ -466,12 +466,8 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
                 Math.Min(errorCount, maxExponent)
             );
             var jitter = _settings.RetryJitter - (_getRandomDouble() * _settings.RetryJitter * 2);
-            return TimeSpan.FromTicks(
-                Math.Min(
-                    (long)(_settings.RetryInterval.Ticks * backoffFactor * (1.0 - jitter)),
-                    _settings.MaxRetryInterval.Ticks
-                )
-            );
+            var rawTicks = _settings.RetryInterval.Ticks * backoffFactor * (1.0 - jitter);
+            return TimeSpan.FromTicks((long)Math.Min(rawTicks, _settings.MaxRetryInterval.Ticks));
         }
     }
 

--- a/src/LeaderElection/LeaderElectionSettingsBase.cs
+++ b/src/LeaderElection/LeaderElectionSettingsBase.cs
@@ -15,7 +15,7 @@ public class LeaderElectionSettingsBase
     public string InstanceId { get; set; } = Guid.NewGuid().ToString();
 
     /// <summary>
-    /// The interval at which the leader will attempt to renew its leadership.
+    /// The interval at which non-leader instances will attempt to acquire leadership.
     /// <para/>
     /// Must be greater than or equal to zero.
     /// Default is 5 seconds.

--- a/src/LeaderElection/LeaderElectionSettingsBase.cs
+++ b/src/LeaderElection/LeaderElectionSettingsBase.cs
@@ -20,11 +20,51 @@ public class LeaderElectionSettingsBase
     /// Must be greater than or equal to zero.
     /// Default is 5 seconds.
     /// </summary>
+    /// <remarks>
+    /// Unexpected errors during leader acquisition will exponentially increase this interval by
+    /// the retry backoff factor. The computed retry interval will be randomly adjusted by ± the
+    /// jitter percentage, up to the maximum retry interval. The exact formula is:
+    /// <code>
+    /// retry := min(RetryInterval * (RetryBackoffFactor ^ errorCount) * (1 ± rand(RetryJitter)), MaxRetryInterval)
+    /// </code>
+    /// </remarks>
     [CustomValidation(
         typeof(BaseSettingsValidator),
         nameof(BaseSettingsValidator.ValidateRetryInterval)
     )]
     public TimeSpan RetryInterval { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// The backoff factor to apply to the retry interval computation.
+    /// <para/>
+    /// Must be between 1.0 and 3.0.
+    /// Default is 2.0.
+    /// </summary>
+    [Range(1.0, 3.0)]
+    public double RetryBackoffFactor { get; set; } = 2.0;
+
+    /// <summary>
+    /// The jitter percentage to apply to the retry interval to avoid thundering herd when multiple
+    /// contenders are trying to acquire leadership. The actual retry interval will be randomly
+    /// adjusted by ± this percentage.
+    /// <para/>
+    /// Must be between 0.0 and 1.0.
+    /// Default is 0.10 (±10%).
+    /// </summary>
+    [Range(0.0, 1.0)]
+    public double RetryJitter { get; set; } = 0.10;
+
+    /// <summary>
+    /// The maximum retry interval (after applying the backoff factor and jitter) when acquiring leadership.
+    /// <para/>
+    /// Must be greater than or equal to <see cref="RetryInterval"/>.
+    /// Default is 40 seconds.
+    /// </summary>
+    [CustomValidation(
+        typeof(BaseSettingsValidator),
+        nameof(BaseSettingsValidator.ValidateMaxRetryInterval)
+    )]
+    public TimeSpan MaxRetryInterval { get; set; } = TimeSpan.FromSeconds(40);
 
     /// <summary>
     /// The interval at which the leader will attempt to renew its leadership.
@@ -41,14 +81,16 @@ public class LeaderElectionSettingsBase
     /// <summary>
     /// The maximum number of retry attempts before giving up on acquiring leadership.
     /// <para/>
-    /// Must be greater than or equal to zero.
     /// Default is 3.
     /// </summary>
-    [Range(0, int.MaxValue)]
+    [Obsolete(
+        "This setting is no longer used and will be removed in a future version. Use MaxRetryInterval instead."
+    )]
     public int MaxRetryAttempts { get; set; } = 3;
 
     /// <summary>
-    /// Whether to enable graceful shutdown when losing leadership.
+    /// Indicates whether leadership should be relinquished when the instance
+    /// is disposed, which typically occurs during application shutdown.
     /// <para/>
     /// Default is true.
     /// </summary>
@@ -63,8 +105,13 @@ public class LeaderElectionSettingsBase
         ArgumentNullException.ThrowIfNull(dst);
         dst.InstanceId = src.InstanceId;
         dst.RetryInterval = src.RetryInterval;
+        dst.RetryBackoffFactor = src.RetryBackoffFactor;
+        dst.RetryJitter = src.RetryJitter;
+        dst.MaxRetryInterval = src.MaxRetryInterval;
         dst.RenewInterval = src.RenewInterval;
         dst.EnableGracefulShutdown = src.EnableGracefulShutdown;
+#pragma warning disable CS0618 // Type or member is obsolete
         dst.MaxRetryAttempts = src.MaxRetryAttempts;
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/src/LeaderElection/README.md
+++ b/src/LeaderElection/README.md
@@ -43,7 +43,6 @@ builder.Services.AddRedisLeaderElection(settings =>
     settings.LockExpiry = TimeSpan.FromSeconds(30);
     settings.RenewInterval = TimeSpan.FromSeconds(10);
     settings.RetryInterval = TimeSpan.FromSeconds(5);
-    settings.MaxRetryAttempts = 3;
     settings.EnableGracefulShutdown = true;
 });
 ```

--- a/tests/LeaderElection.Tests/BlobStorageLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/BlobStorageLeaderElectionTests.cs
@@ -29,7 +29,7 @@ public sealed class BlobStorageLeaderElectionTests(AzuriteContainerFixture azuri
         TimeSpan? leaseDuration = null,
         TimeSpan? renewInterval = null,
         TimeSpan? retryInterval = null,
-        int maxRetryAttempts = 3,
+        TimeSpan? maxRetryInterval = null,
         bool enableGracefulShutdown = true,
         bool createContainerIfNotExists = true,
         string? connectionString = null
@@ -43,7 +43,7 @@ public sealed class BlobStorageLeaderElectionTests(AzuriteContainerFixture azuri
             LeaseDuration = leaseDuration ?? TimeSpan.FromSeconds(15),
             RenewInterval = renewInterval ?? TimeSpan.FromSeconds(5),
             RetryInterval = retryInterval ?? TimeSpan.FromSeconds(2),
-            MaxRetryAttempts = maxRetryAttempts,
+            MaxRetryInterval = maxRetryInterval ?? TimeSpan.FromSeconds(60),
             EnableGracefulShutdown = enableGracefulShutdown,
             CreateContainerIfNotExists = createContainerIfNotExists,
         };

--- a/tests/LeaderElection.Tests/BlobStorageLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/BlobStorageLeaderElectionTests.cs
@@ -202,6 +202,8 @@ public sealed class BlobStorageLeaderElectionTests(AzuriteContainerFixture azuri
         var options = CreateSettings("test-leader-election-manual");
 
         await using var leaderElection = CreateSut(options);
+        await leaderElection.StartAsync(CancellationToken);
+        await WaitForLeadershipChange(leaderElection, true);
 
         // Act
         var result = await leaderElection.TryAcquireLeadershipAsync(CancellationToken);

--- a/tests/LeaderElection.Tests/BlobStorageServiceBuilderExtensionsTests.cs
+++ b/tests/LeaderElection.Tests/BlobStorageServiceBuilderExtensionsTests.cs
@@ -22,7 +22,9 @@ public sealed class BlobStorageServiceBuilderExtensionsTests
         InstanceId = "foo",
         RenewInterval = TimeSpan.FromSeconds(2),
         RetryInterval = TimeSpan.FromSeconds(1),
-        MaxRetryAttempts = 300,
+        RetryBackoffFactor = 1.5,
+        RetryJitter = 0.15,
+        MaxRetryInterval = TimeSpan.FromSeconds(100),
         EnableGracefulShutdown = false,
     };
 
@@ -64,7 +66,10 @@ public sealed class BlobStorageServiceBuilderExtensionsTests
                     // ["LeaderElection:Base:InstanceId"] = settings.InstanceId,
                     ["LeaderElection:Base:RenewInterval"] = settings.RenewInterval.ToString(),
                     ["LeaderElection:Base:RetryInterval"] = settings.RetryInterval.ToString(),
-                    ["LeaderElection:Base:MaxRetryAttempts"] = settings.MaxRetryAttempts.ToString(),
+                    ["LeaderElection:Base:RetryBackoffFactor"] =
+                        settings.RetryBackoffFactor.ToString(),
+                    ["LeaderElection:Base:RetryJitter"] = settings.RetryJitter.ToString(),
+                    ["LeaderElection:Base:MaxRetryInterval"] = settings.MaxRetryInterval.ToString(),
                     // ["LeaderElection:Base:EnableGracefulShutdown"] = settings.EnableGracefulShutdown.ToString(),
                 }
             )

--- a/tests/LeaderElection.Tests/FakeLeaderElection.cs
+++ b/tests/LeaderElection.Tests/FakeLeaderElection.cs
@@ -19,8 +19,12 @@ internal sealed class FakeLeaderElection : LeaderElectionBase<FakeLeaderElection
 {
     public FakeLeaderElectionSettings Settings => _settings;
 
-    public FakeLeaderElection(FakeLeaderElectionSettings settings, FakeTimeProvider timeProvider)
-        : base(settings, timeProvider: timeProvider)
+    public FakeLeaderElection(
+        FakeLeaderElectionSettings settings,
+        FakeTimeProvider timeProvider,
+        Func<double>? getRandomDouble = null
+    )
+        : base(settings, timeProvider: timeProvider, getRandomDouble: getRandomDouble)
     {
         LeadershipChanged += (s, e) =>
         {

--- a/tests/LeaderElection.Tests/FakeLeaderElection.cs
+++ b/tests/LeaderElection.Tests/FakeLeaderElection.cs
@@ -38,9 +38,6 @@ internal sealed class FakeLeaderElection : LeaderElectionBase<FakeLeaderElection
         };
     }
 
-    // Use a fixed retry for easier testing
-    protected override TimeSpan GetNextDelay(int retryCount) => _settings.RetryInterval;
-
     protected override Task<bool> TryAcquireLeadershipInternalAsync(
         CancellationToken cancellationToken
     )

--- a/tests/LeaderElection.Tests/LeaderElectionBaseTests.cs
+++ b/tests/LeaderElection.Tests/LeaderElectionBaseTests.cs
@@ -6,8 +6,12 @@ public class LeaderElectionBaseTests
 {
     readonly FakeTimeProvider _fakeTimeProvider = new();
 
-    FakeLeaderElection CreateSut(FakeLeaderElectionSettings? settings = null) =>
-        new(settings ?? new(), _fakeTimeProvider);
+    // Helper to create a new instance of the SUT with optional settings and random double generator
+    // The random double generator defaults to 0.5 which results in no jitter.
+    FakeLeaderElection CreateSut(
+        FakeLeaderElectionSettings? settings = null,
+        Func<double>? getRandomDouble = null
+    ) => new(settings ?? new(), _fakeTimeProvider, getRandomDouble ?? (() => 0.5));
 
     // Helper method to fast forward time and allow any released tasks to run
     async Task FastForward(TimeSpan timeSpan)
@@ -24,6 +28,64 @@ public class LeaderElectionBaseTests
     {
         await sut.StartAsync(TestContext.Current.CancellationToken);
         await FastForward(TimeSpan.Zero);
+    }
+
+    // Helper to calculate the expected leader-loop retry interval based on
+    // settings, error count, and the "random" double.
+    static TimeSpan ExpectedRetryInterval(
+        FakeLeaderElectionSettings settings,
+        int errorCount,
+        double randomDouble
+    ) =>
+        TimeSpan.FromTicks(
+            Math.Min(
+                (long)(
+                    settings.RetryInterval.Ticks
+                    * Math.Pow(settings.RetryBackoffFactor, Math.Min(errorCount, 30))
+                    * (1 - settings.RetryJitter + (randomDouble * settings.RetryJitter * 2))
+                ),
+                settings.MaxRetryInterval.Ticks
+            )
+        );
+
+    [Fact]
+    public void ExpectedRetryIntervalShouldCalculateCorrectly()
+    {
+        // Arrange
+        var settings = new FakeLeaderElectionSettings
+        {
+            RetryInterval = TimeSpan.FromSeconds(1),
+            RetryJitter = 0.50, // ±50%, depending on random double
+            RetryBackoffFactor = 2.0,
+            // we want to max out on 4th failure, so max should be < (1s * 2^4 * (1 ± jitter)) or 8-24s
+            MaxRetryInterval = TimeSpan.FromSeconds(7.9),
+        };
+
+        // Assert
+        // verify base retry interval
+        ExpectedRetryInterval(settings, 0, 0.0).Should().Be(TimeSpan.FromSeconds(0.5)); // 1s base retry, -50% jitter
+        ExpectedRetryInterval(settings, 0, 0.5).Should().Be(TimeSpan.FromSeconds(1.0)); // 1s base retry, -0% jitter
+        ExpectedRetryInterval(settings, 0, 1.0).Should().Be(TimeSpan.FromSeconds(1.5)); // 1s base retry, +50% jitter
+
+        // verify first retry interval
+        ExpectedRetryInterval(settings, 1, 0.0).Should().Be(TimeSpan.FromSeconds(1)); // 2s backoff, -50% jitter
+        ExpectedRetryInterval(settings, 1, 0.5).Should().Be(TimeSpan.FromSeconds(2)); // 2s backoff, -0% jitter
+        ExpectedRetryInterval(settings, 1, 1.0).Should().Be(TimeSpan.FromSeconds(3)); // 2s backoff, +50% jitter
+
+        // verify second retry interval
+        ExpectedRetryInterval(settings, 2, 0.0).Should().Be(TimeSpan.FromSeconds(2)); // 4s backoff, -50% jitter
+        ExpectedRetryInterval(settings, 2, 0.5).Should().Be(TimeSpan.FromSeconds(4)); // 4s backoff, -0% jitter
+        ExpectedRetryInterval(settings, 2, 1.0).Should().Be(TimeSpan.FromSeconds(6)); // 4s backoff, +50% jitter
+
+        // verify third retry interval
+        ExpectedRetryInterval(settings, 3, 0.0).Should().Be(TimeSpan.FromSeconds(4)); // 8s backoff, -50% jitter
+        ExpectedRetryInterval(settings, 3, 0.5).Should().Be(TimeSpan.FromSeconds(7.9)); // 8s backoff, -0% jitter = 8s but max is 7.9s
+        ExpectedRetryInterval(settings, 3, 1.0).Should().Be(TimeSpan.FromSeconds(7.9)); // 8s backoff, +50% jitter = 12s but max is 7.9s
+
+        // verify the expected retry intervals maxes out correctly
+        ExpectedRetryInterval(settings, 4, 0.0).Should().Be(TimeSpan.FromSeconds(7.9)); // 16s backoff, -50% jitter = 8s but max is 7.9s
+        ExpectedRetryInterval(settings, 5, 0.0).Should().Be(TimeSpan.FromSeconds(7.9)); // 32s backoff, -50% jitter = 16s but max is 7.9s
+        ExpectedRetryInterval(settings, 30, 0.0).Should().Be(TimeSpan.FromSeconds(7.9)); // max is 7.9s
     }
 
     [Fact]
@@ -92,7 +154,7 @@ public class LeaderElectionBaseTests
 
         // Act - Clear error and retry
         sut.Settings.AcquireResult = () => true;
-        await FastForward(sut.Settings.RetryInterval);
+        await FastForward(sut.Settings.RetryInterval * sut.Settings.RetryBackoffFactor); // backoff should be applied
 
         // Assert
         sut.IsLeader.Should().BeTrue();
@@ -100,6 +162,61 @@ public class LeaderElectionBaseTests
         sut.Settings.TryAcquireCount.Should().Be(2);
         sut.Settings.LeadershipChangedCount.Should().Be(1);
         sut.Settings.ErrorCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task LeaderLoopShouldApplyBackoffAndJitterCorrectly()
+    {
+        // Arrange
+        await using var sut = CreateSut(getRandomDouble: () => 0.0);
+
+        // calculates the expected retry interval based on error count
+        TimeSpan expectedRetryInterval(int errorCount) =>
+            ExpectedRetryInterval(sut.Settings, errorCount, 0.0);
+
+        // simulate acquisition failure to trigger retries
+        sut.Settings.AcquireResult = () => throw new InvalidOperationException("Test exception");
+
+        // Act
+        await sut.StartAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        // simulate multiple retries
+        for (var attempt = 0; attempt < 32; attempt++)
+        {
+            await FastForward(expectedRetryInterval(attempt));
+            sut.Settings.TryAcquireCount.Should().Be(attempt + 1);
+            sut.Settings.ErrorCount.Should().Be(attempt + 1);
+        }
+    }
+
+    [Fact]
+    public async Task LeaderLoopRetryIntervalResetsAfterNonFatalAcquisition()
+    {
+        // Arrange
+        await using var sut = CreateSut(getRandomDouble: () => 0.0);
+
+        TimeSpan expectedRetryInterval(int errorCount) =>
+            ExpectedRetryInterval(sut.Settings, errorCount, 0.0);
+
+        // simulate multiple failed retries to increase backoff...
+        sut.Settings.AcquireResult = () => throw new InvalidOperationException("Test exception");
+        await sut.StartAsync(TestContext.Current.CancellationToken);
+        await FastForward(expectedRetryInterval(0));
+        await FastForward(expectedRetryInterval(1));
+
+        // Act - simulate successful retry (but no leadership)
+        sut.Settings.AcquireResult = () => false;
+        await FastForward(expectedRetryInterval(2));
+        sut.Settings.TryAcquireCount.Should().Be(3);
+        sut.Settings.ErrorCount.Should().Be(2); // last attempt did not error
+
+        // Assert - retry interval should be back to base value
+        await FastForward(expectedRetryInterval(0));
+        sut.Settings.TryAcquireCount.Should().Be(4);
+        // same for subsequent attempts...
+        await FastForward(expectedRetryInterval(0));
+        sut.Settings.TryAcquireCount.Should().Be(5);
     }
 
     [Fact]

--- a/tests/LeaderElection.Tests/LeaderElectionBaseTests.cs
+++ b/tests/LeaderElection.Tests/LeaderElectionBaseTests.cs
@@ -12,8 +12,18 @@ public class LeaderElectionBaseTests
     // Helper method to fast forward time and allow any released tasks to run
     async Task FastForward(TimeSpan timeSpan)
     {
+        // small delay to ensure OS has time to unblock any tasks waiting for
+        // the Leader Loop semaphore before advancing time
+        await Task.Delay(5);
         _fakeTimeProvider.Advance(timeSpan);
-        await Task.Yield(); // allow any released tasks to run
+        // allow any released tasks to update state before assertions.
+        await Task.Delay(1);
+    }
+
+    async Task StartAsync(FakeLeaderElection sut)
+    {
+        await sut.StartAsync(TestContext.Current.CancellationToken);
+        await FastForward(TimeSpan.Zero);
     }
 
     [Fact]
@@ -23,8 +33,7 @@ public class LeaderElectionBaseTests
         await using var sut = CreateSut();
 
         // Act
-        await sut.StartAsync(TestContext.Current.CancellationToken);
-        await FastForward(TimeSpan.Zero);
+        await StartAsync(sut);
 
         // Assert
         sut.IsLeader.Should().BeTrue();
@@ -34,7 +43,7 @@ public class LeaderElectionBaseTests
         sut.Settings.ErrorCount.Should().Be(0);
 
         // Call StartAsync again should be no-op
-        await sut.StartAsync(TestContext.Current.CancellationToken);
+        await StartAsync(sut);
         sut.IsLeader.Should().BeTrue();
         sut.Settings.TryAcquireCount.Should().Be(1);
         sut.Settings.LeadershipChangedCount.Should().Be(1);
@@ -48,8 +57,7 @@ public class LeaderElectionBaseTests
         await using var sut = CreateSut();
 
         sut.Settings.AcquireResult = () => false;
-        await sut.StartAsync(TestContext.Current.CancellationToken);
-        await FastForward(TimeSpan.Zero);
+        await StartAsync(sut);
         sut.IsLeader.Should().BeFalse();
         sut.Settings.TryAcquireCount.Should().Be(1);
         sut.Settings.LeadershipChangedCount.Should().Be(0);
@@ -75,8 +83,7 @@ public class LeaderElectionBaseTests
 
         // Act
         sut.Settings.AcquireResult = () => throw new InvalidOperationException("Test exception");
-        await sut.StartAsync(TestContext.Current.CancellationToken);
-        await FastForward(TimeSpan.Zero);
+        await StartAsync(sut);
 
         // Assert - Should have reported the error
         sut.IsLeader.Should().BeFalse();
@@ -96,7 +103,7 @@ public class LeaderElectionBaseTests
     }
 
     [Fact]
-    public async Task LeaderLoopShouldCancelOnRequest()
+    public async Task StartAsyncCancellationTokenShouldHaveNoEffectOnLeaderLoop()
     {
         // Arrange
         await using var sut = CreateSut();
@@ -107,16 +114,22 @@ public class LeaderElectionBaseTests
         sut.Settings.AcquireResult = () =>
         {
             cts.Cancel();
-            cts.Token.ThrowIfCancellationRequested();
             return true;
         };
 
         // Act
         await sut.StartAsync(cts.Token);
         await FastForward(TimeSpan.Zero);
-        sut.IsLeader.Should().BeFalse();
+
+        // Assert - Should have acquired leadership and not been cancelled
+        cts.IsCancellationRequested.Should().BeTrue();
+        sut.IsLeader.Should().BeTrue();
         sut.Settings.TryAcquireCount.Should().Be(1);
         sut.Settings.ErrorCount.Should().Be(0);
+
+        await FastForward(sut.Settings.RenewInterval);
+        sut.Settings.ErrorCount.Should().Be(0);
+        sut.Settings.TryRenewCount.Should().Be(1);
     }
 
     [Fact]
@@ -125,8 +138,7 @@ public class LeaderElectionBaseTests
         // Arrange
         await using var sut = CreateSut();
 
-        await sut.StartAsync(TestContext.Current.CancellationToken);
-        await FastForward(TimeSpan.Zero);
+        await StartAsync(sut);
         sut.IsLeader.Should().BeTrue();
         sut.Settings.LeadershipChangedCount.Should().Be(1);
 
@@ -151,8 +163,7 @@ public class LeaderElectionBaseTests
         await using var sut = CreateSut();
 
         // acquire leadership first
-        await sut.StartAsync(TestContext.Current.CancellationToken);
-        await FastForward(TimeSpan.Zero);
+        await StartAsync(sut);
         sut.IsLeader.Should().BeTrue();
         sut.Settings.TryRenewCount.Should().Be(0);
         sut.Settings.LeadershipChangedCount.Should().Be(1);
@@ -180,6 +191,109 @@ public class LeaderElectionBaseTests
     }
 
     [Fact]
+    public async Task TryAcquireLeadershipAsyncShouldThrowWhenLeaderLoopNotRunning()
+    {
+        // Arrange
+        await using var sut = CreateSut();
+        sut.LeaderLoopRunning.Should().BeFalse();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.TryAcquireLeadershipAsync(TestContext.Current.CancellationToken)
+        );
+    }
+
+    [Fact]
+    public async Task TryAcquireLeadershipAsyncShouldReturnFalseWhenNotLeader()
+    {
+        // Arrange
+        await using var sut = CreateSut();
+        sut.Settings.AcquireResult = () => false; // ensure we don't acquire leadership
+        await StartAsync(sut);
+
+        sut.LeaderLoopRunning.Should().BeTrue();
+        sut.IsLeader.Should().BeFalse();
+
+        // Act
+        var result = await sut.TryAcquireLeadershipAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().BeFalse();
+        sut.IsLeader.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task TryAcquireLeadershipAsyncShouldReturnTrueWhenAlreadyLeader()
+    {
+        // Arrange
+        await using var sut = CreateSut();
+        await StartAsync(sut);
+        sut.IsLeader.Should().BeTrue();
+
+        // Act
+        var result = await sut.TryAcquireLeadershipAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().BeTrue();
+        sut.IsLeader.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TryAcquireLeadershipAsyncShouldAcquireLeadershipWhenNotLeader()
+    {
+        // Arrange
+        await using var sut = CreateSut();
+        sut.Settings.AcquireResult = () => false; // ensure we don't acquire leadership
+        await StartAsync(sut);
+        sut.LeaderLoopRunning.Should().BeTrue();
+        sut.IsLeader.Should().BeFalse();
+
+        sut.Settings.AcquireResult = () => true; // ensure we can acquire leadership
+
+        // Act
+        var result = await sut.TryAcquireLeadershipAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().BeTrue();
+        sut.IsLeader.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task TryAcquireLeadershipAsyncDoesNotThrowWhenAcquireThrows(bool cancel)
+    {
+        // Arrange
+        await using var sut = CreateSut();
+        sut.Settings.AcquireResult = () => false; // ensure we don't acquire leadership
+        await StartAsync(sut);
+        sut.LeaderLoopRunning.Should().BeTrue();
+        sut.IsLeader.Should().BeFalse();
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken
+        );
+
+        sut.Settings.AcquireResult = () =>
+        {
+            if (cancel)
+            {
+                cts.Cancel();
+                cts.Token.ThrowIfCancellationRequested();
+            }
+            throw new InvalidOperationException("Test exception");
+        };
+
+        // Act
+        var result = await sut.TryAcquireLeadershipAsync(cts.Token);
+
+        // Assert
+        result.Should().BeFalse();
+        sut.IsLeader.Should().BeFalse();
+        sut.Settings.ErrorCount.Should().Be(1);
+    }
+
+    [Fact]
     public async Task RunTaskIfLeaderAsyncShouldNotRunWhenNotStarted()
     {
         // Arrange
@@ -204,8 +318,7 @@ public class LeaderElectionBaseTests
 
         // start without leadership
         sut.Settings.AcquireResult = () => false;
-        await sut.StartAsync(TestContext.Current.CancellationToken);
-        await FastForward(TimeSpan.Zero);
+        await StartAsync(sut);
         sut.IsLeader.Should().BeFalse();
 
         // Act
@@ -226,8 +339,7 @@ public class LeaderElectionBaseTests
         await using var sut = CreateSut();
 
         // start with leadership
-        await sut.StartAsync(TestContext.Current.CancellationToken);
-        await FastForward(TimeSpan.Zero);
+        await StartAsync(sut);
         sut.IsLeader.Should().BeTrue();
 
         // Act
@@ -242,15 +354,14 @@ public class LeaderElectionBaseTests
     }
 
     [Fact]
-    public async Task RunTaskIfLeaderAsyncShouldReportErrorOnException()
+    public async Task RunTaskIfLeaderAsyncShouldNotReportErrorOnException()
     {
         // Arrange
         await using var sut = CreateSut();
 
         // start with leadership
         sut.Settings.AcquireResult = () => true;
-        await sut.StartAsync(TestContext.Current.CancellationToken);
-        await FastForward(TimeSpan.Zero);
+        await StartAsync(sut);
         sut.IsLeader.Should().BeTrue();
         sut.Settings.ErrorCount.Should().Be(0);
 
@@ -263,20 +374,19 @@ public class LeaderElectionBaseTests
         );
 
         // Assert
-        sut.Settings.ErrorCount.Should().Be(1);
+        sut.Settings.ErrorCount.Should().Be(0);
     }
 
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task StopAsyncShouldReleaseLeadership(bool gracefulShutdown)
+    public async Task StopAsyncShouldAlwaysReleaseLeadership(bool gracefulShutdown)
     {
         // Arrange
         await using var sut = CreateSut();
         sut.Settings.EnableGracefulShutdown = gracefulShutdown;
 
-        await sut.StartAsync(TestContext.Current.CancellationToken);
-        await FastForward(TimeSpan.Zero);
+        await StartAsync(sut);
         sut.IsLeader.Should().BeTrue();
 
         // Act
@@ -284,7 +394,30 @@ public class LeaderElectionBaseTests
 
         // Assert
         sut.IsLeader.Should().BeFalse(); // because stopped
-        sut.Settings.TryReleaseCount.Should().Be(gracefulShutdown ? 1 : 0);
+        sut.LeaderLoopRunning.Should().BeFalse();
+        // should always release on stop, regardless of graceful shutdown setting
+        sut.Settings.TryReleaseCount.Should().Be(1);
+        sut.Settings.ErrorCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task StopAsyncShouldNotThrowReleaseException()
+    {
+        // Arrange
+        await using var sut = CreateSut();
+        await StartAsync(sut);
+        sut.IsLeader.Should().BeTrue();
+
+        sut.Settings.ReleaseAction = () => throw new InvalidOperationException("Test exception");
+
+        // Act
+        await sut.StopAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        sut.IsLeader.Should().BeFalse(); // stopped
+        sut.LeaderLoopRunning.Should().BeFalse();
+        sut.Settings.TryReleaseCount.Should().Be(1);
+        sut.Settings.ErrorCount.Should().Be(1);
     }
 
     [Fact]
@@ -308,14 +441,15 @@ public class LeaderElectionBaseTests
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task DisposeAsyncShouldReleaseLeadership(bool gracefulShutdown)
+    public async Task DisposeAsyncShouldReleaseLeadershipWhenGracefulShutdownEnabled(
+        bool gracefulShutdown
+    )
     {
         // Arrange
         await using var sut = CreateSut();
         sut.Settings.EnableGracefulShutdown = gracefulShutdown;
 
-        await sut.StartAsync(TestContext.Current.CancellationToken);
-        await FastForward(TimeSpan.Zero);
+        await StartAsync(sut);
         sut.IsLeader.Should().BeTrue();
 
         // Act
@@ -323,7 +457,9 @@ public class LeaderElectionBaseTests
 
         // Assert
         sut.IsLeader.Should().BeFalse(); // because disposed/stopped
+        sut.LeaderLoopRunning.Should().BeFalse();
         sut.Settings.TryReleaseCount.Should().Be(gracefulShutdown ? 1 : 0);
+        sut.Settings.ErrorCount.Should().Be(0);
     }
 
     [Fact]
@@ -365,16 +501,16 @@ public class LeaderElectionBaseTests
         // Arrange
         await using var sut = CreateSut();
         sut.Settings.EnableGracefulShutdown = true;
-        sut.Settings.ReleaseAction = () => throw new InvalidOperationException("Release failed");
+        sut.LeadershipChanged += (_, _) => throw new InvalidOperationException("Client exception");
 
-        await sut.StartAsync(TestContext.Current.CancellationToken);
-        await FastForward(TimeSpan.Zero);
+        await StartAsync(sut);
         sut.IsLeader.Should().BeTrue();
 
         // Act
         await sut.DisposeAsync();
 
         // Assert
+        sut.IsLeader.Should().BeFalse(); // because disposed/stopped
         sut.Settings.TryReleaseCount.Should().Be(1);
         sut.Settings.ErrorCount.Should().Be(0);
     }

--- a/tests/LeaderElection.Tests/PostgresLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/PostgresLeaderElectionTests.cs
@@ -152,6 +152,8 @@ public sealed class PostgresLeaderElectionTests(PostgresContainerFixture postgre
         var options = CreateSettings();
 
         await using var leaderElection = CreateSut(options);
+        await leaderElection.StartAsync(CancellationToken);
+        await WaitForLeadershipChange(leaderElection, true);
 
         var result = await leaderElection.TryAcquireLeadershipAsync(CancellationToken);
 

--- a/tests/LeaderElection.Tests/PostgresLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/PostgresLeaderElectionTests.cs
@@ -176,6 +176,32 @@ public sealed class PostgresLeaderElectionTests(PostgresContainerFixture postgre
     }
 
     [Fact]
+    public async Task ShouldTriggerLeadershipChangeEventWhenConnectionBroken()
+    {
+        // Arrange
+        var options = CreateSettings();
+        await using var leaderElection = CreateSut(options);
+        await leaderElection.StartAsync(CancellationToken);
+        await WaitForLeadershipChange(leaderElection, true);
+
+        leaderElection.ConnectionProcessId.Should().NotBeNull();
+
+        // Act - simulate unexpected connection loss by killing the backend connection holding the lock
+        await using (var killingConn = new NpgsqlConnection(postgresFixture.ConnectionString))
+        {
+            await killingConn.OpenAsync(CancellationToken);
+            using var cmd = new NpgsqlCommand($"SELECT pg_terminate_backend(@pid);", killingConn);
+            cmd.Parameters.AddWithValue("pid", leaderElection.ConnectionProcessId);
+            await cmd.ExecuteNonQueryAsync(CancellationToken);
+        }
+
+        // Assert - Should trigger leadership change event while actively trying to
+        // renew/acquire leadership again
+        await WaitForLeadershipChange(leaderElection, false);
+        leaderElection.LeaderLoopRunning.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task ShouldThrowWhenUsingMultiHostConnectionStringWithInvalidTargetSessionAttributes()
     {
         // Arrange

--- a/tests/LeaderElection.Tests/PostgresServiceBuilderExtensionsTests.cs
+++ b/tests/LeaderElection.Tests/PostgresServiceBuilderExtensionsTests.cs
@@ -15,8 +15,9 @@ public class PostgresServiceBuilderExtensionsTests
         LockId = 12345,
         InstanceId = "foo",
         RenewInterval = TimeSpan.FromSeconds(2),
-        RetryInterval = TimeSpan.FromSeconds(1),
-        MaxRetryAttempts = 300,
+        RetryBackoffFactor = 1.5,
+        RetryJitter = 0.15,
+        MaxRetryInterval = TimeSpan.FromSeconds(100),
         EnableGracefulShutdown = false,
     };
 
@@ -95,7 +96,10 @@ public class PostgresServiceBuilderExtensionsTests
                     // ["LeaderElection:Base:InstanceId"] = settings.InstanceId,
                     ["LeaderElection:Base:RenewInterval"] = settings.RenewInterval.ToString(),
                     ["LeaderElection:Base:RetryInterval"] = settings.RetryInterval.ToString(),
-                    ["LeaderElection:Base:MaxRetryAttempts"] = settings.MaxRetryAttempts.ToString(),
+                    ["LeaderElection:Base:RetryBackoffFactor"] =
+                        settings.RetryBackoffFactor.ToString(),
+                    ["LeaderElection:Base:RetryJitter"] = settings.RetryJitter.ToString(),
+                    ["LeaderElection:Base:MaxRetryInterval"] = settings.MaxRetryInterval.ToString(),
                     // ["LeaderElection:Base:EnableGracefulShutdown"] = settings.EnableGracefulShutdown.ToString(),
                 }
             )
@@ -125,8 +129,9 @@ public class PostgresServiceBuilderExtensionsTests
         actualSettings.LockId.Should().Be(settings.LockId);
         actualSettings.InstanceId.Should().Be(settings.InstanceId);
         actualSettings.RenewInterval.Should().Be(settings.RenewInterval);
-        actualSettings.RetryInterval.Should().Be(settings.RetryInterval);
-        actualSettings.MaxRetryAttempts.Should().Be(settings.MaxRetryAttempts);
+        actualSettings.RetryBackoffFactor.Should().Be(settings.RetryBackoffFactor);
+        actualSettings.RetryJitter.Should().Be(settings.RetryJitter);
+        actualSettings.MaxRetryInterval.Should().Be(settings.MaxRetryInterval);
         actualSettings.EnableGracefulShutdown.Should().Be(settings.EnableGracefulShutdown);
     }
 

--- a/tests/LeaderElection.Tests/RedisLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/RedisLeaderElectionTests.cs
@@ -191,6 +191,8 @@ public sealed class RedisLeaderElectionTests(RedisContainerFixture redisFixture)
         var options = CreateSettings("test-leader-election-manual");
 
         await using var leaderElection = CreateSut(options);
+        await leaderElection.StartAsync(CancellationToken);
+        await WaitForLeadershipChange(leaderElection, true);
 
         // Act
         var result = await leaderElection.TryAcquireLeadershipAsync(CancellationToken);

--- a/tests/LeaderElection.Tests/RedisLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/RedisLeaderElectionTests.cs
@@ -25,7 +25,7 @@ public sealed class RedisLeaderElectionTests(RedisContainerFixture redisFixture)
         TimeSpan? lockExpiry = null,
         TimeSpan? renewInterval = null,
         TimeSpan? retryInterval = null,
-        int maxRetryAttempts = 3,
+        TimeSpan? maxRetryInterval = null,
         bool enableGracefulShutdown = true
     ) =>
         new()
@@ -35,7 +35,7 @@ public sealed class RedisLeaderElectionTests(RedisContainerFixture redisFixture)
             LockExpiry = lockExpiry ?? TimeSpan.FromSeconds(10),
             RenewInterval = renewInterval ?? TimeSpan.FromSeconds(2),
             RetryInterval = retryInterval ?? TimeSpan.FromSeconds(1),
-            MaxRetryAttempts = maxRetryAttempts,
+            MaxRetryInterval = maxRetryInterval ?? TimeSpan.FromSeconds(60),
             EnableGracefulShutdown = enableGracefulShutdown,
         };
 

--- a/tests/LeaderElection.Tests/RedisServiceBuilderExtensionsTests.cs
+++ b/tests/LeaderElection.Tests/RedisServiceBuilderExtensionsTests.cs
@@ -17,8 +17,9 @@ public sealed class RedisServiceBuilderExtensionsTests
         LockExpiry = TimeSpan.FromSeconds(10),
         InstanceId = "foo",
         RenewInterval = TimeSpan.FromSeconds(2),
-        RetryInterval = TimeSpan.FromSeconds(1),
-        MaxRetryAttempts = 300,
+        RetryBackoffFactor = 1.5,
+        RetryJitter = 0.15,
+        MaxRetryInterval = TimeSpan.FromSeconds(100),
         EnableGracefulShutdown = false,
     };
 
@@ -58,7 +59,10 @@ public sealed class RedisServiceBuilderExtensionsTests
                     // ["LeaderElection:Base:InstanceId"] = settings.InstanceId,
                     ["LeaderElection:Base:RenewInterval"] = settings.RenewInterval.ToString(),
                     ["LeaderElection:Base:RetryInterval"] = settings.RetryInterval.ToString(),
-                    ["LeaderElection:Base:MaxRetryAttempts"] = settings.MaxRetryAttempts.ToString(),
+                    ["LeaderElection:Base:RetryBackoffFactor"] =
+                        settings.RetryBackoffFactor.ToString(),
+                    ["LeaderElection:Base:RetryJitter"] = settings.RetryJitter.ToString(),
+                    ["LeaderElection:Base:MaxRetryInterval"] = settings.MaxRetryInterval.ToString(),
                     // ["LeaderElection:Base:EnableGracefulShutdown"] = settings.EnableGracefulShutdown.ToString(),
                 }
             )

--- a/tests/LeaderElection.Tests/S3LeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/S3LeaderElectionTests.cs
@@ -185,6 +185,8 @@ public sealed class S3LeaderElectionTests(MinioContainerFixture minioFixture)
         var options = CreateSettings("test-leader-election-manual");
 
         await using var leaderElection = CreateSut(options);
+        await leaderElection.StartAsync(CancellationToken);
+        await WaitForLeadershipChange(leaderElection, true);
 
         // Act
         var result = await leaderElection.TryAcquireLeadershipAsync(CancellationToken);

--- a/tests/LeaderElection.Tests/S3ServiceBuilderExtensionsTests.cs
+++ b/tests/LeaderElection.Tests/S3ServiceBuilderExtensionsTests.cs
@@ -24,7 +24,9 @@ public sealed class S3ServiceBuilderExtensionsTests
             InstanceId = "foo",
             RenewInterval = TimeSpan.FromSeconds(2),
             RetryInterval = TimeSpan.FromSeconds(1),
-            MaxRetryAttempts = 300,
+            RetryBackoffFactor = 1.5,
+            RetryJitter = 0.15,
+            MaxRetryInterval = TimeSpan.FromSeconds(100),
             EnableGracefulShutdown = false,
         };
     }
@@ -61,7 +63,10 @@ public sealed class S3ServiceBuilderExtensionsTests
                     // ["LeaderElection:Base:InstanceId"] = settings.InstanceId,
                     ["LeaderElection:Base:RenewInterval"] = settings.RenewInterval.ToString(),
                     ["LeaderElection:Base:RetryInterval"] = settings.RetryInterval.ToString(),
-                    ["LeaderElection:Base:MaxRetryAttempts"] = settings.MaxRetryAttempts.ToString(),
+                    ["LeaderElection:Base:RetryBackoffFactor"] =
+                        settings.RetryBackoffFactor.ToString(),
+                    ["LeaderElection:Base:RetryJitter"] = settings.RetryJitter.ToString(),
+                    ["LeaderElection:Base:MaxRetryInterval"] = settings.MaxRetryInterval.ToString(),
                     // ["LeaderElection:Base:EnableGracefulShutdown"] = settings.EnableGracefulShutdown.ToString(),
                 }
             )

--- a/tests/LeaderElection.Tests/SettingsValidatorTests.cs
+++ b/tests/LeaderElection.Tests/SettingsValidatorTests.cs
@@ -16,22 +16,108 @@ public partial class SettingsValidatorTests
     internal partial class TestSettingsValidator : IValidateOptions<TestSettings> { }
 
     [Fact]
-    public void BaseSettingsValidatorShouldFailWhenDefaultSettings()
+    public void BaseSettingsValidatorShouldSucceedWithDefaults()
     {
         var validator = new TestSettingsValidator();
-        var settings = new TestSettings
-        {
-            InstanceId = string.Empty,
-            RenewInterval = TimeSpan.Zero,
-            RetryInterval = TimeSpan.Zero,
-        };
+        var settings = new TestSettings();
+
+        var result = validator.Validate(null, settings);
+
+        result.Failed.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void BaseSettingsValidatorShouldFailWhenInvalidInstanceId(string? instanceId)
+    {
+        var validator = new TestSettingsValidator();
+        var settings = new TestSettings { InstanceId = instanceId! };
 
         var result = validator.Validate(null, settings);
 
         result.Failed.Should().BeTrue();
         result.Failures.Should().Contain(f => f.Contains("InstanceId"));
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-1.0)]
+    public void BaseSettingsValidatorShouldFailWhenInvalidRenewInterval(double renewIntervalSeconds)
+    {
+        var validator = new TestSettingsValidator();
+        var settings = new TestSettings
+        {
+            RenewInterval = TimeSpan.FromSeconds(renewIntervalSeconds),
+        };
+
+        var result = validator.Validate(null, settings);
+
+        result.Failed.Should().BeTrue();
         result.Failures.Should().Contain(f => f.Contains("RenewInterval"));
+    }
+
+    [Theory]
+    [InlineData(0.0)]
+    [InlineData(-1.0)]
+    public void BaseSettingsValidatorShouldFailWhenInvalidRetryInterval(double retryIntervalSeconds)
+    {
+        var validator = new TestSettingsValidator();
+        var settings = new TestSettings
+        {
+            RetryInterval = TimeSpan.FromSeconds(retryIntervalSeconds),
+        };
+
+        var result = validator.Validate(null, settings);
+
+        result.Failed.Should().BeTrue();
         result.Failures.Should().Contain(f => f.Contains("RetryInterval"));
+    }
+
+    [Fact]
+    public void BaseSettingsValidatorShouldFailWhenInvalidMaxRetryInterval()
+    {
+        var validator = new TestSettingsValidator();
+        var settings = new TestSettings
+        {
+            RetryInterval = TimeSpan.FromSeconds(5), // valid
+            MaxRetryInterval = TimeSpan.FromSeconds(3), // invalid
+        };
+
+        var result = validator.Validate(null, settings);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(f => f.Contains("MaxRetryInterval"));
+    }
+
+    [Theory]
+    [InlineData(1.0 - 0.001)]
+    [InlineData(3.0 + 0.001)]
+    public void BaseSettingsValidatorShouldFailWhenInvalidRetryBackoffFactor(
+        double retryBackoffFactor
+    )
+    {
+        var validator = new TestSettingsValidator();
+        var settings = new TestSettings { RetryBackoffFactor = retryBackoffFactor };
+
+        var result = validator.Validate(null, settings);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(f => f.Contains("RetryBackoffFactor"));
+    }
+
+    [Theory]
+    [InlineData(0.0 - 0.001)]
+    [InlineData(1.0 + 0.001)]
+    public void BaseSettingsValidatorShouldFailWhenInvalidRetryJitter(double retryJitter)
+    {
+        var validator = new TestSettingsValidator();
+        var settings = new TestSettings { RetryJitter = retryJitter };
+
+        var result = validator.Validate(null, settings);
+
+        result.Failed.Should().BeTrue();
+        result.Failures.Should().Contain(f => f.Contains("RetryJitter"));
     }
 
     [Fact]

--- a/tests/LeaderElection.Tests/TestBase.cs
+++ b/tests/LeaderElection.Tests/TestBase.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+using Microsoft.Extensions.Time.Testing;
 
 namespace LeaderElection.Tests;
 
@@ -18,43 +18,81 @@ public abstract class TestBase
     /// </summary>
     protected TimeProvider TimeProvider { get; init; } = TimeProvider.System;
 
-    protected static async Task WaitForLeadershipChange(
+    /// <summary>
+    /// Advances time by the specified <see cref="TimeSpan"/> using the configured
+    /// <see cref="TimeProvider"/>. This is a helper method to simulate time passage
+    /// in tests that use a <see cref="FakeTimeProvider"/>.
+    /// </summary>
+    /// <param name="timeSpan">The amount of time to advance/wait.</param>
+    protected async Task AdvanceTime(TimeSpan timeSpan)
+    {
+        if (TimeProvider is FakeTimeProvider fakeTimeProvider)
+        {
+            // small delay to ensure OS has time to unblock any tasks waiting for
+            // the Leader Loop semaphore before advancing time
+            await Task.Delay(5, CancellationToken);
+            fakeTimeProvider.Advance(timeSpan);
+            // allow any released tasks to update state before assertions.
+            await Task.Delay(1, CancellationToken);
+        }
+        else
+        {
+            await TimeProvider.Delay(timeSpan, CancellationToken);
+        }
+    }
+
+    /// <summary>
+    /// Waits for the specified leader election instance to change to the expected
+    /// leadership status.
+    /// </summary>
+    /// <param name="leaderElection">The leader election instance to monitor for leadership changes.</param>
+    /// <param name="expectedLeadership">The expected leadership status to wait for.</param>
+    /// <param name="timeout">The maximum time to wait for the leadership change. Defaults to 30 seconds.</param>
+    /// <returns>A task that completes when the desired leadership state is reached.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="leaderElection"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the leader election instance is not currently the leader.</exception>
+    /// <exception cref="TimeoutException">Thrown if the operation does not complete within the specified timeout.</exception>
+    /// <exception cref="OperationCanceledException">Thrown if the operation is canceled via the <see cref="CancellationToken"/>.</exception>
+    protected async Task WaitForLeadershipChange(
         ILeaderElection leaderElection,
         bool expectedLeadership,
-        TimeSpan timeout = default
+        TimeSpan? timeout = default
     )
     {
-        if (timeout == TimeSpan.Zero)
-            timeout = TimeSpan.FromSeconds(30);
+        timeout ??= TimeSpan.FromSeconds(30);
 
-        var tcs = new TaskCompletionSource<bool>();
+        ArgumentNullException.ThrowIfNull(leaderElection);
+        if (!leaderElection.LeaderLoopRunning)
+        {
+            throw new InvalidOperationException("Leader loop is not running.");
+        }
+
+        if (leaderElection.IsLeader == expectedLeadership)
+        {
+            return; // Already in expected state, no need to wait
+        }
+
+        var tcs = new TaskCompletionSource();
 
         void Handler(object? sender, LeadershipChangedEventArgs leadership)
         {
             if (leadership.IsLeader == expectedLeadership)
             {
-                tcs.TrySetResult(true);
+                tcs.SetResult();
             }
         }
 
-        Debug.Assert(leaderElection != null, nameof(leaderElection) + " != null");
         leaderElection.LeadershipChanged += Handler;
         try
         {
-            // Check if already in the expected state
+            // Now that we've hooked up the event handler, check if already
+            // in the expected state...
             if (leaderElection.IsLeader == expectedLeadership)
             {
-                tcs.TrySetResult(true);
+                return; // Already in expected state, no need to wait
             }
 
-            using var timeoutCts = new CancellationTokenSource(timeout);
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
-                timeoutCts.Token,
-                CancellationToken
-            );
-            linkedCts.Token.Register(() => tcs.TrySetCanceled());
-
-            await tcs.Task;
+            await tcs.Task.WaitAsync(timeout.Value, TimeProvider, CancellationToken);
         }
         finally
         {
@@ -62,32 +100,39 @@ public abstract class TestBase
         }
     }
 
-    protected static async Task WaitForError(
+    /// <summary>
+    /// Waits for an error to be raised by the leader election instance.
+    /// </summary>
+    /// <param name="leaderElection">The leader election instance to monitor for errors.</param>
+    /// <param name="timeout">The maximum time to wait for an error. Defaults to 30 seconds.</param>
+    /// <returns>The <see cref="Exception"/> raised by the leader election instance if an error
+    /// occurs within the timeout period.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="leaderElection"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the leader election instance is not currently the leader.</exception>
+    /// <exception cref="TimeoutException">Thrown if the operation does not complete within the specified timeout.</exception>
+    /// <exception cref="OperationCanceledException">Thrown if the operation is canceled via the <see cref="CancellationToken"/>.</exception>
+    protected async Task<Exception> WaitForError(
         ILeaderElection leaderElection,
-        TimeSpan timeout = default
+        TimeSpan? timeout = default
     )
     {
-        if (timeout == TimeSpan.Zero)
-            timeout = TimeSpan.FromSeconds(30);
+        timeout ??= TimeSpan.FromSeconds(30);
+
+        ArgumentNullException.ThrowIfNull(leaderElection);
+        if (!leaderElection.LeaderLoopRunning)
+        {
+            throw new InvalidOperationException("Leader loop is not running.");
+        }
 
         var tcs = new TaskCompletionSource<Exception>();
 
         void Handler(object? sender, LeadershipExceptionEventArgs args) =>
             tcs.TrySetResult(args.LeadershipException);
 
-        Debug.Assert(leaderElection != null, nameof(leaderElection) + " != null");
         leaderElection.ErrorOccurred += Handler;
-
         try
         {
-            using var timeoutCts = new CancellationTokenSource(timeout);
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(
-                timeoutCts.Token,
-                CancellationToken
-            );
-            linkedCts.Token.Register(() => tcs.TrySetCanceled());
-
-            await tcs.Task;
+            return await tcs.Task.WaitAsync(timeout.Value, TimeProvider, CancellationToken);
         }
         finally
         {
@@ -109,9 +154,13 @@ public abstract class TestBase
     /// also return false.
     /// </remarks>
     /// <param name="leaderElection">The leader election instance to monitor.</param>
-    /// <param name="timeout">The maximum time to wait for a renewal.</param>
-    /// <param name="pollInterval">The interval at which to check for leadership renewal.</param>
+    /// <param name="timeout">The maximum time to wait for a renewal. Defaults to 30 seconds.</param>
+    /// <param name="pollInterval">The interval at which to check for leadership renewal. Defaults to 100ms.</param>
     /// <returns>True if a renewal was observed within the timeout period; otherwise, false.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="leaderElection"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the leader election instance is not currently the leader.</exception>
+    /// <exception cref="TimeoutException">Thrown if the operation does not complete within the specified timeout.</exception>
+    /// <exception cref="OperationCanceledException">Thrown if the operation is canceled via the <see cref="CancellationToken"/>.</exception>
     protected async Task<bool> WaitForLeadershipRenewal(
         ILeaderElection leaderElection,
         TimeSpan? timeout = null,
@@ -119,16 +168,21 @@ public abstract class TestBase
     )
     {
         timeout ??= TimeSpan.FromSeconds(30);
-        pollInterval ??= TimeSpan.FromMilliseconds(50);
+        pollInterval ??= TimeSpan.FromMilliseconds(100);
 
-        Debug.Assert(leaderElection != null, nameof(leaderElection) + " != null");
-        leaderElection.IsLeader.Should().BeTrue("Expected to be leader before waiting for renewal");
+        ArgumentNullException.ThrowIfNull(leaderElection);
+
         var lastKnownRenewal = leaderElection.LastLeadershipRenewal;
+        if (!leaderElection.IsLeader)
+        {
+            throw new InvalidOperationException("Expected to be leader before waiting for renewal");
+        }
+        lastKnownRenewal.Should().BeAfter(DateTime.MinValue);
 
         var stopTime = TimeProvider.GetUtcNow() + timeout.Value;
         while (TimeProvider.GetUtcNow() < stopTime)
         {
-            await TimeProvider.Delay(pollInterval.Value, CancellationToken);
+            await AdvanceTime(pollInterval.Value);
 
             if (!leaderElection.IsLeader)
             {
@@ -141,7 +195,10 @@ public abstract class TestBase
             }
         }
 
-        return false; // Timeout reached without observing renewal
+        // Timeout reached without observing renewal
+        throw new TimeoutException(
+            $"Did not observe leadership renewal within the expected timeout of {timeout.Value}."
+        );
     }
 
     protected async Task TestShouldRetainLeadershipAfterAtLeastOneRenewalCycle(
@@ -149,15 +206,16 @@ public abstract class TestBase
         LeaderElectionSettingsBase settings
     )
     {
+        ArgumentNullException.ThrowIfNull(leaderElection);
+        ArgumentNullException.ThrowIfNull(settings);
+
         // Act
-        Debug.Assert(leaderElection != null, nameof(leaderElection) + " != null");
         await leaderElection.StartAsync(CancellationToken);
         await WaitForLeadershipChange(leaderElection, true);
 
-        Debug.Assert(settings != null, nameof(settings) + " != null");
         var renewalObserved = await WaitForLeadershipRenewal(
             leaderElection,
-            settings.RenewInterval + TimeSpan.FromSeconds(0.5) // Add a buffer to avoid timing issues
+            settings.RenewInterval * 2 // double to avoid timing issues
         );
 
         // Assert


### PR DESCRIPTION
## Description

> [!IMPORTANT]
> This PR contains functional changes. See the review comments for details. 

This pull request refactors `BaseLeaderElection` to ensure robust concurrent access to leadership status and the background loop by replacing volatile fields with explicit Volatile and Interlocked operations. This change prevents potential race conditions and torn reads, particularly for leadership renewal timestamps, while centralizing state transitions to maintain consistency across the lifecycle of the leader election instance. This resolves #59

It resolves #60 by **not** tying the `_leaderLoopTaskCTS` to the `StartAsync()` cancellation token.

It also introduces several improvements and clarifications to the leader election interface, its documentation, and improves test coverage. It includes enhanced XML documentation for the `ILeaderElection` interface, the addition of new properties and exception details, and a significant expansion of unit tests to cover edge cases and error handling. Additionally, some package dependencies have been updated.

---

## Checklist

- [x] My code follows the project's coding style
- [x] I have self-reviewed my changes
- [x] I have added tests (or explain why not needed)
- [ ] I have updated the documentation
- [x] I have linked relevant issue(s)
- [x] I have included meaningful commit messages

---

## Related Issues

Closes #59 and #60

---

## Additional Notes

Note that the target branch is `refactor/di-extensions` and should not be merged until after #64 is merged. 