### PR TITLE
Enhance RunTaskIfLeaderAsync with cancellation and status reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ public class MyService : BackgroundService
             // Run leader tasks
             while (!stoppingToken.IsCancellationRequested)
             {
-                await _leaderElection.RunTaskIfLeaderAsync(async () =>
+                await _leaderElection.RunTaskIfLeaderAsync(async ct =>
                 {
                     _logger.LogInformation("Executing leader task");
-                    await DoLeaderWorkAsync();
+                    await DoLeaderWorkAsync(ct);
                 }, stoppingToken);
 
                 _logger.LogInformation("Executing normal task");
@@ -140,10 +140,10 @@ public class MyService : BackgroundService
 - `StartAsync(CancellationToken)` - Start the leader election process
 - `StopAsync(CancellationToken)` - Stop the leader election process
 - `TryAcquireLeadershipAsync(CancellationToken)` - Manually attempt to acquire leadership
-- `RunTaskIfLeaderAsync(Func<Task>, CancellationToken)` - Execute a task only if this instance is
-  the leader
-- `RunTaskIfLeaderAsync(Action, CancellationToken)` - Execute a synchronous task only if this
-  instance is the leader
+- `RunTaskIfLeaderAsync(Func<CancellationToken, Task>, CancellationToken)` - Execute a task only if
+  this instance is the leader
+- `RunTaskIfLeaderAsync(Action<CancellationToken>, CancellationToken)` - Execute a synchronous task
+  only if this instance is the leader
 
 ### Properties
 

--- a/examples/LeaderElectionTester/Service.cs
+++ b/examples/LeaderElectionTester/Service.cs
@@ -35,7 +35,7 @@ internal sealed class Service : BackgroundService
             {
                 await _election
                     .RunTaskIfLeaderAsync(
-                        () =>
+                        _ =>
                         {
                             _logger.LogInformation(
                                 "Executing leader task at {Time}",

--- a/src/LeaderElection.BlobStorage/README.md
+++ b/src/LeaderElection.BlobStorage/README.md
@@ -71,10 +71,10 @@ public class MyService : BackgroundService
             // Run leader tasks
             while (!stoppingToken.IsCancellationRequested)
             {
-                await _leaderElection.RunTaskIfLeaderAsync(async () =>
+                await _leaderElection.RunTaskIfLeaderAsync(async ct =>
                 {
                     _logger.LogInformation("Executing leader task");
-                    await DoLeaderWorkAsync();
+                    await DoLeaderWorkAsync(ct);
                 }, stoppingToken);
 
                 await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
@@ -108,10 +108,10 @@ public class MyService : BackgroundService
 - `StartAsync(CancellationToken)` - Start the leader election process
 - `StopAsync(CancellationToken)` - Stop the leader election process
 - `TryAcquireLeadershipAsync(CancellationToken)` - Manually attempt to acquire leadership
-- `RunTaskIfLeaderAsync(Func<Task>, CancellationToken)` - Execute a task only if this instance is
-  the leader
-- `RunTaskIfLeaderAsync(Action, CancellationToken)` - Execute a synchronous task only if this
-  instance is the leader
+- `RunTaskIfLeaderAsync(Func<CancellationToken, Task>, CancellationToken)` - Execute a task only if
+  this instance is the leader
+- `RunTaskIfLeaderAsync(Action<CancellationToken>, CancellationToken)` - Execute a synchronous task
+  only if this instance is the leader
 
 ### Properties
 

--- a/src/LeaderElection.DistributedCache/README.md
+++ b/src/LeaderElection.DistributedCache/README.md
@@ -75,10 +75,10 @@ public class MyService : BackgroundService
             // Run leader tasks
             while (!stoppingToken.IsCancellationRequested)
             {
-                await _leaderElection.RunTaskIfLeaderAsync(async () =>
+                await _leaderElection.RunTaskIfLeaderAsync(async ct =>
                 {
                     _logger.LogInformation("Executing leader task");
-                    await DoLeaderWorkAsync();
+                    await DoLeaderWorkAsync(ct);
                 }, stoppingToken);
 
                 await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
@@ -112,10 +112,10 @@ public class MyService : BackgroundService
 - `StartAsync(CancellationToken)` - Start the leader election process
 - `StopAsync(CancellationToken)` - Stop the leader election process
 - `TryAcquireLeadershipAsync(CancellationToken)` - Manually attempt to acquire leadership
-- `RunTaskIfLeaderAsync(Func<Task>, CancellationToken)` - Execute a task only if this instance is
-  the leader
-- `RunTaskIfLeaderAsync(Action, CancellationToken)` - Execute a synchronous task only if this
-  instance is the leader
+- `RunTaskIfLeaderAsync(Func<CancellationToken, Task>, CancellationToken)` - Execute a task only if
+  this instance is the leader
+- `RunTaskIfLeaderAsync(Action<CancellationToken>, CancellationToken)` - Execute a synchronous task
+  only if this instance is the leader
 
 ### Properties
 

--- a/src/LeaderElection.FusionCache/README.md
+++ b/src/LeaderElection.FusionCache/README.md
@@ -75,10 +75,10 @@ public class MyService : BackgroundService
             // Run leader tasks
             while (!stoppingToken.IsCancellationRequested)
             {
-                await _leaderElection.RunTaskIfLeaderAsync(async () =>
+                await _leaderElection.RunTaskIfLeaderAsync(async ct =>
                 {
                     _logger.LogInformation("Executing leader task");
-                    await DoLeaderWorkAsync();
+                    await DoLeaderWorkAsync(ct);
                 }, stoppingToken);
 
                 await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
@@ -112,10 +112,10 @@ public class MyService : BackgroundService
 - `StartAsync(CancellationToken)` - Start the leader election process
 - `StopAsync(CancellationToken)` - Stop the leader election process
 - `TryAcquireLeadershipAsync(CancellationToken)` - Manually attempt to acquire leadership
-- `RunTaskIfLeaderAsync(Func<Task>, CancellationToken)` - Execute a task only if this instance is
-  the leader
-- `RunTaskIfLeaderAsync(Action, CancellationToken)` - Execute a synchronous task only if this
-  instance is the leader
+- `RunTaskIfLeaderAsync(Func<CancellationToken, Task>, CancellationToken)` - Execute a task only if
+  this instance is the leader
+- `RunTaskIfLeaderAsync(Action<CancellationToken>, CancellationToken)` - Execute a synchronous task
+  only if this instance is the leader
 
 ### Properties
 

--- a/src/LeaderElection.Postgres/README.md
+++ b/src/LeaderElection.Postgres/README.md
@@ -80,10 +80,10 @@ public class Worker : BackgroundService
         while (!stoppingToken.IsCancellationRequested)
         {
             // Only runs if this instance currently holds the Postgres advisory lock
-            await _leaderElection.RunTaskIfLeaderAsync(async () =>
+            await _leaderElection.RunTaskIfLeaderAsync(async ct =>
             {
                 _logger.LogInformation("Instance is leader. Doing work...");
-                await Task.Delay(1000, stoppingToken);
+                await Task.Delay(1000, ct);
             }, stoppingToken);
 
             await Task.Delay(5000, stoppingToken);

--- a/src/LeaderElection.Redis/README.md
+++ b/src/LeaderElection.Redis/README.md
@@ -75,10 +75,10 @@ public class MyService : BackgroundService
             // Run leader tasks
             while (!stoppingToken.IsCancellationRequested)
             {
-                await _leaderElection.RunTaskIfLeaderAsync(async () =>
+                await _leaderElection.RunTaskIfLeaderAsync(async ct =>
                 {
                     _logger.LogInformation("Executing leader task");
-                    await DoLeaderWorkAsync();
+                    await DoLeaderWorkAsync(ct);
                 }, stoppingToken);
 
                 await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
@@ -112,10 +112,10 @@ public class MyService : BackgroundService
 - `StartAsync(CancellationToken)` - Start the leader election process
 - `StopAsync(CancellationToken)` - Stop the leader election process
 - `TryAcquireLeadershipAsync(CancellationToken)` - Manually attempt to acquire leadership
-- `RunTaskIfLeaderAsync(Func<Task>, CancellationToken)` - Execute a task only if this instance is
-  the leader
-- `RunTaskIfLeaderAsync(Action, CancellationToken)` - Execute a synchronous task only if this
-  instance is the leader
+- `RunTaskIfLeaderAsync(Func<CancellationToken, Task>, CancellationToken)` - Execute a task only if
+  this instance is the leader
+- `RunTaskIfLeaderAsync(Action<CancellationToken>, CancellationToken)` - Execute a synchronous task
+  only if this instance is the leader
 
 ### Properties
 

--- a/src/LeaderElection.S3/README.md
+++ b/src/LeaderElection.S3/README.md
@@ -72,10 +72,10 @@ public class Worker : BackgroundService
         while (!stoppingToken.IsCancellationRequested)
         {
             // Only runs if this instance currently holds the S3 lease
-            await _leaderElection.RunTaskIfLeaderAsync(async () =>
+            await _leaderElection.RunTaskIfLeaderAsync(async ct =>
             {
                 _logger.LogInformation("Instance is leader. Doing work...");
-                await Task.Delay(1000, stoppingToken);
+                await Task.Delay(1000, ct);
             }, stoppingToken);
 
             await Task.Delay(5000, stoppingToken);

--- a/src/LeaderElection/ILeaderElection.cs
+++ b/src/LeaderElection/ILeaderElection.cs
@@ -71,20 +71,30 @@ public interface ILeaderElection : IAsyncDisposable
     /// <summary>
     /// Executes a task only if this instance is the leader.
     /// </summary>
-    /// <param name="task">The task to execute</param>
+    /// <param name="leaderTask">The task to execute. The function receives a <see cref="CancellationToken"/>
+    /// that is canceled if a) leadership is lost (including when the leader loop is stopped) or b) the provided
+    /// <paramref name="cancellationToken"/> is canceled.</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Task representing the async operation</returns>
-    /// <exception cref="ArgumentNullException">Thrown if the task is null.</exception>
+    /// <returns>A task that resolves to <c>true</c> if the leader task was executed; otherwise, <c>false</c>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if the leader task is null.</exception>
     /// <exception cref="ObjectDisposedException">Thrown if the leader election instance has been disposed.</exception>
-    Task RunTaskIfLeaderAsync(Func<Task> task, CancellationToken cancellationToken = default);
+    Task<bool> RunTaskIfLeaderAsync(
+        Func<CancellationToken, Task> leaderTask,
+        CancellationToken cancellationToken = default
+    );
 
     /// <summary>
     /// Executes a synchronous task only if this instance is the leader.
     /// </summary>
-    /// <param name="task">The task to execute</param>
+    /// <param name="leaderAction">The action to execute. The action receives a <see cref="CancellationToken"/>
+    /// that is canceled if a) leadership is lost (including when the leader loop is stopped) or b) the provided
+    /// <paramref name="cancellationToken"/> is canceled.</param>
     /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Task representing the async operation</returns>
-    /// <exception cref="ArgumentNullException">Thrown if the task is null.</exception>
+    /// <returns>A task that resolves to <c>true</c> if the leader action was executed; otherwise, <c>false</c>.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if the leader action is null.</exception>
     /// <exception cref="ObjectDisposedException">Thrown if the leader election instance has been disposed.</exception>
-    Task RunTaskIfLeaderAsync(Action task, CancellationToken cancellationToken = default);
+    Task<bool> RunTaskIfLeaderAsync(
+        Action<CancellationToken> leaderAction,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/LeaderElection/LeaderElectionBase.cs
+++ b/src/LeaderElection/LeaderElectionBase.cs
@@ -223,9 +223,9 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
             return false;
         }
 
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
-        void OnLeadershipChange(object? _, LeadershipChangedEventArgs e)
+        void onLeadershipChange(object? _, LeadershipChangedEventArgs e)
         {
             if (!e.IsLeader)
             {
@@ -233,22 +233,32 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
             }
         }
 
-        LeadershipChanged += OnLeadershipChange;
-        try
-        {
-            // one last check to avoid starting the task if we lost leadership while subscribing to the event
-            if (!IsLeader)
-            {
-                return false;
-            }
+        LeadershipChanged += onLeadershipChange;
 
-            // Pass the combined token to the work, and the caller's token to the wait...
-            await leaderTask(cts.Token).WaitAsync(cancellationToken).ConfigureAwait(false);
-            return true;
-        }
-        finally
+        // check again now that we have subscribed to the event...
+        if (!IsLeader)
         {
-            LeadershipChanged -= OnLeadershipChange;
+            LeadershipChanged -= onLeadershipChange;
+            cts.Dispose();
+            return false;
+        }
+
+        await ExecTaskAndCleanupAsync().WaitAsync(cancellationToken).ConfigureAwait(false);
+        return true;
+
+        // Helper task to guarantee cleanup happens when the leader task completes,
+        // not necessarily when the function ends.
+        async Task ExecTaskAndCleanupAsync()
+        {
+            try
+            {
+                await leaderTask(cts.Token).ConfigureAwait(false);
+            }
+            finally
+            {
+                LeadershipChanged -= onLeadershipChange;
+                cts.Dispose();
+            }
         }
     }
 

--- a/src/LeaderElection/LeaderElectionBase.cs
+++ b/src/LeaderElection/LeaderElectionBase.cs
@@ -210,28 +210,59 @@ public abstract partial class LeaderElectionBase<TSettings> : ILeaderElection
     }
 
     /// <inheritdoc />
-    public async Task RunTaskIfLeaderAsync(
-        Func<Task> task,
+    public async Task<bool> RunTaskIfLeaderAsync(
+        Func<CancellationToken, Task> leaderTask,
         CancellationToken cancellationToken = default
     )
     {
-        ArgumentNullException.ThrowIfNull(task);
+        ArgumentNullException.ThrowIfNull(leaderTask);
         ThrowIfDisposed();
 
-        if (IsLeader)
+        if (!IsLeader)
         {
-            await task().WaitAsync(cancellationToken).ConfigureAwait(false);
+            return false;
+        }
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        void OnLeadershipChange(object? _, LeadershipChangedEventArgs e)
+        {
+            if (!e.IsLeader)
+            {
+                cts.Cancel();
+            }
+        }
+
+        LeadershipChanged += OnLeadershipChange;
+        try
+        {
+            // one last check to avoid starting the task if we lost leadership while subscribing to the event
+            if (!IsLeader)
+            {
+                return false;
+            }
+
+            // Pass the combined token to the work, and the caller's token to the wait...
+            await leaderTask(cts.Token).WaitAsync(cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        finally
+        {
+            LeadershipChanged -= OnLeadershipChange;
         }
     }
 
     /// <inheritdoc />
-    public Task RunTaskIfLeaderAsync(Action task, CancellationToken cancellationToken = default)
+    public Task<bool> RunTaskIfLeaderAsync(
+        Action<CancellationToken> leaderAction,
+        CancellationToken cancellationToken = default
+    )
     {
-        ArgumentNullException.ThrowIfNull(task);
+        ArgumentNullException.ThrowIfNull(leaderAction);
         return RunTaskIfLeaderAsync(
-            () =>
+            ct =>
             {
-                task();
+                leaderAction(ct);
                 return Task.CompletedTask;
             },
             cancellationToken

--- a/src/LeaderElection/README.md
+++ b/src/LeaderElection/README.md
@@ -75,10 +75,10 @@ public class MyService : BackgroundService
             // Run leader tasks
             while (!stoppingToken.IsCancellationRequested)
             {
-                await _leaderElection.RunTaskIfLeaderAsync(async () =>
+                await _leaderElection.RunTaskIfLeaderAsync(async ct =>
                 {
                     _logger.LogInformation("Executing leader task");
-                    await DoLeaderWorkAsync();
+                    await DoLeaderWorkAsync(ct);
                 }, stoppingToken);
 
                 await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
@@ -112,10 +112,10 @@ public class MyService : BackgroundService
 - `StartAsync(CancellationToken)` - Start the leader election process
 - `StopAsync(CancellationToken)` - Stop the leader election process
 - `TryAcquireLeadershipAsync(CancellationToken)` - Manually attempt to acquire leadership
-- `RunTaskIfLeaderAsync(Func<Task>, CancellationToken)` - Execute a task only if this instance is
-  the leader
-- `RunTaskIfLeaderAsync(Action, CancellationToken)` - Execute a synchronous task only if this
-  instance is the leader
+- `RunTaskIfLeaderAsync(Func<CancellationToken, Task>, CancellationToken)` - Execute a task only if
+  this instance is the leader
+- `RunTaskIfLeaderAsync(Action<CancellationToken>, CancellationToken)` - Execute a synchronous task
+  only if this instance is the leader
 
 ### Properties
 

--- a/tests/LeaderElection.Tests/BlobStorageLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/BlobStorageLeaderElectionTests.cs
@@ -170,10 +170,14 @@ public sealed class BlobStorageLeaderElectionTests(AzuriteContainerFixture azuri
         await leaderElection.StartAsync(CancellationToken);
         await WaitForLeadershipChange(leaderElection, true, options.LeaseDuration);
 
-        await leaderElection.RunTaskIfLeaderAsync(() => taskExecuted = true, CancellationToken);
+        var result = await leaderElection.RunTaskIfLeaderAsync(
+            _ => taskExecuted = true,
+            CancellationToken
+        );
 
         // Assert
         taskExecuted.Should().BeTrue();
+        result.Should().BeTrue();
 
         await leaderElection.StopAsync(CancellationToken);
     }
@@ -189,10 +193,14 @@ public sealed class BlobStorageLeaderElectionTests(AzuriteContainerFixture azuri
         var taskExecuted = false;
 
         // Act - Don't start the leader election, so it won't be leader
-        await leaderElection.RunTaskIfLeaderAsync(() => taskExecuted = true, CancellationToken);
+        var result = await leaderElection.RunTaskIfLeaderAsync(
+            _ => taskExecuted = true,
+            CancellationToken
+        );
 
         // Assert
         taskExecuted.Should().BeFalse();
+        result.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/LeaderElection.Tests/LeaderElectionBaseTests.cs
+++ b/tests/LeaderElection.Tests/LeaderElectionBaseTests.cs
@@ -418,13 +418,14 @@ public class LeaderElectionBaseTests
 
         // Act
         var taskExecuted = false;
-        await sut.RunTaskIfLeaderAsync(
-            () => taskExecuted = true,
+        var result = await sut.RunTaskIfLeaderAsync(
+            _ => taskExecuted = true,
             TestContext.Current.CancellationToken
         );
 
         // Assert
         taskExecuted.Should().BeFalse();
+        result.Should().BeFalse();
     }
 
     [Fact]
@@ -440,13 +441,14 @@ public class LeaderElectionBaseTests
 
         // Act
         var taskExecuted = false;
-        await sut.RunTaskIfLeaderAsync(
-            () => taskExecuted = true,
+        var result = await sut.RunTaskIfLeaderAsync(
+            _ => taskExecuted = true,
             TestContext.Current.CancellationToken
         );
 
         // Assert
         taskExecuted.Should().BeFalse();
+        result.Should().BeFalse();
     }
 
     [Fact]
@@ -461,13 +463,14 @@ public class LeaderElectionBaseTests
 
         // Act
         var taskExecuted = false;
-        await sut.RunTaskIfLeaderAsync(
-            () => taskExecuted = true,
+        var result = await sut.RunTaskIfLeaderAsync(
+            _ => taskExecuted = true,
             TestContext.Current.CancellationToken
         );
 
         // Assert
         taskExecuted.Should().BeTrue();
+        result.Should().BeTrue();
     }
 
     [Fact]
@@ -485,13 +488,55 @@ public class LeaderElectionBaseTests
         // Act
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
             sut.RunTaskIfLeaderAsync(
-                () => throw new InvalidOperationException("Test exception"),
+                _ => throw new InvalidOperationException("Test exception"),
                 TestContext.Current.CancellationToken
             )
         );
 
         // Assert
         sut.Settings.ErrorCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task RunTaskIfLeaderAsyncShouldCancelWhenTokenIsCancelled()
+    {
+        // Arrange
+        await using var sut = CreateSut();
+
+        // start with leadership
+        await StartAsync(sut);
+        sut.IsLeader.Should().BeTrue();
+
+        using var cts = new CancellationTokenSource();
+        var task = sut.RunTaskIfLeaderAsync(ct => Task.Delay(Timeout.Infinite, ct), cts.Token);
+
+        // Act
+        await cts.CancelAsync();
+
+        // Assert
+        await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
+    }
+
+    [Fact]
+    public async Task RunTaskIfLeaderAsyncShouldCancelWhenLeadershipIsLost()
+    {
+        // Arrange
+        await using var sut = CreateSut();
+
+        // start with leadership
+        await StartAsync(sut);
+        sut.IsLeader.Should().BeTrue();
+
+        var task = sut.RunTaskIfLeaderAsync(
+            ct => Task.Delay(Timeout.Infinite, ct),
+            CancellationToken.None
+        );
+
+        // Act
+        await sut.StopAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        await Assert.ThrowsAsync<TaskCanceledException>(async () => await task);
     }
 
     [Theory]
@@ -594,13 +639,10 @@ public class LeaderElectionBaseTests
             sut.StopAsync(TestContext.Current.CancellationToken)
         );
         await Assert.ThrowsAsync<ObjectDisposedException>(() =>
-            sut.RunTaskIfLeaderAsync(
-                () => Task.CompletedTask,
-                TestContext.Current.CancellationToken
-            )
+            sut.RunTaskIfLeaderAsync(_ => Task.CompletedTask, TestContext.Current.CancellationToken)
         );
         await Assert.ThrowsAsync<ObjectDisposedException>(() =>
-            sut.RunTaskIfLeaderAsync(() => { }, TestContext.Current.CancellationToken)
+            sut.RunTaskIfLeaderAsync(_ => { }, TestContext.Current.CancellationToken)
         );
 
         // Properties are okay

--- a/tests/LeaderElection.Tests/PostgresLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/PostgresLeaderElectionTests.cs
@@ -125,9 +125,13 @@ public sealed class PostgresLeaderElectionTests(PostgresContainerFixture postgre
         await leaderElection.StartAsync(CancellationToken);
         await WaitForLeadershipChange(leaderElection, true, TimeSpan.FromSeconds(10));
 
-        await leaderElection.RunTaskIfLeaderAsync(() => taskExecuted = true, CancellationToken);
+        var result = await leaderElection.RunTaskIfLeaderAsync(
+            _ => taskExecuted = true,
+            CancellationToken
+        );
 
         taskExecuted.Should().BeTrue();
+        result.Should().BeTrue();
 
         await leaderElection.StopAsync(CancellationToken);
     }
@@ -141,9 +145,13 @@ public sealed class PostgresLeaderElectionTests(PostgresContainerFixture postgre
 
         var taskExecuted = false;
 
-        await leaderElection.RunTaskIfLeaderAsync(() => taskExecuted = true, CancellationToken);
+        var result = await leaderElection.RunTaskIfLeaderAsync(
+            _ => taskExecuted = true,
+            CancellationToken
+        );
 
         taskExecuted.Should().BeFalse();
+        result.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/LeaderElection.Tests/RedisLeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/RedisLeaderElectionTests.cs
@@ -159,10 +159,14 @@ public sealed class RedisLeaderElectionTests(RedisContainerFixture redisFixture)
         await leaderElection.StartAsync(CancellationToken);
         await WaitForLeadershipChange(leaderElection, true, TimeSpan.FromSeconds(10));
 
-        await leaderElection.RunTaskIfLeaderAsync(() => taskExecuted = true, CancellationToken);
+        var result = await leaderElection.RunTaskIfLeaderAsync(
+            _ => taskExecuted = true,
+            CancellationToken
+        );
 
         // Assert
         taskExecuted.Should().BeTrue();
+        result.Should().BeTrue();
 
         await leaderElection.StopAsync(CancellationToken);
     }
@@ -178,10 +182,14 @@ public sealed class RedisLeaderElectionTests(RedisContainerFixture redisFixture)
         var taskExecuted = false;
 
         // Act - Don't start the leader election, so it won't be leader
-        await leaderElection.RunTaskIfLeaderAsync(() => taskExecuted = true, CancellationToken);
+        var result = await leaderElection.RunTaskIfLeaderAsync(
+            _ => taskExecuted = true,
+            CancellationToken
+        );
 
         // Assert
         taskExecuted.Should().BeFalse();
+        result.Should().BeFalse();
     }
 
     [Fact]

--- a/tests/LeaderElection.Tests/S3LeaderElectionTests.cs
+++ b/tests/LeaderElection.Tests/S3LeaderElectionTests.cs
@@ -169,10 +169,14 @@ public sealed class S3LeaderElectionTests(MinioContainerFixture minioFixture)
         await leaderElection.StartAsync(CancellationToken);
         await WaitForLeadershipChange(leaderElection, true, TimeSpan.FromSeconds(15));
 
-        await leaderElection.RunTaskIfLeaderAsync(() => taskExecuted = true, CancellationToken);
+        var result = await leaderElection.RunTaskIfLeaderAsync(
+            _ => taskExecuted = true,
+            CancellationToken
+        );
 
         // Assert
         taskExecuted.Should().BeTrue();
+        result.Should().BeTrue();
 
         await leaderElection.StopAsync(CancellationToken);
     }


### PR DESCRIPTION
## Description

This pull request modifies the `RunTaskIfLeaderAsync` method to provide better control over task execution and visibility into leadership status. It introduces a `CancellationToken` to the task delegate and changes the return type to `bool` to indicate whether the task was actually executed.

The primary motivation is to ensure that tasks running under leadership can be immediately canceled if leadership is lost during execution, preventing "split-brain" scenarios or unnecessary work.

---

## Changes

- [x] Modified `ILeaderElection` and `LeaderElectionBase` to pass a `CancellationToken` into the `RunTaskIfLeaderAsync` delegates
- [x] Updated the return type of `RunTaskIfLeaderAsync` from `Task` to `Task` to signal execution status
- [x] Implemented linked cancellation logic that triggers if the provided token is canceled or if the instance loses leadership
- [x] Refactored all documentation and README examples to reflect the new API signature
- [x] Added unit tests to verify cancellation behavior when leadership is lost and when tokens are canceled
- [x] Updated existing tests to assert the correctness of the new boolean return value

---

## Checklist

- [x] My code follows the project's coding style
- [x] I have self-reviewed my changes
- [x] I have added tests
- [x] I have updated the documentation
- [x] I have linked relevant issue(s)
- [x] I have included meaningful commit messages

---

## Related Issues

Relates to #68

---

## Additional Notes

This is a breaking change for consumers of `RunTaskIfLeaderAsync` as it changes the method signature and return type. Users will need to update their delegates to accept the new cancellation token parameter.