### PR TITLE
Add .NET Aspire support for LeaderElectionTester

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,80 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch LeaderElectionTester (redis)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build LeaderElectionTester.AppHost",
+      "program": "${workspaceFolder}/artifacts/bin/LeaderElectionTester.AppHost/debug/LeaderElectionTester.AppHost.dll",
+      "args": ["LeaderElectionType=redis"],
+      "cwd": "${workspaceFolder}/examples/LeaderElectionTester.AppHost",
+      "stopAtEntry": false,
+      "console": "integratedTerminal"
+      // "justMyCode": false
+    },
+    {
+      "name": "Launch LeaderElectionTester (distributed cache)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build LeaderElectionTester.AppHost",
+      "program": "${workspaceFolder}/artifacts/bin/LeaderElectionTester.AppHost/debug/LeaderElectionTester.AppHost.dll",
+      "args": ["LeaderElectionType=distributedcache"],
+      "cwd": "${workspaceFolder}/examples/LeaderElectionTester.AppHost",
+      "stopAtEntry": false,
+      "console": "integratedTerminal"
+      // "justMyCode": false
+    },
+    {
+      "name": "Launch LeaderElectionTester (fusion cache)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build LeaderElectionTester.AppHost",
+      "program": "${workspaceFolder}/artifacts/bin/LeaderElectionTester.AppHost/debug/LeaderElectionTester.AppHost.dll",
+      "args": ["LeaderElectionType=fusioncache"],
+      "cwd": "${workspaceFolder}/examples/LeaderElectionTester.AppHost",
+      "stopAtEntry": false,
+      "console": "integratedTerminal"
+      // "justMyCode": false
+    },
+    {
+      "name": "Launch LeaderElectionTester (blob storage)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build LeaderElectionTester.AppHost",
+      "program": "${workspaceFolder}/artifacts/bin/LeaderElectionTester.AppHost/debug/LeaderElectionTester.AppHost.dll",
+      "args": ["LeaderElectionType=blobstorage"],
+      "cwd": "${workspaceFolder}/examples/LeaderElectionTester.AppHost",
+      "stopAtEntry": false,
+      "console": "integratedTerminal"
+      // "justMyCode": false
+    },
+    {
+      "name": "Launch LeaderElectionTester (s3)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build LeaderElectionTester.AppHost",
+      "program": "${workspaceFolder}/artifacts/bin/LeaderElectionTester.AppHost/debug/LeaderElectionTester.AppHost.dll",
+      "args": ["LeaderElectionType=s3"],
+      "cwd": "${workspaceFolder}/examples/LeaderElectionTester.AppHost",
+      "stopAtEntry": false,
+      "console": "integratedTerminal"
+      // "justMyCode": false
+    },
+    {
+      "name": "Launch LeaderElectionTester (postgres)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build LeaderElectionTester.AppHost",
+      "program": "${workspaceFolder}/artifacts/bin/LeaderElectionTester.AppHost/debug/LeaderElectionTester.AppHost.dll",
+      "args": ["LeaderElectionType=postgres"],
+      "cwd": "${workspaceFolder}/examples/LeaderElectionTester.AppHost",
+      "stopAtEntry": false,
+      "console": "integratedTerminal"
+      // "justMyCode": false
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,13 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build LeaderElectionTester.AppHost",
+      "type": "dotnet",
+      "task": "build ${workspaceFolder}/examples/LeaderElectionTester.AppHost/LeaderElectionTester.AppHost.csproj",
+      "file": "${workspaceFolder}/examples/LeaderElectionTester.AppHost/LeaderElectionTester.AppHost.csproj",
+      "group": "build",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,9 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="Aspire.Hosting.Azure.Storage" Version="13.2.4" />
+    <PackageVersion Include="Aspire.Hosting.PostgreSQL" Version="13.2.4" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.2.4" />
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.27.0" />

--- a/LeaderElection.slnx
+++ b/LeaderElection.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/examples/">
+    <Project Path="examples/LeaderElectionTester.AppHost/LeaderElectionTester.AppHost.csproj" />
     <Project Path="examples/LeaderElectionTester/LeaderElectionTester.csproj" />
   </Folder>
   <Folder Name="/src/">
@@ -9,7 +10,7 @@
     <Project Path="src/LeaderElection.Redis/LeaderElection.Redis.csproj" />
     <Project Path="src/LeaderElection.S3/LeaderElection.S3.csproj" />
     <Project Path="src/LeaderElection/LeaderElection.csproj" />
-    <Project Path="src\LeaderElection.Postgres\LeaderElection.Postgres.csproj" Type="Classic C#" />
+    <Project Path="src/LeaderElection.Postgres/LeaderElection.Postgres.csproj" Type="C#" />
   </Folder>
   <Folder Name="/tests/">
     <Project Path="tests/LeaderElection.Tests/LeaderElection.Tests.csproj" />

--- a/build.ps1
+++ b/build.ps1
@@ -81,6 +81,7 @@ param (
     [switch] $SkipDependencies
 )
 $ErrorActionPreference = 'Stop'
+$InformationPreference = 'Continue'
 
 # Define the repository root and scripts directory. All tasks will be executed in the
 # context of the repository root ($RepoRoot).
@@ -146,7 +147,7 @@ Task bootstrap -desc 'Installs required tools' {
         'docker'        = $null # well-known app
         'powershell'    = $null # well-known app
     }
-    Install-RequiredApp $appsToInstall -InstallPackageManagers -InformationAction Continue -Verbose:($VerbosePreference -eq 'Continue')
+    Install-RequiredApp $appsToInstall -InstallPackageManagers
 }
 
 Task version -desc 'Display tool versions' {
@@ -568,6 +569,4 @@ Invoke-TaskFramework `
     -WorkingDirectory $RepoRoot `
     -Variables $Variables `
     -ImportScripts $ImportScripts `
-    -ExitOnError `
-    -InformationAction Continue `
-    -Verbose:($VerbosePreference -eq 'Continue')
+    -ExitOnError

--- a/build.ps1
+++ b/build.ps1
@@ -17,22 +17,30 @@
 
     Lists all available tasks.
 .EXAMPLE
-    PS> ./build.ps1 test -noDeps
+    PS> ./build.ps1 clean -noDeps
 
-    Executes the 'test' task without executing its dependencies.
+    Executes the 'clean' task without executing its dependencies.
+.EXAMPLE
+    PS> ./build.ps1 help clean -full
+
+    Displays the help documentation for the 'clean' task.
+    Run `./build.ps1 help help -full` for more information on the help system.
 .NOTES
     SPDX-License-Identifier: Unlicense
     Source: http://github.com/mrfootoyou/pstaskframework
 #>
 #Requires -Version 7.4
-# spell:ignore winget,choco,opencover,reportgenerator,reportgenerator-globaltool
+# spell:ignore dont,winget,choco,opencover,reportgenerator,reportgenerator-globaltool
 
+[Diagnostics.CodeAnalysis.SuppressMessage('PSReviewUnusedParameter', '')]
+[Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidGlobalVars', 'global:LastTaskContext')]
 [CmdletBinding(PositionalBinding = $false)]
 param (
     # The name of the task(s) to execute.
     [Parameter(Position = 0)]
     [ValidateSet(
         'list',
+        'help',
         'bootstrap',
         'version',
         'updateTools',
@@ -50,83 +58,55 @@ param (
         'push',
         'runExample'
     )]
-    [string[]]
-    $TaskName = @('build'),
+    [string[]] $TaskName = @('build'),
 
     # The build configuration to use when executing tasks that support it (e.g. 'build', 'test').
     # Defaults to 'debug'.
     [ValidateSet('debug', 'release')]
-    [string]
-    $Configuration = 'debug',
+    [string] $Configuration = 'debug',
 
     # The version to use when executing tasks that support it (e.g. 'build', 'package').
-    [string]
-    $Version,
-
-    # Task-specific arguments for the task specified in -TaskName.
-    # Cannot be used when -TaskName contains multiple tasks.
-    # Arguments are _not_ passed to dependencies of the specified task.
-    #
-    # Tip: Use `-- ` to clearly separate build-script arguments from task arguments.
-    # Anything after the `-- ` will be passed verbatim to the invoked task.
-    # For example:
-    #   ./build.ps1 myTask -v -- -v
-    # In this example, the first '-v' is shorthand for PowerShell's -Verbose argument,
-    # while the second '-v' is passed to 'myTask' as a task-specific argument.
-    [Parameter(ValueFromRemainingArguments)]
-    [object[]] $TaskArgs,
+    [ValidateNotNullOrEmpty()]
+    [string] $Version,
 
     # When specified, dependencies of the task(s) will not be executed.
     # Default is execute all dependencies (and their dependencies).
     [Alias("noDeps")]
-    [switch] $SkipDependencies
-)
-$ErrorActionPreference = 'Stop'
-$InformationPreference = 'Continue'
+    [switch] $SkipDependencies,
 
-# Define the repository root and scripts directory. All tasks will be executed in the
-# context of the repository root ($RepoRoot).
-# Assume this script is located in the repository root.
-$RepoRoot = $PSScriptRoot
+    # Receives task-specific arguments for the _single task_ specified in -TaskName.
+    [Parameter(ValueFromRemainingArguments, DontShow)]
+    [ValidateNotNull()]
+    [object[]] $TaskArgs = @()
+)
+# Initialize some default PowerShell preferences...
+$ErrorActionPreference = 'Stop'     # throw exception on any unhandled error
+$InformationPreference = 'Continue' # display informational messages
+
+# Initialize some repository variables...
+$RepoRoot = $PSScriptRoot # assumes this script is located in the repo root
 $ScriptsDir = Convert-Path "$RepoRoot/scripts"
 
-####################################################################################
-# Define tasks variables
-####################################################################################
-# The properties of the $Variables dictionary will be imported as variables
-# into each task prior to execution. This allows you to define common variables that
-# are shared across all tasks, such as the repository root, scripts directory, or any
-# other values that tasks may need, such as input parameters like $Configuration.
-#
-# The following variables are always available:
-# - $Task: The currently executing task definition.
-# - $TaskName: The name of the currently executing task (same as $Task.Name).
-# - $TaskArgs: An array of the arguments passed to the currently executing task.
-# - $SkipDependencies: Indicates if the task's dependencies were executed.
-# - $TasksToExecute: The ordered list of all tasks to execute.
-# - $Variables: The dictionary of variables to import into each task's scope.
-$Variables = @{
-    RepoRoot      = $RepoRoot
-    ScriptsDir    = $ScriptsDir
-    Configuration = $Configuration
-    Version       = $Version
-    # Add more variables here as needed
-}
+# Import and initialize the PSTaskFramework...
+Import-Module "$ScriptsDir/PSTaskFramework" -Verbose:$false
+$TaskContext = Initialize-TaskFramework
 
-# These scripts will be imported into each task prior to execution.
-$ImportScripts = @(
-    # Add more scripts here as needed
-)
+####################################################################################
+# Define shared variables and functions...
+####################################################################################
+
 
 ####################################################################################
 # Define all tasks
+# - Tasks will execute in the order they are defined below, unless they have
+#   dependencies, in which case the dependencies will always be executed first.
+# - The task's working directory is the folder containing this script.
+# - Tasks can assign values to script-scope variables using the `$script:` modifier.
 ####################################################################################
-Import-Module "$ScriptsDir/PSTaskFramework" -Verbose:$false
-Reset-TaskFramework
+#region Task definitions
 
-Task list -desc 'List all tasks' {
-    Get-TaskFrameworkTasks | Format-Table Name, Description, DependsOn -AutoSize
-}
+# Add the default list and help tasks...
+Add-TaskFrameworkDefaultTasks list, help
 
 Task bootstrap -desc 'Installs required tools' {
     <#
@@ -134,7 +114,7 @@ Task bootstrap -desc 'Installs required tools' {
         Bootstraps the repository by installing required tools.
 
         Required tools include:
-        - Git (probably already installed, but we'll update if necessary).
+        - Git (probably already installed).
         - .NET SDK
         - Docker-API compatible container runtime for integration tests.
         - PowerShell 7.4 or later (assumed to be already be installed).
@@ -629,16 +609,16 @@ Task runExample -desc 'Run the example application' -dependsOn build {
     Invoke-Shell -- dotnet run @runArgs
 }
 
-##############################################################
-# Execute the specified task(s) with the Task Framework. See
-# the documentation for Invoke-TaskFramework for more details.
-##############################################################
+#endregion Task definitions
 
+####################################################################################
+# Execute the specified task(s)...
+####################################################################################
 Invoke-TaskFramework `
     -TaskName $TaskName `
     -TaskArgs $TaskArgs `
     -SkipDependencies:$SkipDependencies `
-    -WorkingDirectory $RepoRoot `
-    -Variables $Variables `
-    -ImportScripts $ImportScripts `
     -ExitOnError
+
+# Save TaskContext in a global variable so that it can be inspected
+$global:LastTaskContext = $TaskContext

--- a/build.ps1
+++ b/build.ps1
@@ -47,7 +47,8 @@ param (
         'test',
         'coverage',
         'package',
-        'push'
+        'push',
+        'runExample'
     )]
     [string[]]
     $TaskName = @('build'),
@@ -555,6 +556,77 @@ Task push -desc 'Push NuGet packages' -dependsOn version {
     finally {
         Pop-Secret $ApiKey
     }
+}
+
+Task runExample -desc 'Run the example application' -dependsOn build {
+    <#
+    .DESCRIPTION
+        Runs the example application located in 'examples/LeaderElectionTester' folder.
+
+        By default it uses Aspire to orchestrate the infrastructure and the example
+        application instances. Click the "dashboard" link in the console output to view
+        the Aspire dashboard.
+
+        To run without Aspire, use the -NoAspire switch. In this mode, you are responsible
+        for ensuring that the necessary infrastructure (e.g. docker containers) is
+        properly configured and running *before* starting the example application.
+    .EXAMPLE
+        PS> ./build.ps1 runExample
+
+        Uses Aspire to orchestrate a Redis container and two instances of the example
+        application running Redis leader election.
+    .EXAMPLE
+        PS> ./build.ps1 runExample -- blob -count 5
+
+        Uses Aspire to orchestrate a Blob Storage container and five instances of the
+        example application running BlobStorage leader election.
+    .EXAMPLE
+        PS> ./build.ps1 runExample -- postgres -NoAspire
+
+        Starts one instance of the example application running Postgres leader election.
+        The caller is responsible for managing a compatible Postgres database.
+        Run the command again (in another terminal window) to create a second instance.
+    #>
+    [CmdletBinding(PositionalBinding = $false)]
+    param(
+        # The type of LeaderElection to run. Valid values are:
+        #  - redis
+        #  - blob or blobStorage
+        #  - s3
+        #  - postgres
+        #  - dc or distributedCache
+        #  - fc or fusionCache
+        # Default is redis.
+        [Parameter(Position = 0)]
+        [string] $Type = 'redis',
+
+        # The number of example application instances Aspire should create.
+        # Defaults to 2.
+        [ValidateRange(1, 100)]
+        [int] $Count = 2,
+
+        # When specified, a single instance of the example application will be started without
+        # using Aspire. It is the caller's responsibility to ensure that the necessary
+        # infrastructure (e.g. docker containers) is properly configured.
+        [switch] $NoAspire
+    )
+
+    $runArgs = @(
+        '--no-build'
+        '--launch-profile', 'https'
+        '--'
+        "LeaderElectionType=$Type"
+    )
+
+    if ($NoAspire) {
+        Set-Location './examples/LeaderElectionTester'
+    }
+    else {
+        Set-Location './examples/LeaderElectionTester.AppHost'
+        $runArgs += "TesterCount=$Count"
+    }
+
+    Invoke-Shell -- dotnet run @runArgs
 }
 
 ##############################################################

--- a/examples/LeaderElectionTester.AppHost/AppHost.cs
+++ b/examples/LeaderElectionTester.AppHost/AppHost.cs
@@ -1,0 +1,96 @@
+using Microsoft.Extensions.Configuration;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+var leaderElectionType = (
+    builder.Configuration["LeaderElectionType"] ?? "Redis"
+).ToUpperInvariant() switch
+{
+    "REDIS" => "Redis",
+    "DISTRIBUTEDCACHE" or "DC" => "DistributedCache",
+    "FUSIONCACHE" or "FC" => "FusionCache",
+    "BLOBSTORAGE" or "BLOB" => "BlobStorage",
+    "S3" => "S3",
+    "POSTGRES" => "Postgres",
+#pragma warning disable CA2208
+    var v => throw new ArgumentException(
+        $"Invalid LeaderElectionType '{v}'. Supported values: Redis, DistributedCache (dc), FusionCache (fc), BlobStorage (blob), S3, Postgres.",
+        "LeaderElectionType"
+    ),
+#pragma warning restore CA2208
+};
+
+// Create multiple instances of the tester application. Each instance will
+// attempt to acquire leadership using the selected leader election
+// mechanism...
+var testers = Enumerable
+    .Range(1, builder.Configuration.GetValue("TesterCount", 2))
+    .Select(i =>
+    {
+        var testerId = $"tester-{i}";
+        return builder
+            .AddProject<Projects.LeaderElectionTester>(testerId)
+            .WithEnvironment("LeaderElectionType", leaderElectionType)
+            .WithEnvironment("InstanceId", testerId);
+    })
+    .ToList();
+
+// Setup the required infrastructure for the selected leader election mechanism
+// and configure the testers to reference it and wait for it to be ready...
+if (leaderElectionType is "Redis" or "DistributedCache" or "FusionCache")
+{
+    var redis = builder.AddRedis("redis");
+    testers.ForEach(tester => tester.WithReference(redis).WaitFor(redis));
+}
+else if (leaderElectionType is "BlobStorage")
+{
+    var blobs = builder.AddAzureStorage("storage").RunAsEmulator().AddBlobs("blobs");
+    testers.ForEach(tester => tester.WithReference(blobs).WaitFor(blobs));
+}
+else if (leaderElectionType is "Postgres")
+{
+    var db = builder.AddPostgres("postgres").AddDatabase("mydb");
+    testers.ForEach(tester => tester.WithReference(db).WaitFor(db));
+}
+else if (leaderElectionType is "S3")
+{
+    var minioAccessKey = "accessKey";
+    var minioSecretKey = "secretKey";
+    var minioBucketName = "my-app-locks";
+
+    var minio = builder
+        .AddContainer("minio", "minio/minio")
+        .WithHttpEndpoint(name: "api", targetPort: 9000)
+        .WithHttpEndpoint(name: "console", targetPort: 9001)
+        .WithEnvironment("MINIO_ROOT_USER", minioAccessKey)
+        .WithEnvironment("MINIO_ROOT_PASSWORD", minioSecretKey)
+        .WithArgs("server", "/data", "--console-address", ":9001");
+
+    var minioApi = minio.GetEndpoint("api");
+
+    var minioEndpointExpr = ReferenceExpression.Create(
+        $"http://{minioApi.Property(EndpointProperty.Host)}:{minioApi.Property(EndpointProperty.Port)}"
+    );
+
+    // Setup MinIO with the required bucket for leader election locks before starting the testers.
+    var minioSetup = builder
+        .AddContainer("minio-setup", "minio/mc")
+        .WithEntrypoint("/bin/sh")
+        .WithArgs(
+            "-c",
+            $"until mc alias set myminio \"$MINIO_ENDPOINT\" \"{minioAccessKey}\" \"{minioSecretKey}\" --insecure; do echo 'Waiting for MinIO...'; sleep 1; done; mc mb --ignore-existing myminio/{minioBucketName} --insecure"
+        )
+        .WithEnvironment("MINIO_ENDPOINT", minioEndpointExpr)
+        .WaitFor(minio);
+
+    testers.ForEach(tester =>
+        tester
+            .WithEnvironment("Minio__Endpoint", minioEndpointExpr)
+            .WithEnvironment("Minio__AccessKey", minioAccessKey)
+            .WithEnvironment("Minio__SecretKey", minioSecretKey)
+            .WithEnvironment("Minio__BucketName", minioBucketName)
+            .WaitForCompletion(minioSetup)
+    );
+}
+
+builder.Build().Run();

--- a/examples/LeaderElectionTester.AppHost/LeaderElectionTester.AppHost.csproj
+++ b/examples/LeaderElectionTester.AppHost/LeaderElectionTester.AppHost.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Aspire.AppHost.Sdk/13.2.4">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <UserSecretsId>1c1b1b3f-48bc-4431-8d0f-8df58d60dcf4</UserSecretsId>
+    <NoWarn>CA1848;CA1873;CA1812</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.Azure.Storage" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" />
+    <PackageReference Include="Aspire.Hosting.Redis" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LeaderElectionTester\LeaderElectionTester.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/LeaderElectionTester.AppHost/Properties/launchSettings.json
+++ b/examples/LeaderElectionTester.AppHost/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17233;http://localhost:15006",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21185",
+        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "https://localhost:23171",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22232"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15006",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19029",
+        "ASPIRE_DASHBOARD_MCP_ENDPOINT_URL": "http://localhost:18025",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20019"
+      }
+    }
+  }
+}

--- a/examples/LeaderElectionTester.AppHost/appsettings.Development.json
+++ b/examples/LeaderElectionTester.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/examples/LeaderElectionTester.AppHost/appsettings.json
+++ b/examples/LeaderElectionTester.AppHost/appsettings.json
@@ -1,0 +1,11 @@
+{
+  "LeaderElectionType": "Redis",
+  "TesterCount": 2,
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/examples/LeaderElectionTester.AppHost/aspire.config.json
+++ b/examples/LeaderElectionTester.AppHost/aspire.config.json
@@ -1,0 +1,5 @@
+{
+  "appHost": {
+    "path": "LeaderElectionTester.AppHost.csproj"
+  }
+}

--- a/examples/LeaderElectionTester/Program.cs
+++ b/examples/LeaderElectionTester/Program.cs
@@ -37,12 +37,11 @@ var leaderElectionType = (
 };
 
 // Get a unique ID for each running instance (e.g. in different terminals or machines).
-var instanceId = builder.Configuration.GetValue(
-    "InstanceId",
-    $"{AppDomain.CurrentDomain.FriendlyName}:{Environment.MachineName}:{Environment.ProcessId}"
-);
+var instanceId =
+    builder.Configuration["InstanceId"]
+    ?? $"{AppDomain.CurrentDomain.FriendlyName}:{Environment.MachineName}:{Environment.ProcessId}";
 
-var redisConfiguration = "localhost:6379";
+var redisConfiguration = builder.Configuration.GetConnectionString("redis") ?? "localhost:6379";
 
 if (leaderElectionType is "Redis")
 {
@@ -56,8 +55,7 @@ if (leaderElectionType is "Redis")
             })
     );
 }
-
-if (leaderElectionType is "DistributedCache")
+else if (leaderElectionType is "DistributedCache")
 {
     builder.Services.AddRedisServices(redisConfiguration);
     builder.Services.AddDistributedCache();
@@ -70,8 +68,7 @@ if (leaderElectionType is "DistributedCache")
             })
     );
 }
-
-if (leaderElectionType is "FusionCache")
+else if (leaderElectionType is "FusionCache")
 {
     builder.Services.AddRedisServices(redisConfiguration);
     builder.Services.AddDistributedCache();
@@ -88,13 +85,14 @@ if (leaderElectionType is "FusionCache")
             })
     );
 }
-
-if (leaderElectionType is "BlobStorage")
+else if (leaderElectionType is "BlobStorage")
 {
     builder.Services.AddAzureClients(configure =>
     {
         // blob test using Azurite or Storage Emulator
-        configure.AddBlobServiceClient("UseDevelopmentStorage=true;");
+        configure.AddBlobServiceClient(
+            builder.Configuration["BLOBS_CONNECTIONSTRING"] ?? "UseDevelopmentStorage=true;"
+        );
     });
     builder.Services.AddBlobStorageLeaderElection(builder =>
         builder
@@ -106,13 +104,18 @@ if (leaderElectionType is "BlobStorage")
             })
     );
 }
-
-if (leaderElectionType is "S3")
+else if (leaderElectionType is "S3")
 {
+    var minioUri = new Uri(builder.Configuration["Minio:Endpoint"] ?? "http://localhost:9000");
+    var minioEndpoint = $"{minioUri.Host}:{minioUri.Port}";
+    var minioAccessKey = builder.Configuration["Minio:AccessKey"] ?? "accessKey";
+    var minioSecretKey = builder.Configuration["Minio:SecretKey"] ?? "secretKey";
+    var minioBucketName = builder.Configuration["Minio:BucketName"] ?? "my-app-locks";
+
     builder.Services.AddMinio(client =>
         client
-            .WithEndpoint("localhost:9000")
-            .WithCredentials("accessKey", "secretKey")
+            .WithEndpoint(minioEndpoint)
+            .WithCredentials(minioAccessKey, minioSecretKey)
             .WithSSL(false)
             .Build()
     );
@@ -122,19 +125,22 @@ if (leaderElectionType is "S3")
             .WithInstanceId(instanceId)
             .WithSettings(options =>
             {
-                options.BucketName = "my-app-locks";
+                options.BucketName = minioBucketName;
                 options.ObjectKey = "leader-lock.json";
             })
     );
 }
-
-if (leaderElectionType is "Postgres")
+else if (leaderElectionType is "Postgres")
 {
+    var connectionString =
+        builder.Configuration.GetConnectionString("mydb")
+        ?? "Host=localhost;Database=mydb;Username=myuser;Password=mypassword;";
+
     // Register a NpgsqlDataSource specifically for Leader Election use...
     const string postgresLeaderElectionDataSource = "PostgresLeaderElectionDataSource";
     builder.Services.AddNpgsqlDataSource(
         // Use short CommandTimeout to avoid long waits if the database becomes unresponsive.
-        "Host=localhost;Database=mydb;Username=myuser;Password=mypassword;Timeout=5;CommandTimeout=3;",
+        connectionString + ";Timeout=5;CommandTimeout=3;",
         serviceKey: postgresLeaderElectionDataSource
     );
 
@@ -175,9 +181,12 @@ internal static class ProgramExtensions
         services.AddStackExchangeRedisCache(_ => { });
         services
             .AddOptions<RedisCacheOptions>()
-            .Configure<IConnectionMultiplexer>(
-                (options, connection) =>
-                    options.ConnectionMultiplexerFactory = () => Task.FromResult(connection)
+            .Configure<IServiceProvider>(
+                (options, serviceProvider) =>
+                    options.ConnectionMultiplexerFactory = () =>
+                        Task.FromResult(
+                            serviceProvider.GetRequiredService<IConnectionMultiplexer>()
+                        )
             );
         return services;
     }

--- a/examples/LeaderElectionTester/README.md
+++ b/examples/LeaderElectionTester/README.md
@@ -5,9 +5,8 @@ this repository.
 
 When you run multiple instances of the app:
 
-- only one instance becomes leader
-- only the leader runs the leader-only work
-- leadership transfers automatically when the current leader stops
+- exactly one instance becomes leader and periodically runs "leader work"
+- leadership automatically transfers to another instance when the current leader stops
 
 ## What This Example Uses
 
@@ -35,23 +34,64 @@ See below for examples.
 ## Prerequisites
 
 - .NET SDK that supports `net10.0`, e.g. .NET 10 SDK
-- One backing store running locally (Redis, Azurite, MinIO, or Postgres)
+- A compatible container runtime, such as Docker.
 
-## Start A Backing Store
+## Running With Aspire (Recommended)
 
-### Redis (for Redis, DistributedCache, FusionCache)
+The `LeaderElectionTester.AppHost` project orchestrates the infrastructure automatically using .NET
+Aspire. This is the recommended way to run the example, as it provides a unified experience and
+dashboard for viewing logs across multiple tester instances.
+
+From the repository root:
+
+```bash
+cd examples/LeaderElectionTester.AppHost
+dotnet run
+```
+
+This starts Redis and two tester instances by default. To use a different backing store, pass
+`LeaderElectionType` as a command-line argument:
+
+```bash
+dotnet run -- LeaderElectionType=Redis
+dotnet run -- LeaderElectionType=DistributedCache
+dotnet run -- LeaderElectionType=FusionCache
+dotnet run -- LeaderElectionType=BlobStorage
+dotnet run -- LeaderElectionType=S3
+dotnet run -- LeaderElectionType=Postgres
+```
+
+You can also adjust the number of tester instances using the `TesterCount` setting. For example, to
+start 5 tester instances using Postgres:
+
+```bash
+dotnet run -- LeaderElectionType=Postgres TesterCount=5
+```
+
+You may also set these values via `appsettings.json` inside the AppHost project.
+
+The Aspire dashboard (shown in the terminal on startup) lets you view logs from all tester instances
+side-by-side.
+
+## Running Standalone (Without Aspire)
+
+You can also run the tester directly against manually-started infrastructure.
+
+### Start A Backing Store
+
+#### Redis (for Redis, DistributedCache, FusionCache)
 
 ```bash
 docker run --name leader-election-redis -p 6379:6379 -d redis:7
 ```
 
-### Azurite (for BlobStorage)
+#### Azurite (for BlobStorage)
 
 ```bash
 docker run --name leader-election-azurite -p 10000:10000 -d mcr.microsoft.com/azure-storage/azurite:latest azurite --skipApiVersionCheck --loose --blobPort 10000 --blobHost 0.0.0.0
 ```
 
-### MinIO (for S3)
+#### MinIO (for S3)
 
 ```bash
 docker run --name leader-election-minio -p 9000:9000 -p 9001:9001 -e MINIO_ROOT_USER=accessKey -e MINIO_ROOT_PASSWORD=secretKey -d minio/minio server /data --console-address ":9001"
@@ -60,13 +100,13 @@ docker run --name leader-election-minio -p 9000:9000 -p 9001:9001 -e MINIO_ROOT_
 **Important:** Log into the MinIO console (<http://localhost:9001>) and create the `my-app-locks`
 bucket (or modify the example to use a existing bucket name).
 
-### PostgreSQL (for Postgres)
+#### PostgreSQL (for Postgres)
 
 ```bash
 docker run --name leader-election-postgres -p 5432:5432 -e POSTGRES_DB=mydb -e POSTGRES_USER=myuser -e POSTGRES_PASSWORD=mypassword -d postgres:17
 ```
 
-## Build
+### Build
 
 From the `./examples/LeaderElectionTester` directory, build the app:
 
@@ -75,7 +115,7 @@ cd ./examples/LeaderElectionTester
 dotnet build
 ```
 
-## Run The Example
+### Run The Example (Standalone)
 
 From the `./examples/LeaderElectionTester` directory, run one instance:
 
@@ -97,20 +137,15 @@ dotnet run --no-build -- LeaderElectionType=S3
 dotnet run --no-build -- LeaderElectionType=Postgres
 ```
 
-You can also set it via environment variable:
-
-```powershell
-$env:LeaderElectionType = "Redis"
-dotnet run
-```
+You can also set it via `appsettings.json` in the LeaderElectionTester project.
 
 ## Observe Leadership Transfer
 
-1. Open two terminals.
-2. Start the app in both terminals (same LeaderElection type).
-3. Watch logs: one instance should report it is leader and run leader work.
-4. Stop the leader instance.
-5. The other instance should become leader shortly after.
+1. Start two or more instances of the ElectionLeaderTester app using the same LeaderElectionType
+   settings, e.g., Redis.
+2. Watch logs: one instance will report that it is leader.
+3. Stop or kill the leader instance (Ctrl+C).
+4. One of the remaining instances will become leader shortly after.
 
 ## Notes
 

--- a/examples/LeaderElectionTester/README.md
+++ b/examples/LeaderElectionTester/README.md
@@ -40,42 +40,40 @@ See below for examples.
 
 The `LeaderElectionTester.AppHost` project orchestrates the infrastructure automatically using .NET
 Aspire. This is the recommended way to run the example, as it provides a unified experience and
-dashboard for viewing logs across multiple tester instances.
+dashboard for viewing logs of all the running instances.
 
 From the repository root:
 
 ```bash
-cd examples/LeaderElectionTester.AppHost
-dotnet run
+./build.ps1 runExample
 ```
 
-This starts Redis and two tester instances by default. To use a different backing store, pass
-`LeaderElectionType` as a command-line argument:
+This builds the example project then creates a Redis container and two example application
+instances. To use a different LeaderElection type, pass it as a command-line argument. For example:
 
 ```bash
-dotnet run -- LeaderElectionType=Redis
-dotnet run -- LeaderElectionType=DistributedCache
-dotnet run -- LeaderElectionType=FusionCache
-dotnet run -- LeaderElectionType=BlobStorage
-dotnet run -- LeaderElectionType=S3
-dotnet run -- LeaderElectionType=Postgres
+./build.ps1 runExample -- redis # same as above
+./build.ps1 runExample -- blob # or 'BlobStorage'
+./build.ps1 runExample -- s3
+./build.ps1 runExample -- postgres
+./build.ps1 runExample -- dc # or 'DistributedCache'
+./build.ps1 runExample -- fc # or 'FusionCache'
 ```
 
-You can also adjust the number of tester instances using the `TesterCount` setting. For example, to
-start 5 tester instances using Postgres:
+You can also adjust the number of example application instances using the `-count` parameter. For
+example, to start 5 instances using Postgres:
 
 ```bash
-dotnet run -- LeaderElectionType=Postgres TesterCount=5
+  ./build.ps1 runExample -- postgres -count 5
 ```
 
-You may also set these values via `appsettings.json` inside the AppHost project.
-
-The Aspire dashboard (shown in the terminal on startup) lets you view logs from all tester instances
-side-by-side.
+The Aspire dashboard (click the "dashboard" link in the console output) lets you view logs from all
+example application instances side-by-side. You can stop and start individual instances to see
+leadership transfer in action.
 
 ## Running Standalone (Without Aspire)
 
-You can also run the tester directly against manually-started infrastructure.
+You can also run the tester directly against manually configured infrastructure.
 
 ### Start A Backing Store
 
@@ -106,46 +104,27 @@ bucket (or modify the example to use a existing bucket name).
 docker run --name leader-election-postgres -p 5432:5432 -e POSTGRES_DB=mydb -e POSTGRES_USER=myuser -e POSTGRES_PASSWORD=mypassword -d postgres:17
 ```
 
-### Build
-
-From the `./examples/LeaderElectionTester` directory, build the app:
-
-```bash
-cd ./examples/LeaderElectionTester
-dotnet build
-```
-
 ### Run The Example (Standalone)
 
-From the `./examples/LeaderElectionTester` directory, run one instance:
-
 ```bash
-cd ./examples/LeaderElectionTester
-dotnet run --no-build
+./build.ps1 runExample -- -NoAspire
 ```
 
-This defaults to `LeaderElectionType=Redis`.
-
-Run a specific LeaderElection type:
+This starts a single example application instance running Redis leader election. To use a different
+leader election type, pass it as a command-line argument. For example:
 
 ```bash
-dotnet run --no-build -- LeaderElectionType=Redis
-dotnet run --no-build -- LeaderElectionType=DistributedCache
-dotnet run --no-build -- LeaderElectionType=FusionCache
-dotnet run --no-build -- LeaderElectionType=BlobStorage
-dotnet run --no-build -- LeaderElectionType=S3
-dotnet run --no-build -- LeaderElectionType=Postgres
+./build.ps1 runExample -- -NoAspire redis
+./build.ps1 runExample -- -NoAspire blob # or 'BlobStorage'
+./build.ps1 runExample -- -NoAspire s3
+./build.ps1 runExample -- -NoAspire postgres
+./build.ps1 runExample -- -NoAspire dc # or 'DistributedCache'
+./build.ps1 runExample -- -NoAspire fc # or 'FusionCache'
 ```
 
-You can also set it via `appsettings.json` in the LeaderElectionTester project.
-
-## Observe Leadership Transfer
-
-1. Start two or more instances of the ElectionLeaderTester app using the same LeaderElectionType
-   settings, e.g., Redis.
-2. Watch logs: one instance will report that it is leader.
-3. Stop or kill the leader instance (Ctrl+C).
-4. One of the remaining instances will become leader shortly after.
+Run the command in multiple terminals to start multiple instances. Each instance will log whether it
+is the leader or not. Stop the leader instance (Ctrl+C) to see leadership transfer in the remaining
+instances.
 
 ## Notes
 

--- a/examples/LeaderElectionTester/appsettings.json
+++ b/examples/LeaderElectionTester/appsettings.json
@@ -1,4 +1,6 @@
 {
+  "LeaderElectionType": "Redis", // default leader election mechanism to use. Can be overridden via command line or environment variable.
+
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/scripts/PSTaskFramework/BuildHelpers/BuildHelpers.psm1
+++ b/scripts/PSTaskFramework/BuildHelpers/BuildHelpers.psm1
@@ -133,9 +133,12 @@ function Invoke-Shell {
         # You typically do not use this parameter directly since PowerShell will automatically
         # add any unrecognized arguments to this parameter.
         [Parameter(ValueFromRemainingArguments)]
-        [string[]] $CommandArgs,
+        [ValidateNotNull()]
+        [string[]] $CommandArgs = @(),
 
         # An array of exit codes that are considered successful. Defaults to 0.
+        # An empty array means to ignore the exit code (i.e. consider all exit codes successful).
+        [ValidateNotNull()]
         [int[]] $AllowedExitCodes = @(0)
     )
 
@@ -149,7 +152,7 @@ function Invoke-Shell {
     $PSNativeCommandUseErrorActionPreference = $false # we'll handle errors ourselves
     & $cmdPath @CommandArgs
 
-    if ($global:LASTEXITCODE -notin $AllowedExitCodes) {
+    if ($AllowedExitCodes.Count -gt 0 -and $global:LASTEXITCODE -notin $AllowedExitCodes) {
         if ($ErrorActionPreference -ne 'Ignore') {
             Write-Error -Exception "Command failed with exit code $global:LASTEXITCODE ($cmdText)." `
                 -CategoryActivity 'Invoke-Shell' -CategoryReason 'Non-zero exit code' -CategoryTargetName $Command
@@ -157,12 +160,7 @@ function Invoke-Shell {
     }
 }
 
-$exportModuleMemberParams = @{
-    Function = @(
-        'Test-Administrator'
-        'Assert-AppExists'
-        'Invoke-Shell'
-    )
-}
-
-Export-ModuleMember @exportModuleMemberParams
+Export-ModuleMember -Function `
+    'Test-Administrator', `
+    'Assert-AppExists', `
+    'Invoke-Shell'

--- a/scripts/PSTaskFramework/BuildHelpers/BuildHelpers.psm1
+++ b/scripts/PSTaskFramework/BuildHelpers/BuildHelpers.psm1
@@ -34,6 +34,37 @@ function Test-Administrator {
     }
 }
 
+function assertAppExists {
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string] $AppPath,
+        [string] $AppTitle,
+        [switch] $PassThru
+    )
+
+    # Set the ErrorActionPreference to 'Stop' if not explicitly specified.
+    if (!$PSBoundParameters.ContainsKey('ErrorAction')) {
+        $ErrorActionPreference = 'Stop'
+    }
+
+    # When multiple commands with the same name are found, Get-Command returns
+    # them in execution precedence order. So take the first one
+    $cmd = Get-Command $AppPath -CommandType Application -ea Ignore -TotalCount 1
+    if (!$cmd) {
+        if ($ErrorActionPreference -ne 'Ignore') {
+            $appName = $AppTitle ? "$AppTitle ($AppPath)" : $AppPath
+            Write-Error -Exception "$appName not found. Please bootstrap first using './build.ps1 bootstrap'." `
+                -CategoryActivity 'Assert-AppExists' -CategoryReason 'App not found' -CategoryTargetName $AppPath
+        }
+        return
+    }
+    if ($PassThru) {
+        return $cmd.Path
+    }
+}
+
 function Assert-AppExists {
     <#
     .DESCRIPTION
@@ -61,25 +92,8 @@ function Assert-AppExists {
         # If specified, the cmdlet will return the full path to the application if it exists.
         [switch] $PassThru
     )
-    # Set the ErrorActionPreference to 'Stop' if not explicitly specified.
-    if (!$PSBoundParameters.ContainsKey('ErrorAction')) {
-        $ErrorActionPreference = 'Stop'
-    }
-
-    # When multiple commands with the same name are found, Get-Command returns
-    # them in execution precedence order. So take the first one
-    $cmd = Get-Command $AppPath -CommandType Application -ea Ignore -TotalCount 1
-    if (!$cmd) {
-        if ($ErrorActionPreference -ne 'Ignore') {
-            $appName = $AppTitle ? "$AppTitle ($AppPath)" : $AppPath
-            Write-Error -Exception "$appName not found. Please bootstrap first using './build.ps1 bootstrap'." `
-                -CategoryActivity 'Assert-AppExists' -CategoryReason 'App not found' -CategoryTargetName $AppPath
-        }
-        return
-    }
-    if ($PassThru) {
-        return $cmd.Path
-    }
+    & $PSScriptRoot/../syncCallerPreferences.ps1 $MyInvocation -PreferencesToSync ErrorAction
+    assertAppExists @PSBoundParameters
 }
 
 function Invoke-Shell {
@@ -125,7 +139,9 @@ function Invoke-Shell {
         [int[]] $AllowedExitCodes = @(0)
     )
 
-    $cmdPath = Assert-AppExists $Command -PassThru
+    & $PSScriptRoot/../syncCallerPreferences.ps1 $MyInvocation -PreferencesToSync ErrorAction, InformationAction
+
+    $cmdPath = assertAppExists $Command -PassThru
     $cmdText = Protect-Secret "$(ConvertTo-PSString $cmdPath) $(ConvertTo-CommandArg $CommandArgs)"
     Write-Information "$($PSStyle.Dim)>> $cmdText$($PSStyle.Reset)"
 

--- a/scripts/PSTaskFramework/InstallHelpers/InstallHelpers.psm1
+++ b/scripts/PSTaskFramework/InstallHelpers/InstallHelpers.psm1
@@ -35,6 +35,8 @@ function Get-WellKnownAppInfo {
         [string[]] $Name = @('*')
     )
     process {
+        & $PSScriptRoot/../syncCallerPreferences.ps1 $MyInvocation -PreferencesToSync ErrorAction
+
         switch ($Name) {
             { $_.IndexOfAny([char[]]'*?[') -ge 0 } {
                 $n = $_
@@ -622,6 +624,8 @@ function Install-PackageManager {
         [string[]] $PackageManager
     )
 
+    & $PSScriptRoot/../syncCallerPreferences.ps1 $MyInvocation
+
     $PackageManager = @(
         $PackageManager |
         ForEach-Object {
@@ -808,6 +812,8 @@ function Install-RequiredApp {
         [switch] $InstallPackageManagers
     )
 
+    & $PSScriptRoot/../syncCallerPreferences.ps1 $MyInvocation
+
     # Validate that all apps have installation information, either provided
     # directly or via the well-known apps list...
     $copiedAppsToInstall = [ordered]@{}
@@ -964,6 +970,8 @@ function Install-PowerShellModule {
         [ValidateSet('CurrentUser', 'AllUsers')]
         [string]$Scope = 'CurrentUser'
     )
+
+    & $PSScriptRoot/../syncCallerPreferences.ps1 $MyInvocation
 
     function tryGetModule([string]$Name, [version]$MinimumVersion) {
         Get-Module -Name $Name -ListAvailable -ea Ignore |

--- a/scripts/PSTaskFramework/InstallHelpers/InstallHelpers.psm1
+++ b/scripts/PSTaskFramework/InstallHelpers/InstallHelpers.psm1
@@ -32,6 +32,7 @@ function Get-WellKnownAppInfo {
         # Defaults to '*'.
         [Parameter(Position = 0, ValueFromPipeline, ValueFromPipelineByPropertyName)]
         [SupportsWildcards()]
+        [ValidateNotNullOrEmpty()]
         [string[]] $Name = @('*')
     )
     process {
@@ -1001,14 +1002,9 @@ function Install-PowerShellModule {
     }
 }
 
-$exportModuleMemberParams = @{
-    Function = @(
-        'Install-PowerShellModule'
-        'Get-WellKnownAppInfo'
-        'Install-PackageManager'
-        'Get-PackageManager'
-        'Install-RequiredApp'
-    )
-}
-
-Export-ModuleMember @exportModuleMemberParams
+Export-ModuleMember -Function `
+    Install-PowerShellModule, `
+    Get-WellKnownAppInfo, `
+    Install-PackageManager, `
+    Get-PackageManager, `
+    Install-RequiredApp

--- a/scripts/PSTaskFramework/PSArgs/PSArgs.psm1
+++ b/scripts/PSTaskFramework/PSArgs/PSArgs.psm1
@@ -106,11 +106,6 @@ function ConvertTo-CommandArg {
     }
 }
 
-$exportModuleMemberParams = @{
-    Function = @(
-        'ConvertTo-PSString'
-        'ConvertTo-CommandArg'
-    )
-}
-
-Export-ModuleMember @exportModuleMemberParams
+Export-ModuleMember -Function `
+    ConvertTo-PSString, `
+    ConvertTo-CommandArg

--- a/scripts/PSTaskFramework/PSTaskFramework.psd1
+++ b/scripts/PSTaskFramework/PSTaskFramework.psd1
@@ -39,7 +39,11 @@
     # NestedModules        = @()
 
     # Modules that must be imported into the global environment prior to importing this module
-    # RequiredModules      = @()
+    RequiredModules      = @(
+        './BuildHelpers/BuildHelpers.psm1'
+        './Secrets/Secrets.psm1'
+        './PSArgs/PSArgs.psm1'
+    )
 
     # Assemblies that must be loaded prior to importing this module
     # RequiredAssemblies = @()
@@ -55,10 +59,13 @@
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport    = @(
-        'Reset-TaskFramework'
+        'Initialize-TaskFramework'
+        'Get-TaskFrameworkContext'
         'Task'
         'Get-TaskFrameworkTasks'
         'Invoke-TaskFramework'
+        'Get-TaskFrameworkHelp'
+        'Add-TaskFrameworkDefaultTasks'
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/scripts/PSTaskFramework/PSTaskFramework.psm1
+++ b/scripts/PSTaskFramework/PSTaskFramework.psm1
@@ -1,136 +1,341 @@
 <#
 .DESCRIPTION
     Task management helpers for PowerShell.
+
+    Q: Why is the PSTaskFramework implemented as a PowerShell module?
+    A: It ensures that tasks defined in the user's build script have access to all variables
+       and functions in the build script.
+
+       When a script block (SB) is invoked, PowerShell uses the SB's Module property to determine
+       its execution context (session state and scope):
+       - If the Module property is the current module (or is unset), then the script block will
+         be executed in the current context (in a new child scope when using the call operator).
+       - Otherwise the script block will be executed using the session state of the module it was
+         defined in. The exact scope within the session depends on the call stack: PowerShell
+         will search the call stack for the nearest (most recent) stack frame belonging to the
+         SB's module and will execute the SB in a child scope of that frame. If a matching frame
+         is not found, the nearest global-scope frame is used.
+       This has a few critically important implications:
+       1. SBs _defined_ in other modules will be executed in the context (and nearest scope!)
+          of the module/script they were defined in. For external tasks, that will be the scope
+          where the `Invoke-TaskFramework` function is called (usually script scope), thus they
+          will have access to all variables and functions defined in their script, including
+          `$TaskContext` returned by `Initialize-TaskFramework`.
+       2. SBs _defined_ in this module do have access to this module's session state. Thus tasks
+          defined in this module will have access to all stack variables going back to the
+          `Invoke-TaskFramework` invocation, including `$TaskContext`.
+       3. SBs without a module session (e.g. created via `[scriptblock]::Create("...")`) will be
+          executed as if they were defined in this module (see above).
+
 .NOTES
     SPDX-License-Identifier: Unlicense
     Source: http://github.com/mrfootoyou/pstaskframework
 #>
 #Requires -Version 7.4
-# spell:ignore psargs,targs
+# spell:ignore maml
 
 param()
 
+class TaskContext {
+    # A hashtable for storing arbitrary information.
+    [hashtable]$State = @{}
+
+    # Details about the build script.
+    [System.IO.FileInfo]$BuildScriptPath
+    [string]$TaskNameArgName = 'TaskName'
+    [string]$TaskArgsArgName = 'TaskArgs'
+
+    # All defined tasks. The keys are task names.
+    [ordered]$AllTasks = [ordered]@{}
+    [bool]$AllTasksSorted = $true
+    [string]$HelpTaskName
+
+    # Execution metadata for the current run.
+    [System.IO.DirectoryInfo]$WorkingDirectory
+    [string[]]$TasksToExecute = @()
+    [bool]$SkipDependencies
+    [Nullable[DateTime]]$Start
+    [Nullable[TimeSpan]]$Duration
+    [Nullable[int]]$ExitCode
+    [System.Management.Automation.ErrorRecord]$Error
+
+    # Task execution metadata. This is updated as tasks are executed.
+    [TaskDefinition]$CurrentTask
+    [ordered]$Results = [ordered]@{}
+}
+
+# The definition of a task. Store the task metadata and action.
 class TaskDefinition {
     [string]$Name
-    [string]$Description
-    [string[]]$DependsOn
-    [ScriptBlock]$Action
+    [string]$Description = ''
+    [string[]]$DependsOn = @()
     [int[]]$AllowedExitCodes = @(0)
+    [ScriptBlock]$Action
 
     [string] ToString() { return $this.Name }
+}
 
-    static hidden [ordered] $AllTasks = [ordered]@{}
-    static hidden [bool] $TasksSorted = $true
+# The result of a task execution. Stores the execution metadata and result.
+class TaskResult {
+    [DateTime]$Start = [DateTime]::UtcNow
+    [TaskArgs]$TaskArgs
+    [Nullable[TimeSpan]]$Duration
+    [Nullable[int]]$ExitCode
+    [System.Management.Automation.ErrorRecord]$Error
+}
 
-    static [void] Clear() {
-        [TaskDefinition]::AllTasks.Clear()
-        [TaskDefinition]::TasksSorted = $true
+# The arguments passed to a task. Stores the raw, bound, and unbound arguments.
+class TaskArgs {
+    [object[]]$Raw = @()
+    [System.Collections.IDictionary]$Bound = @{}
+    [object[]]$Unbound = @()
+}
+
+# The name of the external variable containing the current TaskContext object.
+# This is set when calling Initialize-TaskFramework and is used by Get-TaskFrameworkContext
+# to retrieve the callers TaskContext when it is not passed explicitly.
+# This is, unfortunately, global data, but should be okay as long as the callers always use
+# the same variable name, or do not interleave runs (it's hard to imagine what that would
+# even look like).
+$script:ExternalTaskContextVariableName = 'TaskContext'
+
+function Initialize-TaskFramework {
+    <#
+    .DESCRIPTION
+        Initializes the task framework by creating a new TaskContext object.
+
+        !IMPORTANT! The caller must save the returned object to a variable named `TaskContext`.
+        If this is not possible for some reason, then the replacement name must be specified
+        using the -TaskContextVariableName parameter.
+    #>
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([TaskContext])]
+    param(
+        # The path to the callers build script.
+        # Defaults to caller's `$MyInvocation.MyCommand.Path`.
+        [ValidateNotNullOrEmpty()]
+        [string]$BuildScriptPath,
+        # The name of the parameter used to specify the task name when invoking the build script.
+        # This is used for help generation. Defaults to 'TaskName'.
+        [ValidateNotNullOrEmpty()]
+        [string]$TaskNameArgName = 'TaskName',
+        # The name of the parameter used to specify task arguments when invoking the build script.
+        # This is used for help generation. Defaults to 'TaskArgs'.
+        [ValidateNotNullOrEmpty()]
+        [string]$TaskArgsArgName = 'TaskArgs',
+
+        # The name of the variable to save the TaskContext object to. Defaults to 'TaskContext'.
+        # Note that this function does _NOT_ create this variable. The caller's must do that,
+        # e.g. `$MyTaskContext = Initialize-TaskFramework -TaskContextVariableName 'MyTaskContext'`.
+        [ValidateNotNullOrEmpty()]
+        [string]$TaskContextVariableName = 'TaskContext'
+    )
+    & $PSScriptRoot/syncCallerPreferences.ps1 $MyInvocation
+
+    if (!$BuildScriptPath) {
+        $callersInvocation = $ExecutionContext.SessionState.Module.GetVariableFromCallersModule("MyInvocation")
+        if (!$callersInvocation.Value.MyCommand.Path) {
+            Write-Error -Exception "Could not determine caller's script path. Please provide the path via the -BuildScriptPath parameter."
+            return
+        }
+        $BuildScriptPath = $callersInvocation.Value.MyCommand.Path
+    }
+    if (!(Test-Path $BuildScriptPath -PathType Leaf)) {
+        Write-Error -Exception "The specified build script path '$BuildScriptPath' does not exist."
+        return
     }
 
-    static [void] AddTask([TaskDefinition]$task) {
-        if ([TaskDefinition]::AllTasks.Contains($task.Name)) {
-            throw "A task with the name '$($task.Name)' already exists."
-        }
-        [TaskDefinition]::AllTasks[$task.Name] = $task
-        [TaskDefinition]::TasksSorted = $false
+    $TaskContext = [TaskContext]@{
+        BuildScriptPath = Get-Item $BuildScriptPath -Force
+        TaskNameArgName = $TaskNameArgName
+        TaskArgsArgName = $TaskArgsArgName
     }
 
-    # Returns an ordered array of TaskDefinition objects corresponding to the specified task
-    # names and their dependencies (if $includeDependencies is specified). The tasks are returned
-    # in dependency order. For example, if taskA depends on taskB, then GetOrderedTasks('taskA', $true)
-    # will return an array with taskB first, followed by taskA.
-    static [TaskDefinition[]] GetOrderedTasks([string[]]$taskNames, [switch]$includeDependencies) {
-        # get all tasks in dependency order...
-        $orderedTaskMap = [TaskDefinition]::GetOrderedTasks()
+    # Save the name in a global variable so that Get-TaskFrameworkContext can retrieve it.
+    $script:ExternalTaskContextVariableName = $TaskContextVariableName
 
-        # get the set of all tasks to execute, including dependencies if specified.
-        $execTaskNames = @{}
-        $queue = [System.Collections.Generic.Queue[string]]::new($taskNames)
-        while ($queue.Count -gt 0) {
-            $taskName = $queue.Dequeue()
-            if ($execTaskNames.ContainsKey($taskName)) {
-                continue # already visited
-            }
-            $execTaskNames[$taskName] = $true
-            $task = $orderedTaskMap[$taskName]
-            if (-not $task) {
-                throw "Task '$taskName' not found."
-            }
-            if ($includeDependencies) {
-                foreach ($dep in $task.DependsOn) {
-                    $queue.Enqueue($dep)
-                }
-            }
-        }
+    return $TaskContext
+}
 
-        # Return the tasks in dependency order...
-        return @(
-            foreach ($task in $orderedTaskMap.Values) {
-                if ($execTaskNames.ContainsKey($task.Name)) {
-                    $task
-                }
-            }
-        )
+function Get-TaskFrameworkContext {
+    <#
+    .DESCRIPTION
+        Gets the current task framework context object.
+    #>
+    [OutputType([TaskContext])]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [string]$Name = $script:ExternalTaskContextVariableName
+    )
+
+    # First, try the current session state where it is always called 'TaskContext'...
+    # Get-Variable will also return variables defined in the global scope...
+    $TaskContextVar = Get-Variable -Name 'TaskContext' -ErrorAction Ignore
+    if ($TaskContextVar.Module -eq $ExecutionContext.SessionState.Module) {
+        $TaskContext = $TaskContextVar.Value
+    }
+    else {
+        $TaskContext = $null
     }
 
-    # Returns an ordered dictionary of all defined tasks, sorted in dependency order.
-    # The keys are task names and the values are TaskDefinition objects.
-    static [System.Collections.Specialized.IOrderedDictionary] GetOrderedTasks() {
-        if ([TaskDefinition]::TasksSorted) {
-            return [TaskDefinition]::AllTasks
-        }
+    # if not found, try from caller's session state...
+    if ($null -eq $TaskContext -and $ExecutionContext.SessionState.Module) {
+        $TaskContext = $ExecutionContext.SessionState.Module.GetVariableFromCallersModule($Name).Value
+    }
 
-        # Sort tasks in dependency order using a depth-first search.
-        # Preserve the original order of tasks as much as possible while ensuring that
-        # dependencies are always defined before the tasks that depend on them.
-        # This also detects circular dependencies.
-        $visited = @{}
-        function visit([TaskDefinition]$task) {
-            if ($visited.ContainsKey($task.Name)) {
-                # already visited this node; if we're visiting it again, we have a
-                # circular dependency
-                if ($visited[$task.Name] -eq 'visiting') {
-                    throw "Circular dependency detected at task '$($task.Name)'."
-                }
-                return
-            }
-            $visited[$task.Name] = 'visiting'
-            foreach ($dep in $task.DependsOn) {
-                $depTask = [TaskDefinition]::AllTasks[$dep]
-                if (-not $depTask) {
-                    throw "Dependency '$dep' of task '$($task.Name)' not found."
-                }
-                visit $depTask
-            }
-            $visited[$task.Name] = ''
-            $task
-        }
+    if ($null -eq $TaskContext) {
+        throw "Task context variable '$Name' not found. Make sure to define it in the build script, e.g., `$$Name = Initialize-TaskFramework."
+    }
+    if ($TaskContext -isnot [TaskContext]) {
+        throw "Task context variable '$Name' is not a TaskContext object. Make sure to define it in the build script, e.g., `$$Name = Initialize-TaskFramework."
+    }
 
-        $orderedTasks = @(
-            foreach ($task in [TaskDefinition]::AllTasks.Values) {
-                visit $task
-            }
-        )
+    # looks good!
+    return $TaskContext
+}
 
-        [TaskDefinition]::AllTasks.Clear()
-        foreach ($task in $orderedTasks) {
-            [TaskDefinition]::AllTasks[$task.Name] = $task
+function getTask {
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([TaskDefinition])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string]$TaskName,
+        [ValidateNotNull()]
+        [TaskContext]$TaskContext = (Get-TaskFrameworkContext)
+    )
+
+    if (!$TaskContext.AllTasks.Contains($TaskName)) {
+        Write-Error -Exception "Task '$TaskName' not found." -CategoryActivity 'Get task' -Category ObjectNotFound -TargetObject $TaskName
+        return
+    }
+    return $TaskContext.AllTasks[$TaskName]
+}
+
+function getAllOrderedTasks {
+    <#
+    .DESCRIPTION
+        Gets an ordered dictionary of all defined tasks, sorted in dependency order.
+        The keys are task names and the values are [TaskDefinition] objects.
+    .OUTPUTS
+        [System.Collections.Specialized.OrderedDictionary]
+        An ordered dictionary of all defined tasks, sorted in dependency order.
+    #>
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([System.Collections.Specialized.OrderedDictionary])]
+    param(
+        [ValidateNotNull()]
+        [TaskContext]$TaskContext = (Get-TaskFrameworkContext)
+    )
+
+    if ($TaskContext.AllTasksSorted -eq $true) {
+        return $TaskContext.AllTasks
+    }
+
+    # Sort tasks in dependency order using a depth-first search.
+    # Preserve the original order of tasks as much as possible while ensuring that
+    # dependencies are always defined before the tasks that depend on them.
+    # This also detects circular dependencies.
+    $visited = @{}
+    function visit([TaskDefinition]$task) {
+        if ($visited.ContainsKey($task.Name)) {
+            # already visited this node; if we're visiting it again, we have a
+            # circular dependency
+            if ($visited[$task.Name] -eq 'visiting') {
+                throw "Circular dependency detected at task '$($task.Name)'."
+            }
+            return
         }
-        [TaskDefinition]::TasksSorted = $true
-        return [TaskDefinition]::AllTasks
+        $visited[$task.Name] = 'visiting'
+        foreach ($dep in $task.DependsOn) {
+            $depTask = $TaskContext.AllTasks[$dep]
+            if (-not $depTask) {
+                throw "Dependency '$dep' of task '$($task.Name)' not found."
+            }
+            visit $depTask
+        }
+        $visited[$task.Name] = ''
+        $task
+    }
+
+    $orderedTasks = @(
+        foreach ($task in $TaskContext.AllTasks.Values) {
+            visit $task
+        }
+    )
+
+    $allTasks = [ordered]@{}
+    foreach ($task in $orderedTasks) {
+        $allTasks[$task.Name] = $task
+    }
+
+    $TaskContext.AllTasks = $allTasks
+    $TaskContext.AllTasksSorted = $true
+    return $allTasks
+}
+
+function Get-TaskFrameworkTasks {
+    <#
+    .DESCRIPTION
+        Gets all tasks defined in the task framework in dependency order. The returned
+        objects are of type TaskDefinition, which has the following properties:
+            - Name: The name of the task.
+            - Description: A brief description of the task.
+            - DependsOn: An array of task names that this task depends on.
+            - Action: The script block to execute when the task is invoked.
+
+        This can be useful for listing available tasks or for debugging task definitions.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessage('PSUseSingularNouns', '', Justification = 'Tasks is plural because it manages multiple tasks.')]
+    [CmdletBinding(PositionalBinding = $false)]
+    param(
+        # The task context hashtable. Defaults to the current task context returned by Get-TaskFrameworkContext.
+        [ValidateNotNull()]
+        [TaskContext]$TaskContext = (Get-TaskFrameworkContext)
+    )
+    & $PSScriptRoot/syncCallerPreferences.ps1 $MyInvocation -PreferencesToSync ErrorAction
+    try {
+        return (getAllOrderedTasks @PSBoundParameters).Values
+    }
+    catch {
+        Write-Error -Exception $_ -CategoryActivity 'Get-TaskFrameworkTasks' -Category InvalidOperation
     }
 }
 
-function Reset-TaskFramework {
+function addTask {
     <#
     .DESCRIPTION
-        Resets the state of the task framework by clearing all defined tasks. This can be useful
-        to ensure a clean slate when invoking multiple tasks or when reloading the task framework.
+        Private implementation of the `Task` function that adds a task to the task framework.
+        This is separated from the public Task function to allow for easier error handling and
+        to avoid syncing caller preferences multiple times when adding multiple tasks.
     #>
-    [Diagnostics.CodeAnalysis.SuppressMessage('PSUseShouldProcessForStateChangingFunctions', '', Justification = 'Resetting the task framework is a state change, but it is not something that users would typically want to confirm.')]
     [CmdletBinding()]
-    param()
-    [TaskDefinition]::Clear()
+    param (
+        [Parameter(Mandatory, Position = 0)]
+        [string]$Name,
+        [Parameter(Mandatory, Position = 1)]
+        [AllowNull()]
+        [ScriptBlock]$Action,
+        [ValidateNotNull()]
+        [string]$Description,
+        [ValidateNotNull()]
+        [string[]]$DependsOn = @(),
+        [ValidateNotNull()]
+        [int[]]$AllowedExitCodes = @(0),
+        [ValidateNotNull()]
+        [TaskContext]$TaskContext = (Get-TaskFrameworkContext)
+    )
+    if ($TaskContext.AllTasks.Contains($Name)) {
+        Write-Error -Exception "A task with the name '$Name' already exists." -CategoryActivity 'Add task' -Category ResourceExists -TargetObject $Name
+        return
+    }
+    $TaskContext.AllTasks[$Name] = [TaskDefinition]@{
+        Name             = $Name
+        Description      = $Description
+        DependsOn        = $DependsOn
+        AllowedExitCodes = $AllowedExitCodes
+        Action           = $Action
+    }
+    $TaskContext.AllTasksSorted = $false
 }
 
 function Task {
@@ -152,42 +357,372 @@ function Task {
         [ScriptBlock]$Action,
 
         # A brief description of the task.
+        [ValidateNotNull()]
         [string]$Description,
 
         # An array of task names that this task depends on. These tasks will be executed
         # before this task unless -SkipDependencies is specified when invoking.
+        [ValidateNotNull()]
         [string[]]$DependsOn = @(),
 
         # An array of allowed exit codes for the task. If the task completes with an
         # exit code that is not in this array, it will be considered a failure. Pass an
         # empty array to ignore the exit code. Defaults to 0.
-        [int[]]$AllowedExitCodes = @(0)
+        [ValidateNotNull()]
+        [int[]]$AllowedExitCodes = @(0),
+
+        # The task context hashtable. Defaults to the current task context returned by Get-TaskFrameworkContext.
+        [ValidateNotNull()]
+        [TaskContext]$TaskContext = (Get-TaskFrameworkContext)
     )
-    [TaskDefinition]::AddTask(@{
-            Name             = $Name
-            Description      = $Description
-            DependsOn        = $DependsOn
-            Action           = $Action
-            AllowedExitCodes = $AllowedExitCodes
-        })
+    & $PSScriptRoot/syncCallerPreferences.ps1 $MyInvocation -PreferencesToSync ErrorAction, InformationAction
+    addTask @PSBoundParameters
 }
 
-function Get-TaskFrameworkTasks {
+function Add-TaskFrameworkDefaultTasks {
     <#
     .DESCRIPTION
-        Gets all tasks defined in the task framework in dependency order. The returned
-        objects are of type TaskDefinition, which has the following properties:
-            - Name: The name of the task.
-            - Description: A brief description of the task.
-            - DependsOn: An array of task names that this task depends on.
-            - Action: The script block to execute when the task is invoked.
-
-        This can be useful for listing available tasks or for debugging task definitions.
+        Adds default tasks to the task framework, such as 'list' and 'help'.
     #>
-    [Diagnostics.CodeAnalysis.SuppressMessage('PSUseSingularNouns', '', Justification = 'Tasks is plural because it manages multiple tasks.')]
+    [Diagnostics.CodeAnalysis.SuppressMessage('PSUseSingularNouns', '')]
+    [CmdletBinding(PositionalBinding = $false)]
+    param(
+        # The tasks to include.
+        [Parameter(Position = 0)]
+        [ValidateSet('help', 'list', 'null')]
+        [string[]] $Include = @('help', 'list'),
+
+        # A hashtable specifying custom names for the default tasks.
+        [ValidateNotNull()]
+        [hashtable] $NameMap = @{},
+
+        # The task context hashtable. Defaults to the current task context returned by Get-TaskFrameworkContext.
+        [ValidateNotNull()]
+        [TaskContext]$TaskContext = (Get-TaskFrameworkContext)
+
+    )
+    & $PSScriptRoot/syncCallerPreferences.ps1 $MyInvocation -PreferencesToSync WarningAction, Verbose
+
+    switch ($Include.where{ !(getTask ($NameMap[$_] ?? $_) -ea Ignore -TaskContext $TaskContext) }) {
+        'null' {
+            $name = $NameMap[$_] ?? $_
+            Write-Verbose "Including default 'null' task as '$name'."
+            addTask $name -Description 'An empty task that does nothing.' -TaskContext $TaskContext -Action $null
+        }
+        'list' {
+            $name = $NameMap[$_] ?? $_
+            Write-Verbose "Including default 'list' task as '$name'."
+            addTask $name -Description 'List all defined tasks' -TaskContext $TaskContext {
+                <#
+                .DESCRIPTION
+                    Lists all tasks defined in the task framework along with their descriptions
+                    and dependencies.
+                #>
+                Get-TaskFrameworkTasks |
+                Format-Table Name, Description, DependsOn -AutoSize |
+                Out-Host
+            }
+        }
+        'help' {
+            $name = $NameMap[$_] ?? $_
+            Write-Verbose "Including default 'help' task as '$name'."
+            $TaskContext.HelpTaskName = $name
+            addTask $name -Description 'Show detailed help for a task' -TaskContext $TaskContext {
+                <#
+                .DESCRIPTION
+                    Generates help for a task defined in the task framework. If a task name is not
+                    specified, it generates help for the build script itself.
+                .EXAMPLE
+                    PS> .\build.ps1 help
+
+                    Shows help for the build script.
+                .EXAMPLE
+                    PS> .\build.ps1 help test -full
+
+                    Shows detailed help for the 'test' task, including its description, parameters,
+                    usage, dependencies, and examples.
+                .EXAMPLE
+                    PS> .\build.ps1 help test -examples
+
+                    Shows the 'test' task examples.
+                #>
+                [CmdletBinding(PositionalBinding = $false)]
+                param(
+                    # The name of the task to show help for. If not specified, shows help for the build script itself.
+                    [Parameter(Position = 0)]
+                    [string]$TaskName,
+
+                    # Displays the entire help article for a cmdlet. Full includes parameter descriptions and attributes,
+                    # examples, input and output object types, and additional notes.
+                    [Parameter(ParameterSetName = 'Full')]
+                    [switch]$Full,
+
+                    # Adds parameter descriptions and examples to the basic help display.
+                    [Parameter(ParameterSetName = 'Detailed', Mandatory)]
+                    [switch]$Detailed,
+
+                    # Displays only the name, synopsis, and examples.
+                    [Parameter(ParameterSetName = 'Examples', Mandatory)]
+                    [switch]$Examples,
+
+                    # When specified, the help output will not be paged. By default, the help output is paged
+                    # if it exceeds the console height.
+                    [switch]$NoPaging
+                )
+
+                $getHelpArgs = [hashtable]$PSBoundParameters
+                $null = $getHelpArgs.Remove('TaskName')
+                $null = $getHelpArgs.Remove('NoPaging')
+                $help = Get-TaskFrameworkHelp -TaskName $TaskName -GetHelpArgs $getHelpArgs
+
+                if ($NoPaging) { $help | Out-Host }
+                elseif ($IsWindows -and (Get-Command 'more' -ErrorAction Ignore)) { $help | more }
+                elseif (!$IsWindows -and (Get-Command 'less' -ErrorAction Ignore)) { $help | less }
+                else { $help | Out-Host -Paging }
+            }
+        }
+        default {
+            Write-Warning "Unknown default task requested: '$_'."
+        }
+    }
+}
+
+function Get-TaskFrameworkHelp {
+    <#
+    .DESCRIPTION
+        Generates help for a task defined in the task framework. If a task name is not
+        specified, it generates help for the build script itself.
+
+        The help output is generated by merging the help info from the build script and the
+        task action. This allows the task help to include information about the build script's
+        parameters and syntax, which is relevant when invoking the task via the build script.
+    .OUTPUTS
+        [System.String]
+        The formatted help string.
+    #>
     [CmdletBinding()]
-    param()
-    return [TaskDefinition]::GetOrderedTasks().Values
+    [OutputType([string])]
+    param(
+        # The name of the task to show help for. If not specified, shows help for the build script itself.
+        [string]$TaskName,
+
+        # The arguments to pass to Get-Help when retrieving help info for the build script and task action.
+        [ValidateNotNull()]
+        [hashtable]$GetHelpArgs = @{},
+
+        # The task context hashtable. Defaults to the current task context returned by Get-TaskFrameworkContext.
+        [ValidateNotNull()]
+        [TaskContext]$TaskContext = (Get-TaskFrameworkContext)
+    )
+    & $PSScriptRoot/syncCallerPreferences.ps1 $MyInvocation
+
+    $helpTaskName = $TaskContext.HelpTaskName ?? $TaskContext.CurrentTask.Name ?? 'help'
+    $buildScriptPath = $TaskContext.BuildScriptPath ?? (Get-Item './build.ps1')
+    $taskNameArgName = $TaskContext.TaskNameArgName ?? 'TaskName'
+    $taskArgsArgName = $TaskContext.TaskArgsArgName ?? 'TaskArgs'
+
+    # Get the help info for the build script. We will merge it's parameters and syntax
+    # with the task help info to produce the final help output.
+    $buildHelp = Get-Help -Name $buildScriptPath @GetHelpArgs
+    if (!$buildHelp) { return }
+
+    if (-not ($buildHelp.parameters.parameter.name -eq $taskNameArgName)) {
+        Write-Warning "Parameter '$taskNameArgName' was not found in the build script. Specify the actual parameter name in Initialize-TaskFramework."
+    }
+    if (-not ($buildHelp.parameters.parameter.name -eq $taskArgsArgName)) {
+        Write-Warning "Parameter '$taskArgsArgName' was not found in the build script. Specify the actual parameter name in Initialize-TaskFramework."
+    }
+
+    function normalizeText([string]$text) {
+        # trim and normalize line endings to CR to simplify regexes
+        $text = $text -creplace '\s*?\r?\n', "`n"
+        return $text
+    }
+    function finalizeText([string]$text) {
+        # Assumes CR line endings.
+        # remove empty section
+        $text = $text -creplace '(?m)^(SYNOPSIS|DESCRIPTION|INPUTS|OUTPUTS|RELATED LINKS)\n\n+', ''
+        # collapse consecutive empty lines
+        $text = $text -creplace '\n\n\n+', "`n`n"
+        # trim trailing empty lines to at most 1
+        $text = $text -creplace '\n\n$', "`n"
+        # convert to the environment's newline
+        $text = $text -creplace '\r?\n', [Environment]::NewLine
+        return $text
+    }
+
+    # If no task name specified, show the build script help
+    if (!$TaskName) {
+        $text = normalizeText ($buildHelp | Out-String)
+        return finalizeText $text
+    }
+
+    # Get the specified task...
+    $task = getTask $TaskName -TaskContext $TaskContext -ea Ignore
+    if (-not $task) {
+        throw "Task '$TaskName' not found."
+    }
+
+    $TaskName = $task.Name # use the canonical name
+    $taskDescription = $task.Description
+    if ($taskDescription) {
+        # ensure ends with a period
+        $taskDescription = $taskDescription -replace '\.\s*$', '.'
+    }
+    $taskAction = $task.Action ?? ([scriptblock]::Create("
+        <#
+        .DESCRIPTION
+            This is a `"meta-task`" that only serves as a grouping of dependencies.
+            No additional help is available for this task.
+        #>
+        param()"))
+
+    # Use the taskAction to generate a temporary function that we can call Get-Help on to generate the
+    # help info. We use a unique name to aid in regex replacements later.
+    $functionName = "_$([Guid]::NewGuid().ToString('N'))"
+    $tempModule = New-Module -ScriptBlock ([scriptblock]::Create("function $functionName {$taskAction.Ast.ParamBlock}"))
+    $taskHelp = Get-Help $functionName @GetHelpArgs
+    $tempModule | Remove-Module
+
+    # Fixup the help object...
+    function mamlParaTextItem($text) {
+        return [PSObject]@{ Text = $text; type = 'text' } |
+        Add-Member -TypeName 'MamlParaTextItem' -PassThru
+    }
+    function mamlParaText([string[]]$text) {
+        # must return an array of ParaTextItem
+        return , $text.ForEach{ mamlParaTextItem $_ }
+    }
+
+    # remove the ModuleName member
+    if ($taskHelp.ModuleName) {
+        $null = $taskHelp.PSObject.Members.Remove('ModuleName')
+    }
+
+    # fix the name
+    $taskHelp.details | Add-Member 'name' $TaskName -Force
+    $taskHelp | Add-Member 'Name' $TaskName -Force
+
+    # set Synopsis using the task description, if missing
+    if ($taskDescription) {
+        if (!$taskHelp.details.description) {
+            $taskHelp.details | Add-Member 'description' (mamlParaText $taskDescription) -Force
+        }
+        if (!$taskHelp.Synopsis) {
+            $taskHelp | Add-Member 'Synopsis' $taskDescription -Force
+        }
+    }
+
+    # merge the build script's parameters and syntax into the task's help...
+    $taskCommonParameters = $task.Action -and ($taskHelp.CommonParameters ?? $true)
+    $buildCommonParameters = $task.Action -and ($buildHelp.CommonParameters ?? $true)
+
+    $dashSwitch = [PSObject]@{
+        name          = '-'
+        description   = mamlParaText 'A meta-parameter used to separate build script parameters from task parameters.'
+        required      = $false
+        globbing      = $false
+        pipelineInput = $false
+        position      = 'named'
+    } | Add-Member -TypeName 'MamlCommandHelpInfo#parameter' -PassThru
+
+    # Update the description of the 'TaskName' parameter to indicate the value it should have to invoke the task.
+    foreach ($param in $buildHelp.parameters.parameter) {
+        if ($param.name -eq $taskNameArgName) {
+            $param.description = mamlParaText "The name of the task to execute. '$TaskName' in this case."
+            break
+        }
+    }
+
+    # Merge parameters:
+    # We omit the build script's 'TaskArgs' parameters since the actual task args are already included.
+    if ($null -eq $taskHelp.parameters) {
+        $taskHelp | Add-Member 'parameters' ([PSCustomObject]@{ parameter = @() } | Add-Member -TypeName 'ExtendedCmdletHelpInfo#parameters' -PassThru) -Force
+    }
+    if ($null -eq $taskHelp.parameters.parameter) {
+        $taskHelp.parameters | Add-Member 'parameter' @() -Force
+    }
+    $taskHelp.parameters.parameter = @(
+        $buildHelp.parameters.parameter.where{ $_.name -ne $taskArgsArgName }
+        if ($taskHelp.parameters.parameter.Count -or $taskCommonParameters) { $dashSwitch }
+        $taskHelp.parameters.parameter
+    )
+
+    # Merge Syntax:
+    # We omit the 'TaskName' parameter itself since the task name is fixed in this context.
+    # We only include those build script syntax items that include the 'TaskName' parameter
+    # since those are the ones relevant to invoking tasks.
+    $buildSyntaxItems = $buildHelp.syntax.syntaxItem.where{ $_.parameter.name -eq $TaskNameArgName }
+
+    if ($null -eq $taskHelp.syntax) {
+        $taskHelp | Add-Member 'syntax' ([PSCustomObject]@{ syntaxItem = @() }) -Force
+    }
+    if ($null -eq $taskHelp.syntax.syntaxItem) {
+        $taskHelp.syntax | Add-Member 'syntaxItem' @() -Force
+    }
+    if ($taskHelp.syntax.syntaxItem.Count -eq 0) {
+        # add a default syntaxItem so that we have somewhere to merge the build script syntax into
+        $taskHelp.syntax.syntaxItem += [PSCustomObject]@{
+            name      = $functionName
+            parameter = @()
+        } | Add-Member -TypeName 'MamlCommandHelpInfo#syntaxItem' -PassThru
+    }
+    $taskHelp.syntax.syntaxItem = @(
+        foreach ($buildSyntaxItem in $buildSyntaxItems) {
+            $buildParams = $buildSyntaxItem.parameter.where{ $_.name -notin $taskNameArgName, $taskArgsArgName }
+            foreach ($item in $taskHelp.syntax.syntaxItem) {
+                $copy = $item.PSObject.Copy() # shallow copy
+                $copy.name = "$buildScriptPath [-$taskNameArgName] $TaskName"
+                $copy | Add-Member 'parameter' @(
+                    $buildParams
+                    if ($item.parameter.Count -or $taskCommonParameters) { $dashSwitch }
+                    $item.parameter
+                ) -Force
+                $copy
+            }
+        }
+    )
+
+    # The remaining fixups are done via text manipulation on the help output.
+    $text = normalizeText ($taskHelp | Out-String)
+    function escapeRegex([string]$s) { return [regex]::Escape($s) }
+    function escapeReplacement([string]$s) { return $s.Replace('$', '$$') }
+
+    # change NAME heading to TASK NAME
+    $text = $text -creplace '(?m)^NAME$', 'TASK NAME'
+    # replace the temp function name with the build script help invocation.
+    $text = $text -creplace $functionName, (escapeReplacement "$buildScriptPath $TaskName")
+
+    # Insert 'DEPENDS ON' section before RELATED LINKS or REMARKS
+    if ($text -match '(?m)^(RELATED LINKS|REMARKS)$') {
+        $insertBefore = $Matches[1]
+        $dependsOnText = @(
+            if ($task.DependsOn) {
+                'This task depends on the following tasks:'
+                $task.DependsOn.foreach{ "- $_" }
+            }
+            else {
+                'This task has no task dependencies.'
+            }
+        )
+        $dependsOnText = "DEPENDS ON`n    $($dependsOnText -join "`n    ")"
+        $text = $text -creplace "(?m)^$insertBefore`$", "$(escapeReplacement $dependsOnText)`n`n`$0"
+    }
+
+    if ($buildCommonParameters) {
+        # Insert build script's "[<CommonParameters>]" before the '--' separator
+        $text = $text -creplace "($(escapeRegex $buildScriptPath) .*?)(\[--])", '$1[<CommonParameters>] $2'
+    }
+    if ($taskCommonParameters) {
+        # Rename the task's [<CommonParameters>] (the one after the '--') to avoid confusion with the
+        # build script's common parameters
+        $text = $text -creplace "($(escapeRegex $buildScriptPath) .*? \[--] .*?)\[\<CommonParameters\>\]", '$1[<TaskCommonParameters>]'
+    }
+
+    # fixup the additional help remarks
+    $text = $text -creplace "Get-Help $(escapeRegex $TaskName) ", "$(escapeReplacement "$buildScriptPath $HelpTaskName $TaskName") -- "
+
+    return finalizeText $text
 }
 
 function Repair-TaskStackTrace {
@@ -216,7 +751,9 @@ function Repair-TaskStackTrace {
         with the filename and line number of the task action.
     #>
     param(
+        [Parameter(Mandatory)]
         [System.Management.Automation.ErrorRecord]$ErrorRecord,
+        [Parameter(Mandatory)]
         [TaskDefinition]$Task,
         # The line where the task action starts within the Invoke-Expression command.
         [int]$TaskActionStartLine = 2
@@ -279,76 +816,138 @@ function Invoke-Task {
         Invokes a task defined in the task framework.
 
         This is typically not called directly; use Invoke-TaskFramework instead.
-
-        The function will import the specified scripts and variables into the scope
-        of the invoked task, allowing them to be used in the task action. Mutable variables,
-        such as HashTables or lists, can be used to share state across tasks, but be cautious
-        of potential side effects.
     #>
     [Diagnostics.CodeAnalysis.SuppressMessage('PSAvoidUsingInvokeExpression', '', Justification = 'Using Invoke-Expression is necessary to allow task actions to accept named arguments.')]
+    [CmdletBinding(PositionalBinding = $false)]
     param(
+        [Parameter(Mandatory)]
         [TaskDefinition]$Task,
-        [object[]]$TaskArgs,
-        [hashtable]$Variables,
-        [string[]]$ImportScripts
+        [ValidateNotNull()]
+        [object[]]$TaskArgs = @(),
+        [ValidateNotNull()]
+        [TaskContext]$TaskContext = (Get-TaskFrameworkContext)
     )
-
-    if ($null -eq $Task.Action) {
-        Write-Verbose "Skipping task '$($Task.Name)' since it has no action."
-        return
-    }
-
-    Import-Module PSArgs -Verbose:$false
-    Import-Module Secrets -Verbose:$false
-    Import-Module BuildHelpers -Verbose:$false
-
-    $ImportScripts.foreach{
-        Write-Verbose "Importing script '$_'."
-        if ($_ -like '*.ps1') {
-            . $_
-        }
-        else {
-            Import-Module $_ -Verbose:$false
-        }
-    }
-
-    $Variables.Keys.foreach{
-        Write-Verbose "Importing variable '$_' with value $(ConvertTo-PSString $Variables[$_] -UseQuotes)."
-        Set-Variable -Name $_ -Value $Variables[$_] -Force -ea Ignore
-    }
 
     $TaskName = $Task.Name
 
-    $private:_taskCommandArgs = ConvertTo-CommandArg $TaskArgs
-    if ($_taskCommandArgs) {
-        Write-Verbose "Invoking task '$TaskName' with arguments: $_taskCommandArgs"
+    $global:LASTEXITCODE = 0
+    $result = [TaskResult]@{
+        Start    = [datetime]::UtcNow
+        TaskArgs = [TaskArgs]@{
+            Raw = $TaskArgs
+        }
+    }
+    $TaskContext.CurrentTask = $Task
+    $TaskContext.Results[$TaskName] = $result
+
+    if ($null -eq $Task.Action) {
+        Write-Verbose "Skipping task '$TaskName' since it has no action."
+        $result.Duration = [TimeSpan]::Zero
+        $result.ExitCode = 0
+        $TaskContext.CurrentTask = $null
+        return
+    }
+
+    $taskCommandArgs = @()
+    if ($TaskArgs) {
+        Import-Module PSArgs -Verbose:$false
+        $taskCommandArgs = ConvertTo-CommandArg $TaskArgs
+        Write-Verbose "Invoking task '$TaskName' with arguments: $taskCommandArgs"
     }
     else {
         Write-Verbose "Invoking task '$TaskName' with no arguments."
     }
 
-    $global:LASTEXITCODE = 0
-
+    # Use Invoke-Expression to parse $TaskArgs in the context of the task's action.
+    # This enables $TaskArgs to contain named arguments (i.e. '-foo','bar') not
+    # just positional arguments ('bar')...
     try {
-        # Use Invoke-Expression to invoke the script block with arguments. This enables
-        # $TaskArgs to contain named parameters (i.e. '-foo','bar') not just positional
-        # parameters ('bar').
-        Invoke-Expression -Command "&{`n$($Task.Action)`n} $_taskCommandArgs"
+        $tArgs = Invoke-Expression "&{`n$($Task.Action.Ast.ParamBlock) return @{Bound=`$PSBoundParameters;Unbound=`$args}} $taskCommandArgs"
+        $result.TaskArgs.Bound = $tArgs.Bound
+        $result.TaskArgs.Unbound = $tArgs.Unbound
     }
     catch {
-        # Since we used Invoke-Expression to execute the task's action, the stack trace will
-        # not contain the action's actual filename and line number. Let's fixup the stack
-        # trace to include the task action's filename and line number...
         Repair-TaskStackTrace -ErrorRecord $_ -Task $Task -TaskActionStartLine 2
-        throw $_
+        $result.Error = $_
+        $result.Duration = [datetime]::UtcNow - $result.Start
+        throw
     }
 
-    if ($Task.AllowedExitCodes.Count -gt 0 -and $global:LASTEXITCODE -notin $Task.AllowedExitCodes) {
-        Write-Verbose "Task '$TaskName' failed with exit code $global:LASTEXITCODE."
-        throw "Task '$TaskName' failed with exit code $global:LASTEXITCODE."
+    # Now invoke the task action with the parsed arguments...
+    try {
+        $bound = $result.TaskArgs.Bound
+        $unbound = $result.TaskArgs.Unbound
+        & $Task.Action @bound @unbound
     }
-    Write-Verbose "Completed task '$TaskName' with exit code $global:LASTEXITCODE."
+    catch {
+        $result.Error = $_
+        throw
+    }
+    finally {
+        $result.Duration = [datetime]::UtcNow - $result.Start
+    }
+
+    $result.ExitCode = $global:LASTEXITCODE
+    if ($Task.AllowedExitCodes.Count -gt 0 -and $result.ExitCode -notin $Task.AllowedExitCodes) {
+        Write-Verbose "Task '$TaskName' failed with exit code $($result.ExitCode)."
+        throw "Task '$TaskName' failed with exit code $($result.ExitCode)."
+    }
+
+    # Success!
+    Write-Verbose "Completed task '$TaskName' with exit code $($result.ExitCode)."
+    $TaskContext.CurrentTask = $null
     $global:LASTEXITCODE = 0 # reset to avoid affecting the final exit code
+}
+
+function getOrderedTasks {
+    <#
+    .DESCRIPTION
+        Returns an ordered array of TaskDefinition objects corresponding to the specified task
+        names and their dependencies (if $includeDependencies is specified). The tasks are returned
+        in dependency order. For example, if taskA depends on taskB, then `getOrderedTasks taskA $true`
+        will return an array with taskB first, followed by taskA.
+    .OUTPUTS
+        [TaskDefinition[]]
+        An array of TaskDefinition objects corresponding to the specified task names and their dependencies (if $includeDependencies is specified), sorted in dependency order.
+    #>
+    [CmdletBinding(PositionalBinding = $false)]
+    [OutputType([TaskDefinition])]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string[]]$TaskNames,
+        [switch]$IncludeDependencies,
+        [TaskContext]$TaskContext = (Get-TaskFrameworkContext)
+    )
+
+    # get all tasks in dependency order...
+    $orderedTaskMap = getAllOrderedTasks -TaskContext $TaskContext
+
+    # get the set of all tasks to execute, including dependencies if specified.
+    $execTaskNames = @{}
+    $queue = [System.Collections.Generic.Queue[string]]::new($TaskNames)
+    while ($queue.Count -gt 0) {
+        $taskName = $queue.Dequeue()
+        if ($execTaskNames.ContainsKey($taskName)) {
+            continue # already visited
+        }
+        $execTaskNames[$taskName] = $true
+        $task = $orderedTaskMap[$taskName]
+        if (-not $task) {
+            throw "Task '$taskName' not found."
+        }
+        if ($IncludeDependencies) {
+            foreach ($dep in $task.DependsOn) {
+                $queue.Enqueue($dep)
+            }
+        }
+    }
+
+    # Return the tasks in dependency order...
+    return $orderedTaskMap.Values.foreach{
+        if ($execTaskNames.ContainsKey($_.Name)) {
+            $_
+        }
+    }
 }
 
 function Invoke-TaskFramework {
@@ -358,81 +957,82 @@ function Invoke-TaskFramework {
 
         Tasks will be executed in the order they were defined. If a task has dependencies,
         those will be executed first unless $SkipDependencies is specified.
-
-        The function will import the specified scripts and variables into the scope
-        of each invoked task, allowing them to be used in task actions. Mutable variables,
-        such as HashTables or lists, can be used to share state across tasks, but be cautious
-        of potential side effects.
     #>
     [CmdletBinding(PositionalBinding = $false)]
     param(
-        # The working directory in which to invoke the task(s).
-        [Parameter(Mandatory)]
-        [string]$WorkingDirectory,
-
         # The name(s) of the task(s) to invoke.
         [Parameter(Mandatory)]
         [string[]]$TaskName,
 
         # Task-specific arguments. Can only be used when invoking a _single_ task.
+        [ValidateNotNull()]
         [object[]]$TaskArgs = @(),
 
         # Indicates whether to skip invoking dependencies of specified tasks. Defaults to $false.
         [switch]$SkipDependencies,
 
-        # A list of scripts to import into the scope of invoked tasks. This can be used to share
-        # helper functions across tasks.
-        [string[]]$ImportScripts = @(),
-
-        # A hashtable of variables to import into the scope of invoked tasks. This can be used to
-        # pass configuration or state to tasks.
-        [hashtable]$Variables = @{},
+        # The working directory in which to invoke the task(s).
+        # Defaults to the BuildScriptPath's directory.
+        [ValidateNotNullOrEmpty()]
+        [string]$WorkingDirectory,
 
         # Indicates that the function should exit the script if a failure occurs. If not specified,
         # the function will throw an exception failure.
-        [switch]$ExitOnError
+        [switch]$ExitOnError,
+
+        # The task context hashtable. Defaults to the current task context returned by Get-TaskFrameworkContext.
+        [ValidateNotNull()]
+        [TaskContext]$TaskContext = (Get-TaskFrameworkContext)
     )
     & $PSScriptRoot/syncCallerPreferences.ps1 $MyInvocation
     $ErrorActionPreference = 'Stop'
 
-    $private:_orig = @{
+    if (!$WorkingDirectory) {
+        $WorkingDirectory = $TaskContext.BuildScriptPath.DirectoryName
+    }
+    elseif (!(Test-Path $WorkingDirectory -PathType Container)) {
+        Write-Error -Exception "The specified working directory '$WorkingDirectory' does not exist."
+        return
+    }
+
+    $TaskContext.WorkingDirectory = Get-Item $WorkingDirectory -Force
+    $TaskContext.SkipDependencies = $SkipDependencies.IsPresent
+    $TaskContext.Start = [datetime]::UtcNow
+
+    $orig = @{
         PSModulePath = $env:PSModulePath
         Location     = Get-Location
     }
 
-    Write-Verbose "Working directory: '$WorkingDirectory'."
-    Set-Location $WorkingDirectory
+    Write-Verbose "Working directory: '$($TaskContext.WorkingDirectory)'."
+    Set-Location $TaskContext.WorkingDirectory
     try {
         if ($TaskArgs.Count -gt 0 -and $TaskName.Count -gt 1) {
             throw 'Task arguments cannot be used when invoking multiple tasks.'
         }
 
-        $TasksToExecute = [TaskDefinition]::GetOrderedTasks($TaskName, !$SkipDependencies)
-
-        # Add the scripts directory to the module path so that task actions
-        # can more easily import helper modules if needed.
+        # Add this scripts directory to the module path so that task actions
+        # can import our helper modules using the module's folder name.
         $pathSeparator = $IsWindows ? ';' : ':'
         $env:PSModulePath = "$PSScriptRoot$pathSeparator$env:PSModulePath"
 
-        $private:targs = @{
-            Task          = $null
-            TaskArgs      = @()
-            ImportScripts = $ImportScripts
-            Variables     = $Variables
-        }
+        $tasksToExecute = getOrderedTasks $TaskName -IncludeDependencies:(!$TaskContext.SkipDependencies) -TaskContext $TaskContext
+        $TaskContext.TasksToExecute = $tasksToExecute
+        Write-Verbose "Executing tasks: $($tasksToExecute.Name -join ', ')"
 
-        Write-Verbose "Executing tasks: $($TasksToExecute.Name -join ', ')"
-
-        foreach ($task in $TasksToExecute) {
-            $targs.Task = $task
-            $targs.TaskArgs = $task.Name -eq $TaskName ? $TaskArgs : @()
-            Invoke-Task @targs
+        foreach ($task in $tasksToExecute) {
+            Invoke-Task -Task $task -TaskArgs ($task.Name -eq $TaskName ? $TaskArgs : @()) -TaskContext $TaskContext
+            Set-Location $TaskContext.WorkingDirectory
         }
 
         Write-Verbose "Done executing tasks."
+        $TaskContext.ExitCode = $global:LASTEXITCODE
     }
     catch {
         if ($global:LASTEXITCODE -eq 0) { $global:LASTEXITCODE = -1 }
+        $TaskContext.ExitCode = $global:LASTEXITCODE
+        $TaskContext.Error = $_
+
         Write-Verbose "Error: $_`n$(($_ | Format-List -Force | Out-String).Trim())"
         if ($ExitOnError) {
             # Output a user-friendly error message with a stack trace
@@ -443,22 +1043,18 @@ function Invoke-TaskFramework {
         throw
     }
     finally {
-        $env:PSModulePath = $_orig.PSModulePath
-        Set-Location $_orig.Location
+        $TaskContext.Duration = [datetime]::UtcNow - $TaskContext.Start
+        $env:PSModulePath = $orig.PSModulePath
+        Set-Location $orig.Location
     }
 }
 
-# reset the task framework state when the module is [force] imported to ensure a clean slate
-Reset-TaskFramework
-
 # !Important! Remember to update the module manifest (.psd1) when adding or removing exports.
-$exportModuleMemberParams = @{
-    Function = @(
-        'Reset-TaskFramework'
-        'Task'
-        'Get-TaskFrameworkTasks'
-        'Invoke-TaskFramework'
-    )
-}
-
-Export-ModuleMember @exportModuleMemberParams
+Export-ModuleMember -Function `
+    Initialize-TaskFramework, `
+    Get-TaskFrameworkContext, `
+    Task, `
+    Get-TaskFrameworkTasks, `
+    Invoke-TaskFramework, `
+    Get-TaskFrameworkHelp, `
+    Add-TaskFrameworkDefaultTasks

--- a/scripts/PSTaskFramework/PSTaskFramework.psm1
+++ b/scripts/PSTaskFramework/PSTaskFramework.psm1
@@ -392,6 +392,7 @@ function Invoke-TaskFramework {
         # the function will throw an exception failure.
         [switch]$ExitOnError
     )
+    & $PSScriptRoot/syncCallerPreferences.ps1 $MyInvocation
     $ErrorActionPreference = 'Stop'
 
     $private:_orig = @{

--- a/scripts/PSTaskFramework/Secrets/Secrets.psm1
+++ b/scripts/PSTaskFramework/Secrets/Secrets.psm1
@@ -72,7 +72,6 @@ function Push-Secret {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory, ValueFromPipeline)]
-        [ValidateNotNullOrEmpty()]
         [string]$Value
     )
     process {
@@ -105,7 +104,6 @@ function Pop-Secret {
     param (
         # The secret value which was previously registered with Push-Secret.
         [Parameter(Mandatory, ValueFromPipeline)]
-        [ValidateNotNullOrEmpty()]
         [string]$Value
     )
     begin {
@@ -140,7 +138,7 @@ function Protect-Secret {
         [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [AllowEmptyString()]
         [string]$Message,
-        [AllowEmptyString()]
+        [ValidateNotNull()]
         [string]$Mask = '****'
     )
     process {
@@ -171,6 +169,7 @@ function Read-Secret {
         [System.String]
         The secret value read from the console.
     #>
+    # TODO: Add a "-Secret" switch, rename to "Read-Input", and move to BuildHelpers.
     [CmdletBinding()]
     [OutputType([string])]
     param(
@@ -209,14 +208,9 @@ function Read-Secret {
     return $value
 }
 
-$exportModuleMemberParams = @{
-    Function = @(
-        'Read-Secret'
-        'Push-Secret'
-        'Pop-Secret'
-        'Protect-Secret'
-        'Clear-SecretStore'
-    )
-}
-
-Export-ModuleMember @exportModuleMemberParams
+Export-ModuleMember -Function `
+    Read-Secret, `
+    Push-Secret, `
+    Pop-Secret, `
+    Protect-Secret, `
+    Clear-SecretStore

--- a/scripts/PSTaskFramework/Secrets/Secrets.psm1
+++ b/scripts/PSTaskFramework/Secrets/Secrets.psm1
@@ -108,6 +108,9 @@ function Pop-Secret {
         [ValidateNotNullOrEmpty()]
         [string]$Value
     )
+    begin {
+        & $PSScriptRoot/../syncCallerPreferences.ps1 $MyInvocation -PreferencesToSync ErrorAction
+    }
     process {
         $secrets = getState
         if (!$secrets.values.ContainsKey($Value)) {
@@ -176,6 +179,8 @@ function Read-Secret {
         [string] $Prompt,
         [switch] $AllowEmpty
     )
+    & $PSScriptRoot/../syncCallerPreferences.ps1 $MyInvocation -PreferencesToSync ErrorAction, WarningAction
+
     if (isContinuousIntegration) {
         if ($AllowEmpty) {
             Write-Warning "CI environment detected. Returning empty value for prompt '$Prompt'."

--- a/scripts/PSTaskFramework/syncCallerPreferences.ps1
+++ b/scripts/PSTaskFramework/syncCallerPreferences.ps1
@@ -1,0 +1,82 @@
+<#
+.SYNOPSIS
+    Syncs the calling module's preference variables into the caller's scope.
+.DESCRIPTION
+    Annoyingly, advanced functions defined in a script-module do not inherit the preferences variables
+    from the caller's scope. This function manually imports the preferences variables from the calling
+    module into the scope of the caller.
+
+    See https://github.com/PowerShell/PowerShell/issues/4568 for more information about this issue.
+#>
+[CmdletBinding(PositionalBinding = $false)]
+param(
+    # The Invocation trying to sync preferences.
+    # Defaults to the invocation of the caller of this function. Pass $MyInvocation for a slight
+    # performance boost, since it will avoid a call to Get-PSCallStack.
+    [Parameter(Position = 0)]
+    [System.Management.Automation.InvocationInfo] $Invocation,
+
+    # The scope of the Invocation, relative to the caller. Defaults to 0, which is the caller's scope.
+    [int] $Scope = 0,
+
+    # The preferences to sync.
+    [string[]] $PreferencesToSync = @(
+        'ErrorAction'
+        'WarningAction'
+        'InformationAction'
+        'Verbose'
+        'Debug'
+        'Confirm'
+        'WhatIf'
+    ),
+
+    # The preferences to ignore.
+    [ValidateSet('ErrorAction', 'WarningAction', 'InformationAction', 'Verbose', 'Debug', 'Confirm', 'WhatIf')]
+    [string[]] $PreferencesToIgnore = @(),
+
+    # Additional variables to sync.
+    [string[]] $VariablesToSync = @()
+)
+
+# Make scope relative to this function instead of the caller
+$Scope += 1
+
+if (!$Invocation) {
+    $callstack = Get-PSCallStack
+    $Invocation = $callstack[$Scope].InvocationInfo
+}
+
+$boundParameters = $Invocation.BoundParameters
+$callerModule = $Invocation.MyCommand.Module
+if ($null -eq $callerModule) {
+    throw 'Invocation must be from a script module.'
+}
+
+@(
+    $VariablesToSync
+    switch ($PreferencesToSync | Where-Object { $_ -notin $PreferencesToIgnore }) {
+        'ErrorAction' { if (!$boundParameters.ContainsKey($_)) { 'ErrorActionPreference' } }
+        'WarningAction' { if (!$boundParameters.ContainsKey($_)) { 'WarningPreference' } }
+        'InformationAction' { if (!$boundParameters.ContainsKey($_)) { 'InformationPreference' } }
+        'Verbose' { if (!$boundParameters.ContainsKey($_)) { 'VerbosePreference' } }
+        'Debug' { if (!$boundParameters.ContainsKey($_)) { 'DebugPreference' } }
+        'Confirm' { if (!$boundParameters.ContainsKey($_)) { 'ConfirmPreference' } }
+        'WhatIf' { if (!$boundParameters.ContainsKey($_)) { 'WhatIfPreference' } }
+    }
+) |
+Select-Object -Unique |
+ForEach-Object {
+    $v = $_
+    try {
+        $var = $callerModule.GetVariableFromCallersModule($v)
+        if ($var) {
+            Set-Variable -Name $var.Name -Value $var.Value -Scope $Scope -Force -ErrorAction Stop -Verbose:$false -WhatIf:$false -Confirm:$false
+        }
+        else {
+            Write-Warning "Failed to sync variable '$v': Variable not found in caller's module."
+        }
+    }
+    catch {
+        Write-Warning "Failed to sync variable '$v': $_"
+    }
+}

--- a/src/LeaderElection.Postgres/PostgresLeaderElection.cs
+++ b/src/LeaderElection.Postgres/PostgresLeaderElection.cs
@@ -234,12 +234,6 @@ public sealed partial class PostgresLeaderElection : LeaderElectionBase<Postgres
         }
     }
 
-    protected override async ValueTask DisposeAsyncCore()
-    {
-        await ResetLeadershipAsync().ConfigureAwait(false);
-        await base.DisposeAsyncCore().ConfigureAwait(false);
-    }
-
     private static NpgsqlCommand CreateCommand(
         NpgsqlConnection connection,
         /* language=sql */string query,

--- a/src/LeaderElection.Postgres/README.md
+++ b/src/LeaderElection.Postgres/README.md
@@ -96,7 +96,7 @@ public class Worker : BackgroundService
 | :----------------------- | :--------------- | :------------------------------------------------------------------------------------------------------------------------------ |
 | `DataSourceFactory`      | `null`           | A factory function used to create an `NpgsqlDataSource`. If not specified, the `ConnectionString` will be tried.                |
 | `ConnectionString`       | `null`           | The connection string for the PostgreSQL database. If not specified, the `NpgsqlDataSource` from the DI container will be used. |
-| `LockId`                 | (required)       | The unique 64-bit advisory lock id to use for leader election.                                                                  |
+| `LockId`                 | `0`              | The unique 64-bit advisory lock id to use for leader election.                                                                  |
 | `InstanceId`             | `Guid.NewGuid()` | Unique ID for this node.                                                                                                        |
 | `RetryInterval`          | `5s`             | The interval to wait before retrying a failed leadership acquisition.                                                           |
 | `RenewInterval`          | `10s`            | The interval at which the leader will attempt to renew its leadership.                                                          |


### PR DESCRIPTION
## Description

This pull request introduces a new Aspire AppHost project for the `LeaderElectionTester` example, enabling unified orchestration of infrastructure and multiple tester instances with .NET Aspire. It also updates the tester to support configuration via environment variables and connection strings, and improves the documentation to recommend running with Aspire for a smoother developer experience. The most important changes are grouped below:

**Aspire AppHost Integration:**

* Added a new `LeaderElectionTester.AppHost` project using Aspire, which orchestrates backing infrastructure (Redis, Postgres, Blob Storage, S3/MinIO) and multiple tester instances based on configuration. This enables out-of-the-box local orchestration and easier scaling/testing. [[1]](diffhunk://#diff-8fcccf9bfcd3cbde043ac772e14dd79db3ddc69d590caac7f926f3f7637ca63dR1-R22) [[2]](diffhunk://#diff-1d43bbad89cce0ef9d782936f1ff646df2fa5de96bb8c78ab4a4b441d5c58bc7R1-R96)
* Added Aspire-related configuration files: `aspire.config.json`, `appsettings.json`, `appsettings.Development.json`, and `Properties/launchSettings.json` to support local development and environment configuration. [[1]](diffhunk://#diff-5648131629641faaf872b7e1f5ea5701537160ddedc3feebb2c0fc17b7a4f70aR1-R5) [[2]](diffhunk://#diff-8ac2c585d3affbf9f1d7d2cf4a530866c17b95900f27c8d8f198a3c0069d7653R1-R11) [[3]](diffhunk://#diff-049fe3b5a6326347d239414b0b5405be10cd132e48643423f152f152e5d68751R1-R8) [[4]](diffhunk://#diff-08ea36d945f1587544222a8a75fecd827dea2a075367ba2e40f0520603b45f5dR1-R31)
* Updated solution (`LeaderElection.slnx`) to include the new AppHost project and fixed the Postgres project path. [[1]](diffhunk://#diff-8a90d39270bdedef5c3ed59516ff642d68dd1da20a20475c760361b31a80a34bR3) [[2]](diffhunk://#diff-8a90d39270bdedef5c3ed59516ff642d68dd1da20a20475c760361b31a80a34bL12-R13)

**Developer Experience Enhancements:**

* Added VS Code launch and task configurations to easily run and debug the AppHost project with different leader election types. [[1]](diffhunk://#diff-bd5430ee7c51dc892a67b3f2829d1f5b6d223f0fd48b82322cfd45baf9f5e945R1-R80) [[2]](diffhunk://#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745aR1-R13)
* Centralized package version management for Aspire-related hosting packages in `Directory.Packages.props`.

**Tester Application Improvements:**

* Refactored `LeaderElectionTester` to read configuration (such as `LeaderElectionType`, instance ID, and connection strings) from environment variables, supporting seamless integration with Aspire and containerized environments. [[1]](diffhunk://#diff-0a77dff84819dd2aa30bf09723f87976f7dcf4e5937d7f6fa079e3cea4523ba6L19-R21) [[2]](diffhunk://#diff-0a77dff84819dd2aa30bf09723f87976f7dcf4e5937d7f6fa079e3cea4523ba6L39-R43) [[3]](diffhunk://#diff-0a77dff84819dd2aa30bf09723f87976f7dcf4e5937d7f6fa079e3cea4523ba6L81-R85) [[4]](diffhunk://#diff-0a77dff84819dd2aa30bf09723f87976f7dcf4e5937d7f6fa079e3cea4523ba6L96-R120)
* Improved distributed cache and S3/MinIO setup to use injected configuration and connection strings, making the tester more flexible and production-like. [[1]](diffhunk://#diff-0a77dff84819dd2aa30bf09723f87976f7dcf4e5937d7f6fa079e3cea4523ba6L149-R157) [[2]](diffhunk://#diff-0a77dff84819dd2aa30bf09723f87976f7dcf4e5937d7f6fa079e3cea4523ba6L96-R120)

**Documentation Updates:**

* Updated the `README.md` to recommend running with Aspire, provide new instructions for orchestrated and standalone modes, and clarify prerequisites and expected behavior. [[1]](diffhunk://#diff-d5c4f3fd4b10df4501a41c4929f0b283d1c09e2aef8dbc65201c867611fcfc25L8-R9) [[2]](diffhunk://#diff-d5c4f3fd4b10df4501a41c4929f0b283d1c09e2aef8dbc65201c867611fcfc25L38-R94)

These changes collectively make it much easier to run, test, and debug leader election scenarios locally, both with and without containerized infrastructure.

---

## Checklist

- [x] My code follows the project's coding style
- [x] I have self-reviewed my changes
- [ ] I have added tests (or explain why not needed)
- [x] I have updated the documentation
- [x] I have linked relevant issue(s)
- [x] I have included meaningful commit messages

---

## Related Issues

Closes #63

---

## Additional Notes

Note the target branch is `refactor/di-extensions`. This PR should not be merged until after #64 is merged.